### PR TITLE
Upgrade REST API to v2 and document external client architecture Migr…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "mayara-core"
-version = "1.0.0"
+version = "0.5.1"
 dependencies = [
  "bincode",
  "bitflags 2.9.0",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "mayara-server"
-version = "1.0.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/develop/getting_started.md
+++ b/docs/develop/getting_started.md
@@ -146,21 +146,21 @@ The server exposes a SignalK-compatible REST API:
 
 ```bash
 # List all radars
-curl http://localhost:6502/v1/api/radars
+curl http://localhost:6502/v2/api/radars
 
 # Get radar capabilities (controls, ranges, features)
-curl http://localhost:6502/v1/api/radars/radar-1/capabilities
+curl http://localhost:6502/v2/api/radars/radar-1/capabilities
 
 # Get current state (control values)
-curl http://localhost:6502/v1/api/radars/radar-1/state
+curl http://localhost:6502/v2/api/radars/radar-1/state
 
 # Set a control
-curl -X PUT http://localhost:6502/v1/api/radars/radar-1/controls/gain \
+curl -X PUT http://localhost:6502/v2/api/radars/radar-1/controls/gain \
   -H "Content-Type: application/json" \
   -d '{"value": 50}'
 
 # Set control with auto mode
-curl -X PUT http://localhost:6502/v1/api/radars/radar-1/controls/gain \
+curl -X PUT http://localhost:6502/v2/api/radars/radar-1/controls/gain \
   -H "Content-Type: application/json" \
   -d '{"value": 50, "auto": true}'
 ```
@@ -168,8 +168,8 @@ curl -X PUT http://localhost:6502/v1/api/radars/radar-1/controls/gain \
 ### WebSocket Endpoints
 
 ```
-/v1/api/radars/{id}/spokes   - Binary protobuf spoke stream
-/v1/api/radars/{id}/targets  - ARPA target updates (JSON)
+/v2/api/radars/{id}/spokes   - Binary protobuf spoke stream
+/v2/api/radars/{id}/targets  - ARPA target updates (JSON)
 ```
 
 ---

--- a/mayara-server/build.rs
+++ b/mayara-server/build.rs
@@ -14,9 +14,12 @@ fn main() {
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
-    // Download GUI from npm if not present
+    // Skip GUI download in dev mode - we serve from filesystem instead
+    let is_dev = env::var("CARGO_FEATURE_DEV").is_ok();
+
+    // Download GUI from npm if not present (skip in dev mode)
     let gui_dir = PathBuf::from(&out_dir).join("gui");
-    if !gui_dir.join("index.html").exists() {
+    if !is_dev && !gui_dir.join("index.html").exists() {
         println!("cargo:warning=Downloading GUI from npm...");
 
         // Create temp dir for npm install

--- a/mayara-server/src/web.rs
+++ b/mayara-server/src/web.rs
@@ -56,29 +56,29 @@ use mayara_core::engine::RadarEngine;
 use mayara_core::capabilities::{builder::build_capabilities_from_model_with_key, RadarStateV5, SupportedFeature};
 use mayara_core::models;
 
-// Standalone Radar API v1 paths (matches SignalK Radar API structure for GUI compatibility)
-const RADARS_URI: &str = "/v1/api/radars";
-const RADAR_CAPABILITIES_URI: &str = "/v1/api/radars/{radar_id}/capabilities";
-const RADAR_STATE_URI: &str = "/v1/api/radars/{radar_id}/state";
-const SPOKES_URI: &str = "/v1/api/radars/{radar_id}/spokes";
-const CONTROL_URI: &str = "/v1/api/radars/{radar_id}/control";
-const CONTROL_VALUE_URI: &str = "/v1/api/radars/{radar_id}/controls/{control_id}";
-const TARGETS_URI: &str = "/v1/api/radars/{radar_id}/targets";
-const TARGET_URI: &str = "/v1/api/radars/{radar_id}/targets/{target_id}";
-const ARPA_SETTINGS_URI: &str = "/v1/api/radars/{radar_id}/arpa/settings";
+// Standalone Radar API v2 paths (matches SignalK Radar API v2 structure)
+const RADARS_URI: &str = "/v2/api/radars";
+const RADAR_CAPABILITIES_URI: &str = "/v2/api/radars/{radar_id}/capabilities";
+const RADAR_STATE_URI: &str = "/v2/api/radars/{radar_id}/state";
+const SPOKES_URI: &str = "/v2/api/radars/{radar_id}/spokes";
+const CONTROL_URI: &str = "/v2/api/radars/{radar_id}/control";
+const CONTROL_VALUE_URI: &str = "/v2/api/radars/{radar_id}/controls/{control_id}";
+const TARGETS_URI: &str = "/v2/api/radars/{radar_id}/targets";
+const TARGET_URI: &str = "/v2/api/radars/{radar_id}/targets/{target_id}";
+const ARPA_SETTINGS_URI: &str = "/v2/api/radars/{radar_id}/arpa/settings";
 // Guard zones
-const GUARD_ZONES_URI: &str = "/v1/api/radars/{radar_id}/guardZones";
-const GUARD_ZONE_URI: &str = "/v1/api/radars/{radar_id}/guardZones/{zone_id}";
+const GUARD_ZONES_URI: &str = "/v2/api/radars/{radar_id}/guardZones";
+const GUARD_ZONE_URI: &str = "/v2/api/radars/{radar_id}/guardZones/{zone_id}";
 // Trails
-const TRAILS_URI: &str = "/v1/api/radars/{radar_id}/trails";
-const TRAIL_URI: &str = "/v1/api/radars/{radar_id}/trails/{target_id}";
-const TRAIL_SETTINGS_URI: &str = "/v1/api/radars/{radar_id}/trails/settings";
+const TRAILS_URI: &str = "/v2/api/radars/{radar_id}/trails";
+const TRAIL_URI: &str = "/v2/api/radars/{radar_id}/trails/{target_id}";
+const TRAIL_SETTINGS_URI: &str = "/v2/api/radars/{radar_id}/trails/settings";
 // Dual-range
-const DUAL_RANGE_URI: &str = "/v1/api/radars/{radar_id}/dualRange";
-const DUAL_RANGE_SPOKES_URI: &str = "/v1/api/radars/{radar_id}/dualRange/spokes";
+const DUAL_RANGE_URI: &str = "/v2/api/radars/{radar_id}/dualRange";
+const DUAL_RANGE_SPOKES_URI: &str = "/v2/api/radars/{radar_id}/dualRange/spokes";
 
 // Non-radar endpoints
-const INTERFACES_URI: &str = "/v1/api/interfaces";
+const INTERFACES_URI: &str = "/v2/api/interfaces";
 
 // SignalK applicationData API (for settings persistence)
 const APP_DATA_URI: &str = "/signalk/v1/applicationData/global/{appid}/{version}/{*key}";
@@ -164,9 +164,10 @@ impl Web {
 
         // In dev mode, serve files from filesystem for live reload
         // In production, use embedded files
-        // Note: CARGO_MANIFEST_DIR is the directory containing mayara-server/Cargo.toml
+        // Note: CARGO_MANIFEST_DIR is /home/dirk/dev/mayara-server/mayara-server
+        // So we go up two levels to reach /home/dirk/dev/mayara-gui
         #[cfg(feature = "dev")]
-        let serve_assets = ServeDir::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../mayara-gui"));
+        let serve_assets = ServeDir::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../mayara-gui"));
         #[cfg(not(feature = "dev"))]
         let serve_assets = ServeEmbed::<Assets>::new();
 
@@ -333,8 +334,8 @@ async fn get_radars(
     {
         let legend = &info.legend;
         let id = format!("radar-{}", info.id);
-        let stream_url = format!("ws://{}/v1/api/radars/{}/spokes", host, id);
-        let control_url = format!("ws://{}/v1/api/radars/{}/control", host, id);
+        let stream_url = format!("ws://{}/v2/api/radars/{}/spokes", host, id);
+        let control_url = format!("ws://{}/v2/api/radars/{}/control", host, id);
         let name = info.controls.user_name();
         let v = RadarApi::new(
             id.to_owned(),
@@ -369,7 +370,7 @@ fn to_core_brand(brand: mayara_server::Brand) -> mayara_core::Brand {
     }
 }
 
-/// GET /v1/api/radars/{radar_id}/capabilities
+/// GET /v2/api/radars/{radar_id}/capabilities
 /// Returns the capability manifest for a specific radar (v5 API format)
 #[debug_handler]
 async fn get_radar_capabilities(
@@ -443,7 +444,7 @@ async fn get_radar_capabilities(
     }
 }
 
-/// GET /v1/api/radars/{radar_id}/state
+/// GET /v2/api/radars/{radar_id}/state
 /// Returns the current state of a radar (v5 API format)
 #[debug_handler]
 async fn get_radar_state(
@@ -777,7 +778,7 @@ struct SetControlRequest {
     value: serde_json::Value,
 }
 
-/// PUT /v1/api/radars/{radar_id}/controls/{control_id}
+/// PUT /v2/api/radars/{radar_id}/controls/{control_id}
 /// Sets a control value on the radar
 #[debug_handler]
 async fn set_control_value(


### PR DESCRIPTION
…ate all REST API endpoints from /v1/api/* to /v2/api/* for alignment with SignalK Radar API v2. API Changes:

All radar endpoints: /v1/api/radars/* → /v2/api/radars/* Interfaces endpoint: /v1/api/interfaces → /v2/api/interfaces WebSocket endpoints updated accordingly
Documentation:
Add comprehensive "External Clients" section explaining shared API architecture Document mayara-server-signalk-plugin as a native JS plugin client Update future OpenCPN integration to use same API
Add client comparison table (mayara-gui, mayara-signalk-wasm, signalk-plugin, opencpn) Build improvements:
Skip GUI npm download in dev mode (serve from filesystem instead) Fix dev mode asset path to correctly locate mayara-gui sibling directory Version: Align Cargo.lock versions to 0.5.1
This is a breaking change - clients using the v1 API will need to update to v2 endpoints.