### PR TITLE
Fix Furuno NIC selection to skip interfaces without carrier

### DIFF
--- a/mayara-server/src/core_locator.rs
+++ b/mayara-server/src/core_locator.rs
@@ -38,6 +38,8 @@ use tokio::sync::mpsc;
 use tokio::time::{interval, MissedTickBehavior};
 use tokio_graceful_shutdown::SubsystemHandle;
 
+use crate::network::has_carrier;
+
 use crate::network::is_wireless_interface;
 use crate::tokio_io::TokioIoProvider;
 use crate::Brand;
@@ -423,6 +425,11 @@ fn find_furuno_interface(allow_wifi: bool, interface: &Option<String>) -> Option
                     continue;
                 }
             }
+        }
+        // Skip interfaces without carrier (link down)
+        if !has_carrier(&itf.name) {
+            log::debug!("Skipping interface {} (no carrier)", itf.name);
+            continue;
         }
         for addr in &itf.addr {
             if let (IpAddr::V4(nic_ip), Some(IpAddr::V4(netmask))) = (addr.ip(), addr.netmask()) {


### PR DESCRIPTION
The find_furuno_interface() function was selecting network interfaces based solely on IP subnet matching, ignoring whether the interface actually had link. This caused issues in multi-NIC setups where an interface with the correct IP was down (no carrier), but multicast traffic was arriving on a different interface with an alias IP.

Add has_carrier() check before selecting an interface, ensuring we only use NICs that have an active link. This fixes spoke data reception when the radar's multicast traffic arrives on a different physical interface than expected.