### PR TITLE
Re-implement radar recording and playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,7 @@ dependencies = [
  "socket2 0.5.10",
  "strum",
  "system-configuration",
+ "tempfile",
  "terminal_size 0.3.0",
  "thiserror 1.0.69",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ rtnetlink = "0.14.1"
 w32-error = "1.0.0"
 windows = { version = "0.59.0", features = ["Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_WiFi", "Win32_Networking_WinSock", "Win32_System", "Win32_System_Threading", "Win32_Security", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_System_SystemServices" ] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 protobuf-codegen = "3.7.2"
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/bin/mayara-server/web.rs
+++ b/src/bin/mayara-server/web.rs
@@ -26,6 +26,7 @@ use tower_http::trace::TraceLayer;
 use utoipa::ToSchema;
 
 mod axum_fix;
+mod recordings;
 mod signalk;
 
 pub use signalk::v2::generate_openapi_json;
@@ -56,6 +57,7 @@ pub struct Web {
     args: Cli,
     shutdown_tx: broadcast::Sender<()>,
     tx_interface_request: broadcast::Sender<Option<mpsc::Sender<InterfaceApi>>>,
+    recording_state: recordings::RecordingState,
 }
 
 impl Web {
@@ -69,6 +71,7 @@ impl Web {
             args,
             shutdown_tx,
             tx_interface_request,
+            recording_state: recordings::RecordingState::new(),
         }
     }
 
@@ -91,6 +94,7 @@ impl Web {
 
         let router = Router::new().route("/", get(endpoints));
         let router = signalk::v2::routes(router);
+        let router = recordings::routes(router);
 
         let app = router
             .fallback_service(serve_assets)

--- a/src/bin/mayara-server/web/recordings.rs
+++ b/src/bin/mayara-server/web/recordings.rs
@@ -1,0 +1,593 @@
+//! REST API routes for radar recording and playback.
+
+use axum::{
+    Json,
+    body::Body,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post, put},
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use mayara::recording::{
+    ActivePlayback, ActiveRecording, PlaybackSettings, PlaybackStatus, RecordingManager,
+    RecordingStatus,
+    recorder::{build_initial_state, start_recording},
+    player::{load_recording, unregister_playback_radar},
+};
+
+use super::Web;
+
+/// Shared recording state accessible across request handlers
+#[derive(Clone)]
+pub struct RecordingState {
+    pub active_recording: Arc<RwLock<Option<ActiveRecording>>>,
+    pub active_playback: Arc<RwLock<Option<ActivePlayback>>>,
+}
+
+impl RecordingState {
+    pub fn new() -> Self {
+        Self {
+            active_recording: Arc::new(RwLock::new(None)),
+            active_playback: Arc::new(RwLock::new(None)),
+        }
+    }
+}
+
+// Request/response types
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StartRecordingRequest {
+    radar_id: String,
+    filename: Option<String>,
+    subdirectory: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoadPlaybackRequest {
+    filename: String,
+    subdirectory: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SeekRequest {
+    position_ms: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RenameRequest {
+    new_name: String,
+}
+
+#[derive(Deserialize)]
+struct ListQuery {
+    #[serde(rename = "dir")]
+    subdirectory: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RecordableRadar {
+    id: String,
+    name: String,
+    brand: String,
+}
+
+const RECORDINGS_BASE: &str = "/v2/api/vessels/self/radars/recordings";
+
+fn validate_filename(filename: &str) -> Result<(), &'static str> {
+    if filename.is_empty()
+        || filename.contains("..")
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.starts_with('.')
+        || !filename.is_ascii()
+    {
+        return Err("Invalid filename");
+    }
+    Ok(())
+}
+
+fn sanitize_for_header(filename: &str) -> String {
+    filename
+        .replace('"', "_")
+        .replace('\n', "_")
+        .replace('\r', "_")
+}
+
+pub fn routes(router: axum::Router<Web>) -> axum::Router<Web> {
+    router
+        // Recording control
+        .route(
+            &format!("{}/radars", RECORDINGS_BASE),
+            get(get_recordable_radars),
+        )
+        .route(
+            &format!("{}/record/start", RECORDINGS_BASE),
+            post(start_recording_handler),
+        )
+        .route(
+            &format!("{}/record/stop", RECORDINGS_BASE),
+            post(stop_recording_handler),
+        )
+        .route(
+            &format!("{}/record/status", RECORDINGS_BASE),
+            get(get_recording_status),
+        )
+        // Playback control
+        .route(
+            &format!("{}/playback/load", RECORDINGS_BASE),
+            post(load_playback_handler),
+        )
+        .route(
+            &format!("{}/playback/play", RECORDINGS_BASE),
+            post(play_handler),
+        )
+        .route(
+            &format!("{}/playback/pause", RECORDINGS_BASE),
+            post(pause_handler),
+        )
+        .route(
+            &format!("{}/playback/stop", RECORDINGS_BASE),
+            post(stop_playback_handler),
+        )
+        .route(
+            &format!("{}/playback/seek", RECORDINGS_BASE),
+            post(seek_handler),
+        )
+        .route(
+            &format!("{}/playback/settings", RECORDINGS_BASE),
+            put(settings_handler),
+        )
+        .route(
+            &format!("{}/playback/status", RECORDINGS_BASE),
+            get(get_playback_status),
+        )
+        // File management
+        .route(
+            &format!("{}/files", RECORDINGS_BASE),
+            get(list_recordings_handler),
+        )
+        .route(
+            &format!("{}/files/{{filename}}", RECORDINGS_BASE),
+            get(get_recording_handler)
+                .delete(delete_recording_handler)
+                .put(rename_recording_handler),
+        )
+        .route(
+            &format!("{}/files/{{filename}}/download", RECORDINGS_BASE),
+            get(download_recording_handler),
+        )
+        .route(
+            &format!("{}/directories", RECORDINGS_BASE),
+            get(list_directories_handler).post(create_directory_handler),
+        )
+        .route(
+            &format!("{}/directories/{{name}}", RECORDINGS_BASE),
+            delete(delete_directory_handler),
+        )
+}
+
+// --- Recording control handlers ---
+
+async fn get_recordable_radars(State(state): State<Web>) -> impl IntoResponse {
+    let radars = state.radars.get_active();
+    let recordable: Vec<RecordableRadar> = radars
+        .iter()
+        .filter(|r| r.brand != mayara::Brand::Playback)
+        .map(|r| RecordableRadar {
+            id: r.key(),
+            name: r.controls.user_name(),
+            brand: format!("{}", r.brand),
+        })
+        .collect();
+
+    Json(recordable)
+}
+
+async fn start_recording_handler(
+    State(state): State<Web>,
+    Json(req): Json<StartRecordingRequest>,
+) -> impl IntoResponse {
+    if let Some(ref f) = req.filename {
+        if let Err(e) = validate_filename(f) {
+            return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+        }
+    }
+    if let Some(ref sub) = req.subdirectory {
+        if let Err(e) = validate_filename(sub) {
+            return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+        }
+    }
+
+    let mut active = state.recording_state.active_recording.write().await;
+
+    if active.is_some() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "Recording already in progress"})),
+        );
+    }
+
+    let radar = match state.radars.get_by_key(&req.radar_id) {
+        Some(r) => r,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Radar not found"})),
+            );
+        }
+    };
+
+    let capabilities_json = serde_json::to_vec(&serde_json::json!({
+        "brand": format!("{}", radar.brand),
+        "spokesPerRevolution": radar.spokes_per_revolution,
+        "maxSpokeLen": radar.max_spoke_len,
+        "pixelValues": radar.pixel_values,
+    }))
+    .unwrap_or_default();
+
+    let initial_state = build_initial_state(&radar);
+
+    match start_recording(
+        &radar,
+        &req.radar_id,
+        req.filename.as_deref(),
+        req.subdirectory.as_deref(),
+        &capabilities_json,
+        &initial_state,
+    )
+    .await
+    {
+        Ok(recording) => {
+            let status = recording.status();
+            *active = Some(recording);
+            (StatusCode::OK, Json(serde_json::to_value(status).unwrap()))
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+async fn stop_recording_handler(State(state): State<Web>) -> impl IntoResponse {
+    let mut active = state.recording_state.active_recording.write().await;
+
+    match active.take() {
+        Some(recording) => {
+            recording.stop();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"state": "stopped"})),
+            )
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No active recording"})),
+        ),
+    }
+}
+
+async fn get_recording_status(State(state): State<Web>) -> impl IntoResponse {
+    let active = state.recording_state.active_recording.read().await;
+
+    match active.as_ref() {
+        Some(recording) if recording.is_running() => {
+            Json(serde_json::to_value(recording.status()).unwrap())
+        }
+        _ => Json(serde_json::to_value(RecordingStatus::default()).unwrap()),
+    }
+}
+
+// --- Playback control handlers ---
+
+async fn load_playback_handler(
+    State(state): State<Web>,
+    Json(req): Json<LoadPlaybackRequest>,
+) -> impl IntoResponse {
+    let mut active = state.recording_state.active_playback.write().await;
+
+    // Stop existing playback if any
+    if let Some(existing) = active.take() {
+        existing.stop();
+        unregister_playback_radar(&state.radars, existing.radar_key());
+    }
+
+    match load_recording(
+        &state.args,
+        &state.radars,
+        &req.filename,
+        req.subdirectory.as_deref(),
+    )
+    .await
+    {
+        Ok(playback) => {
+            let status = playback.status().await;
+            *active = Some(playback);
+            (StatusCode::OK, Json(serde_json::to_value(status).unwrap()))
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+async fn play_handler(State(state): State<Web>) -> impl IntoResponse {
+    let active = state.recording_state.active_playback.read().await;
+
+    match active.as_ref() {
+        Some(playback) => {
+            playback.resume();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"state": "playing"})),
+            )
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No active playback"})),
+        ),
+    }
+}
+
+async fn pause_handler(State(state): State<Web>) -> impl IntoResponse {
+    let active = state.recording_state.active_playback.read().await;
+
+    match active.as_ref() {
+        Some(playback) => {
+            playback.pause();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"state": "paused"})),
+            )
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No active playback"})),
+        ),
+    }
+}
+
+async fn stop_playback_handler(State(state): State<Web>) -> impl IntoResponse {
+    let mut active = state.recording_state.active_playback.write().await;
+
+    match active.take() {
+        Some(playback) => {
+            playback.stop();
+            unregister_playback_radar(&state.radars, playback.radar_key());
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"state": "stopped"})),
+            )
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No active playback"})),
+        ),
+    }
+}
+
+async fn seek_handler(
+    State(state): State<Web>,
+    Json(req): Json<SeekRequest>,
+) -> impl IntoResponse {
+    let active = state.recording_state.active_playback.read().await;
+
+    match active.as_ref() {
+        Some(playback) => {
+            playback.seek(req.position_ms).await;
+            (StatusCode::OK, Json(serde_json::json!({"ok": true})))
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No active playback"})),
+        ),
+    }
+}
+
+async fn settings_handler(
+    State(state): State<Web>,
+    Json(req): Json<PlaybackSettings>,
+) -> impl IntoResponse {
+    let active = state.recording_state.active_playback.read().await;
+
+    match active.as_ref() {
+        Some(playback) => {
+            if let Some(speed) = req.speed {
+                playback.set_speed(speed);
+            }
+            if let Some(loop_playback) = req.loop_playback {
+                playback.set_loop(loop_playback);
+            }
+            let status = playback.status().await;
+            (StatusCode::OK, Json(serde_json::to_value(status).unwrap()))
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No active playback"})),
+        ),
+    }
+}
+
+async fn get_playback_status(State(state): State<Web>) -> impl IntoResponse {
+    let active = state.recording_state.active_playback.read().await;
+
+    match active.as_ref() {
+        Some(playback) => Json(serde_json::to_value(playback.status().await).unwrap()),
+        None => Json(serde_json::to_value(PlaybackStatus::default()).unwrap()),
+    }
+}
+
+// --- File management handlers ---
+
+async fn list_recordings_handler(
+    Query(query): Query<ListQuery>,
+) -> impl IntoResponse {
+    let manager = RecordingManager::new();
+    let recordings = manager.list_recordings(query.subdirectory.as_deref());
+    let total_size: u64 = recordings.iter().map(|r| r.size).sum();
+    let total_count = recordings.len();
+    Json(serde_json::json!({
+        "recordings": recordings,
+        "totalCount": total_count,
+        "totalSize": total_size,
+    }))
+}
+
+async fn get_recording_handler(
+    Path(filename): Path<String>,
+    Query(query): Query<ListQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_filename(&filename) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+    }
+    let manager = RecordingManager::new();
+    match manager.get_recording(&filename, query.subdirectory.as_deref()) {
+        Some(info) => (StatusCode::OK, Json(serde_json::to_value(info).unwrap())),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Recording not found"})),
+        ),
+    }
+}
+
+async fn delete_recording_handler(
+    Path(filename): Path<String>,
+    Query(query): Query<ListQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_filename(&filename) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+    }
+    let manager = RecordingManager::new();
+    match manager.delete_recording(&filename, query.subdirectory.as_deref()) {
+        Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+async fn rename_recording_handler(
+    Path(filename): Path<String>,
+    Query(query): Query<ListQuery>,
+    Json(req): Json<RenameRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_filename(&filename) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+    }
+    if let Err(e) = validate_filename(&req.new_name) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+    }
+    let manager = RecordingManager::new();
+    match manager.rename_recording(
+        &filename,
+        &req.new_name,
+        query.subdirectory.as_deref(),
+    ) {
+        Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+async fn list_directories_handler() -> impl IntoResponse {
+    let manager = RecordingManager::new();
+    Json(manager.list_directories())
+}
+
+#[derive(Deserialize)]
+struct CreateDirectoryRequest {
+    name: String,
+}
+
+async fn create_directory_handler(
+    Json(req): Json<CreateDirectoryRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_filename(&req.name) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+    }
+    let manager = RecordingManager::new();
+    match manager.create_directory(&req.name) {
+        Ok(()) => (StatusCode::CREATED, Json(serde_json::json!({"ok": true}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+async fn delete_directory_handler(Path(name): Path<String>) -> impl IntoResponse {
+    if let Err(e) = validate_filename(&name) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e})));
+    }
+    let manager = RecordingManager::new();
+    match manager.delete_directory(&name) {
+        Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+async fn download_recording_handler(
+    Path(filename): Path<String>,
+    Query(query): Query<ListQuery>,
+) -> axum::response::Response {
+    if let Err(e) = validate_filename(&filename) {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e}))).into_response();
+    }
+    if let Some(ref sub) = query.subdirectory {
+        if let Err(e) = validate_filename(sub) {
+            return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e}))).into_response();
+        }
+    }
+    let manager = RecordingManager::new();
+    let info = match manager.get_recording(&filename, query.subdirectory.as_deref()) {
+        Some(info) => info,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Recording not found"})),
+            )
+                .into_response();
+        }
+    };
+    let path = info.path;
+
+    match tokio::fs::File::open(&path).await {
+        Ok(file) => {
+            let stream = tokio_util::io::ReaderStream::new(file);
+            let body = Body::from_stream(stream);
+            let mut headers = axum::http::HeaderMap::new();
+            headers.insert(
+                axum::http::header::CONTENT_TYPE,
+                "application/octet-stream".parse().unwrap(),
+            );
+            headers.insert(
+                axum::http::header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{}\"", sanitize_for_header(&filename))
+                    .parse()
+                    .unwrap(),
+            );
+            (StatusCode::OK, headers, body).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to open file: {}", e)})),
+        )
+            .into_response(),
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -22,6 +22,7 @@ pub mod navdata;
 pub mod network;
 pub mod protos;
 pub mod radar;
+pub mod recording;
 pub mod stream;
 pub mod util;
 
@@ -151,6 +152,7 @@ pub enum Brand {
     Navico,
     Raymarine,
     Emulator,
+    Playback,
 }
 
 impl Brand {
@@ -161,6 +163,7 @@ impl Brand {
             Self::Navico => "nav",
             Self::Raymarine => "ray",
             Self::Emulator => "emu",
+            Self::Playback => "play",
         }
     }
 }
@@ -173,6 +176,7 @@ impl Into<Brand> for &str {
             "navico" => Brand::Navico,
             "raymarine" => Brand::Raymarine,
             "emulator" => Brand::Emulator,
+            "playback" => Brand::Playback,
             _ => panic!("Invalid brand"),
         }
     }
@@ -189,6 +193,7 @@ impl Serialize for Brand {
             Self::Navico => serializer.serialize_str("Navico"),
             Self::Raymarine => serializer.serialize_str("Raymarine"),
             Self::Emulator => serializer.serialize_str("Emulator"),
+            Self::Playback => serializer.serialize_str("Playback"),
         }
     }
 }
@@ -201,6 +206,7 @@ impl std::fmt::Display for Brand {
             Self::Navico => write!(f, "Navico"),
             Self::Raymarine => write!(f, "Raymarine"),
             Self::Emulator => write!(f, "Emulator"),
+            Self::Playback => write!(f, "Playback"),
         }
     }
 }

--- a/src/lib/recording/file_format.rs
+++ b/src/lib/recording/file_format.rs
@@ -1,0 +1,667 @@
+//! MRR (MaYaRa Radar Recording) file format implementation.
+//!
+//! Binary format for recording and playing back radar data.
+
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Magic bytes for MRR file header
+pub const MRR_MAGIC: [u8; 4] = *b"MRR1";
+
+/// Magic bytes for MRR file footer
+pub const MRR_FOOTER_MAGIC: [u8; 4] = *b"MRRF";
+
+/// Current format version
+pub const MRR_VERSION: u16 = 1;
+
+/// Header size in bytes (fixed)
+pub const HEADER_SIZE: usize = 256;
+
+/// Footer size in bytes (fixed)
+pub const FOOTER_SIZE: usize = 32;
+
+/// Index entry size in bytes
+pub const INDEX_ENTRY_SIZE: usize = 16;
+
+/// Frame flags
+pub const FRAME_FLAG_HAS_STATE: u8 = 0x01;
+
+/// File header (256 bytes fixed size)
+#[derive(Debug, Clone)]
+pub struct MrrHeader {
+    pub version: u16,
+    pub flags: u16,
+    /// Radar brand (Brand enum numeric ID)
+    pub radar_brand: u32,
+    /// Spokes per revolution (e.g., 2048)
+    pub spokes_per_rev: u32,
+    /// Maximum spoke length in pixels
+    pub max_spoke_len: u32,
+    /// Number of pixel values
+    pub pixel_values: u32,
+    /// Recording start time (Unix timestamp in milliseconds)
+    pub start_time_ms: u64,
+    /// Offset to capabilities JSON in file
+    pub capabilities_offset: u64,
+    pub capabilities_len: u32,
+    /// Offset to initial state JSON in file
+    pub initial_state_offset: u64,
+    pub initial_state_len: u32,
+    /// Offset to first frame
+    pub frames_offset: u64,
+}
+
+impl Default for MrrHeader {
+    fn default() -> Self {
+        Self {
+            version: MRR_VERSION,
+            flags: 0,
+            radar_brand: 0,
+            spokes_per_rev: 0,
+            max_spoke_len: 0,
+            pixel_values: 0,
+            start_time_ms: 0,
+            capabilities_offset: 0,
+            capabilities_len: 0,
+            initial_state_offset: 0,
+            initial_state_len: 0,
+            frames_offset: 0,
+        }
+    }
+}
+
+impl MrrHeader {
+    pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        let mut buf = [0u8; HEADER_SIZE];
+
+        buf[0..4].copy_from_slice(&MRR_MAGIC);
+        buf[4..6].copy_from_slice(&self.version.to_le_bytes());
+        buf[6..8].copy_from_slice(&self.flags.to_le_bytes());
+        buf[8..12].copy_from_slice(&self.radar_brand.to_le_bytes());
+        buf[12..16].copy_from_slice(&self.spokes_per_rev.to_le_bytes());
+        buf[16..20].copy_from_slice(&self.max_spoke_len.to_le_bytes());
+        buf[20..24].copy_from_slice(&self.pixel_values.to_le_bytes());
+        buf[24..32].copy_from_slice(&self.start_time_ms.to_le_bytes());
+        buf[32..40].copy_from_slice(&self.capabilities_offset.to_le_bytes());
+        buf[40..44].copy_from_slice(&self.capabilities_len.to_le_bytes());
+        buf[44..52].copy_from_slice(&self.initial_state_offset.to_le_bytes());
+        buf[52..56].copy_from_slice(&self.initial_state_len.to_le_bytes());
+        buf[56..64].copy_from_slice(&self.frames_offset.to_le_bytes());
+        // Remaining 192 bytes are reserved (already zeroed)
+
+        writer.write_all(&buf)
+    }
+
+    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let mut buf = [0u8; HEADER_SIZE];
+        reader.read_exact(&mut buf)?;
+
+        if &buf[0..4] != &MRR_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid MRR file: bad magic bytes",
+            ));
+        }
+
+        let version = u16::from_le_bytes([buf[4], buf[5]]);
+        if version > MRR_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Unsupported MRR version: {}", version),
+            ));
+        }
+
+        Ok(Self {
+            version,
+            flags: u16::from_le_bytes([buf[6], buf[7]]),
+            radar_brand: u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]),
+            spokes_per_rev: u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]),
+            max_spoke_len: u32::from_le_bytes([buf[16], buf[17], buf[18], buf[19]]),
+            pixel_values: u32::from_le_bytes([buf[20], buf[21], buf[22], buf[23]]),
+            start_time_ms: u64::from_le_bytes([
+                buf[24], buf[25], buf[26], buf[27], buf[28], buf[29], buf[30], buf[31],
+            ]),
+            capabilities_offset: u64::from_le_bytes([
+                buf[32], buf[33], buf[34], buf[35], buf[36], buf[37], buf[38], buf[39],
+            ]),
+            capabilities_len: u32::from_le_bytes([buf[40], buf[41], buf[42], buf[43]]),
+            initial_state_offset: u64::from_le_bytes([
+                buf[44], buf[45], buf[46], buf[47], buf[48], buf[49], buf[50], buf[51],
+            ]),
+            initial_state_len: u32::from_le_bytes([buf[52], buf[53], buf[54], buf[55]]),
+            frames_offset: u64::from_le_bytes([
+                buf[56], buf[57], buf[58], buf[59], buf[60], buf[61], buf[62], buf[63],
+            ]),
+        })
+    }
+}
+
+/// File footer (32 bytes fixed size)
+#[derive(Debug, Clone, Default)]
+pub struct MrrFooter {
+    pub index_offset: u64,
+    pub index_count: u32,
+    pub frame_count: u32,
+    pub duration_ms: u64,
+}
+
+impl MrrFooter {
+    pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        let mut buf = [0u8; FOOTER_SIZE];
+
+        buf[0..4].copy_from_slice(&MRR_FOOTER_MAGIC);
+        buf[4..12].copy_from_slice(&self.index_offset.to_le_bytes());
+        buf[12..16].copy_from_slice(&self.index_count.to_le_bytes());
+        buf[16..20].copy_from_slice(&self.frame_count.to_le_bytes());
+        buf[20..28].copy_from_slice(&self.duration_ms.to_le_bytes());
+
+        writer.write_all(&buf)
+    }
+
+    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let mut buf = [0u8; FOOTER_SIZE];
+        reader.read_exact(&mut buf)?;
+
+        if &buf[0..4] != &MRR_FOOTER_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid MRR footer: bad magic bytes",
+            ));
+        }
+
+        Ok(Self {
+            index_offset: u64::from_le_bytes([
+                buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11],
+            ]),
+            index_count: u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]),
+            frame_count: u32::from_le_bytes([buf[16], buf[17], buf[18], buf[19]]),
+            duration_ms: u64::from_le_bytes([
+                buf[20], buf[21], buf[22], buf[23], buf[24], buf[25], buf[26], buf[27],
+            ]),
+        })
+    }
+}
+
+/// Index entry for seeking (16 bytes)
+#[derive(Debug, Clone, Default)]
+pub struct MrrIndexEntry {
+    pub timestamp_ms: u64,
+    pub file_offset: u64,
+}
+
+impl MrrIndexEntry {
+    pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&self.timestamp_ms.to_le_bytes())?;
+        writer.write_all(&self.file_offset.to_le_bytes())
+    }
+
+    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let mut buf = [0u8; INDEX_ENTRY_SIZE];
+        reader.read_exact(&mut buf)?;
+
+        Ok(Self {
+            timestamp_ms: u64::from_le_bytes([
+                buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
+            ]),
+            file_offset: u64::from_le_bytes([
+                buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
+            ]),
+        })
+    }
+}
+
+/// Frame data (variable size)
+#[derive(Debug, Clone)]
+pub struct MrrFrame {
+    pub timestamp_ms: u64,
+    pub flags: u8,
+    /// Protobuf RadarMessage data
+    pub data: Vec<u8>,
+    /// Optional state delta (JSON)
+    pub state_delta: Option<Vec<u8>>,
+}
+
+/// Maximum allowed frame data size (64 MB)
+const MAX_FRAME_DATA_SIZE: usize = 64 * 1024 * 1024;
+
+impl MrrFrame {
+    pub fn new(timestamp_ms: u64, data: Vec<u8>) -> Self {
+        Self {
+            timestamp_ms,
+            flags: 0,
+            data,
+            state_delta: None,
+        }
+    }
+
+    pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        // Derive flag from state_delta to ensure consistency
+        let flags = if self.state_delta.is_some() {
+            self.flags | FRAME_FLAG_HAS_STATE
+        } else {
+            self.flags & !FRAME_FLAG_HAS_STATE
+        };
+
+        writer.write_all(&self.timestamp_ms.to_le_bytes())?;
+        writer.write_all(&[flags])?;
+        writer.write_all(&(self.data.len() as u32).to_le_bytes())?;
+        writer.write_all(&self.data)?;
+
+        if let Some(ref state) = self.state_delta {
+            writer.write_all(&(state.len() as u32).to_le_bytes())?;
+            writer.write_all(state)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let mut ts_buf = [0u8; 8];
+        reader.read_exact(&mut ts_buf)?;
+        let timestamp_ms = u64::from_le_bytes(ts_buf);
+
+        let mut flags_buf = [0u8; 1];
+        reader.read_exact(&mut flags_buf)?;
+        let flags = flags_buf[0];
+
+        let mut len_buf = [0u8; 4];
+        reader.read_exact(&mut len_buf)?;
+        let data_len = u32::from_le_bytes(len_buf) as usize;
+        if data_len > MAX_FRAME_DATA_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Frame data too large: {} bytes", data_len),
+            ));
+        }
+
+        let mut data = vec![0u8; data_len];
+        reader.read_exact(&mut data)?;
+
+        let state_delta = if flags & FRAME_FLAG_HAS_STATE != 0 {
+            reader.read_exact(&mut len_buf)?;
+            let state_len = u32::from_le_bytes(len_buf) as usize;
+            if state_len > MAX_FRAME_DATA_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("State data too large: {} bytes", state_len),
+                ));
+            }
+            let mut state = vec![0u8; state_len];
+            reader.read_exact(&mut state)?;
+            Some(state)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            timestamp_ms,
+            flags,
+            data,
+            state_delta,
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        let base = 8 + 1 + 4 + self.data.len();
+        if let Some(ref state) = self.state_delta {
+            base + 4 + state.len()
+        } else {
+            base
+        }
+    }
+}
+
+/// Writer for creating MRR files
+pub struct MrrWriter<W: Write + Seek> {
+    writer: W,
+    header: MrrHeader,
+    frame_count: u32,
+    last_timestamp_ms: u64,
+    index: Vec<MrrIndexEntry>,
+    index_interval: u32,
+    frames_since_index: u32,
+}
+
+impl<W: Write + Seek> MrrWriter<W> {
+    pub fn new(
+        mut writer: W,
+        radar_brand: u32,
+        spokes_per_rev: u32,
+        max_spoke_len: u32,
+        pixel_values: u32,
+        capabilities_json: &[u8],
+        initial_state_json: &[u8],
+    ) -> io::Result<Self> {
+        let start_time_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let capabilities_end = HEADER_SIZE + capabilities_json.len();
+        let initial_state_offset = capabilities_end as u64;
+        let frames_offset = (capabilities_end + initial_state_json.len()) as u64;
+
+        let header = MrrHeader {
+            version: MRR_VERSION,
+            flags: 0,
+            radar_brand,
+            spokes_per_rev,
+            max_spoke_len,
+            pixel_values,
+            start_time_ms,
+            capabilities_offset: HEADER_SIZE as u64,
+            capabilities_len: capabilities_json.len() as u32,
+            initial_state_offset,
+            initial_state_len: initial_state_json.len() as u32,
+            frames_offset,
+        };
+
+        header.write(&mut writer)?;
+        writer.write_all(capabilities_json)?;
+        writer.write_all(initial_state_json)?;
+
+        Ok(Self {
+            writer,
+            header,
+            frame_count: 0,
+            last_timestamp_ms: 0,
+            index: Vec::new(),
+            index_interval: 100,
+            frames_since_index: 0,
+        })
+    }
+
+    pub fn write_frame(&mut self, frame: &MrrFrame) -> io::Result<()> {
+        if self.frames_since_index >= self.index_interval {
+            let current_pos = self.writer.stream_position()?;
+            self.index.push(MrrIndexEntry {
+                timestamp_ms: frame.timestamp_ms,
+                file_offset: current_pos,
+            });
+            self.frames_since_index = 0;
+        }
+
+        frame.write(&mut self.writer)?;
+        self.frame_count += 1;
+        self.last_timestamp_ms = frame.timestamp_ms;
+        self.frames_since_index += 1;
+
+        Ok(())
+    }
+
+    pub fn finish(mut self) -> io::Result<()> {
+        let index_offset = self.writer.stream_position()?;
+        for entry in &self.index {
+            entry.write(&mut self.writer)?;
+        }
+
+        let footer = MrrFooter {
+            index_offset,
+            index_count: self.index.len() as u32,
+            frame_count: self.frame_count,
+            duration_ms: self.last_timestamp_ms,
+        };
+        footer.write(&mut self.writer)?;
+
+        self.writer.seek(SeekFrom::Start(0))?;
+        self.header.write(&mut self.writer)?;
+
+        self.writer.flush()
+    }
+}
+
+/// Maximum allowed metadata size (16 MB)
+const MAX_METADATA_SIZE: usize = 16 * 1024 * 1024;
+
+/// Reader for MRR files
+pub struct MrrReader<R: Read + Seek> {
+    reader: R,
+    header: MrrHeader,
+    footer: MrrFooter,
+    capabilities: Vec<u8>,
+    initial_state: Vec<u8>,
+    /// File offset where frames end (= index start)
+    frames_end_offset: u64,
+}
+
+impl<R: Read + Seek> MrrReader<R> {
+    pub fn open(mut reader: R) -> io::Result<Self> {
+        let header = MrrHeader::read(&mut reader)?;
+
+        let cap_len = header.capabilities_len as usize;
+        if cap_len > MAX_METADATA_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Capabilities too large: {} bytes", cap_len),
+            ));
+        }
+        reader.seek(SeekFrom::Start(header.capabilities_offset))?;
+        let mut capabilities = vec![0u8; cap_len];
+        reader.read_exact(&mut capabilities)?;
+
+        let state_len = header.initial_state_len as usize;
+        if state_len > MAX_METADATA_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Initial state too large: {} bytes", state_len),
+            ));
+        }
+        reader.seek(SeekFrom::Start(header.initial_state_offset))?;
+        let mut initial_state = vec![0u8; state_len];
+        reader.read_exact(&mut initial_state)?;
+
+        reader.seek(SeekFrom::End(-(FOOTER_SIZE as i64)))?;
+        let footer = MrrFooter::read(&mut reader)?;
+
+        let frames_end_offset = footer.index_offset;
+
+        reader.seek(SeekFrom::Start(header.frames_offset))?;
+
+        Ok(Self {
+            reader,
+            header,
+            footer,
+            capabilities,
+            initial_state,
+            frames_end_offset,
+        })
+    }
+
+    pub fn header(&self) -> &MrrHeader {
+        &self.header
+    }
+
+    pub fn footer(&self) -> &MrrFooter {
+        &self.footer
+    }
+
+    pub fn capabilities(&self) -> &[u8] {
+        &self.capabilities
+    }
+
+    pub fn initial_state(&self) -> &[u8] {
+        &self.initial_state
+    }
+
+    pub fn read_frame(&mut self) -> io::Result<Option<MrrFrame>> {
+        if self.reader.stream_position()? >= self.frames_end_offset {
+            return Ok(None);
+        }
+
+        let frame = MrrFrame::read(&mut self.reader)?;
+        Ok(Some(frame))
+    }
+
+    pub fn seek_to_timestamp(&mut self, target_ms: u64) -> io::Result<()> {
+        self.reader
+            .seek(SeekFrom::Start(self.footer.index_offset))?;
+
+        let mut best_entry: Option<MrrIndexEntry> = None;
+        for _ in 0..self.footer.index_count {
+            let entry = MrrIndexEntry::read(&mut self.reader)?;
+            if entry.timestamp_ms <= target_ms {
+                best_entry = Some(entry);
+            } else {
+                break;
+            }
+        }
+
+        let seek_pos = best_entry
+            .map(|e| e.file_offset)
+            .unwrap_or(self.header.frames_offset);
+        self.reader.seek(SeekFrom::Start(seek_pos))?;
+
+        loop {
+            let pos_before = self.reader.stream_position()?;
+            let frame = self.read_frame()?;
+            match frame {
+                Some(f) if f.timestamp_ms >= target_ms => {
+                    self.reader.seek(SeekFrom::Start(pos_before))?;
+                    break;
+                }
+                Some(_) => continue,
+                None => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn rewind(&mut self) -> io::Result<()> {
+        self.reader
+            .seek(SeekFrom::Start(self.header.frames_offset))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_header_roundtrip() {
+        let header = MrrHeader {
+            version: 1,
+            flags: 0,
+            radar_brand: 42,
+            spokes_per_rev: 2048,
+            max_spoke_len: 1024,
+            pixel_values: 64,
+            start_time_ms: 1234567890123,
+            capabilities_offset: 256,
+            capabilities_len: 100,
+            initial_state_offset: 356,
+            initial_state_len: 50,
+            frames_offset: 406,
+        };
+
+        let mut buf = Vec::new();
+        header.write(&mut buf).unwrap();
+        assert_eq!(buf.len(), HEADER_SIZE);
+
+        let mut cursor = Cursor::new(buf);
+        let read_header = MrrHeader::read(&mut cursor).unwrap();
+
+        assert_eq!(read_header.version, header.version);
+        assert_eq!(read_header.radar_brand, header.radar_brand);
+        assert_eq!(read_header.spokes_per_rev, header.spokes_per_rev);
+        assert_eq!(read_header.start_time_ms, header.start_time_ms);
+    }
+
+    #[test]
+    fn test_footer_roundtrip() {
+        let footer = MrrFooter {
+            index_offset: 12345678,
+            index_count: 100,
+            frame_count: 10000,
+            duration_ms: 60000,
+        };
+
+        let mut buf = Vec::new();
+        footer.write(&mut buf).unwrap();
+        assert_eq!(buf.len(), FOOTER_SIZE);
+
+        let mut cursor = Cursor::new(buf);
+        let read_footer = MrrFooter::read(&mut cursor).unwrap();
+
+        assert_eq!(read_footer.index_offset, footer.index_offset);
+        assert_eq!(read_footer.index_count, footer.index_count);
+        assert_eq!(read_footer.frame_count, footer.frame_count);
+        assert_eq!(read_footer.duration_ms, footer.duration_ms);
+    }
+
+    #[test]
+    fn test_frame_roundtrip() {
+        let frame = MrrFrame::new(1000, vec![1, 2, 3, 4, 5]);
+
+        let mut buf = Vec::new();
+        frame.write(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let read_frame = MrrFrame::read(&mut cursor).unwrap();
+
+        assert_eq!(read_frame.timestamp_ms, frame.timestamp_ms);
+        assert_eq!(read_frame.data, frame.data);
+        assert!(read_frame.state_delta.is_none());
+    }
+
+    #[test]
+    fn test_frame_with_state_roundtrip() {
+        let frame = MrrFrame {
+            timestamp_ms: 2000,
+            flags: FRAME_FLAG_HAS_STATE,
+            data: vec![1, 2, 3],
+            state_delta: Some(vec![b'{', b'}']),
+        };
+
+        let mut buf = Vec::new();
+        frame.write(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let read_frame = MrrFrame::read(&mut cursor).unwrap();
+
+        assert_eq!(read_frame.timestamp_ms, frame.timestamp_ms);
+        assert_eq!(read_frame.data, frame.data);
+        assert_eq!(read_frame.state_delta, Some(vec![b'{', b'}']));
+    }
+
+    #[test]
+    fn test_writer_reader_roundtrip() {
+        let capabilities = br#"{"controls":["range","gain"]}"#;
+        let initial_state = br#"{"range":1000,"gain":50}"#;
+
+        let mut raw = Cursor::new(Vec::new());
+        {
+            let mut writer =
+                MrrWriter::new(&mut raw, 1, 2048, 1024, 64, capabilities, initial_state).unwrap();
+
+            for i in 0..250u64 {
+                let frame = MrrFrame::new(i * 100, vec![i as u8; 10]);
+                writer.write_frame(&frame).unwrap();
+            }
+            writer.finish().unwrap();
+        }
+
+        // Read it back
+        raw.set_position(0);
+        let mut reader = MrrReader::open(raw).unwrap();
+
+        assert_eq!(reader.header().radar_brand, 1);
+        assert_eq!(reader.header().spokes_per_rev, 2048);
+        assert_eq!(reader.header().max_spoke_len, 1024);
+        assert_eq!(reader.footer().frame_count, 250);
+        assert_eq!(reader.capabilities(), capabilities);
+        assert_eq!(reader.initial_state(), initial_state);
+
+        // Verify first frame
+        let first = reader.read_frame().unwrap().unwrap();
+        assert_eq!(first.timestamp_ms, 0);
+        assert_eq!(first.data, vec![0u8; 10]);
+
+        // Verify second frame
+        let second = reader.read_frame().unwrap().unwrap();
+        assert_eq!(second.timestamp_ms, 100);
+        assert_eq!(second.data, vec![1u8; 10]);
+    }
+}

--- a/src/lib/recording/manager.rs
+++ b/src/lib/recording/manager.rs
@@ -1,0 +1,457 @@
+//! Recording file manager.
+//!
+//! Handles listing, metadata extraction, and deletion of recordings.
+
+use log::{debug, error, info};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::config::get_project_dirs;
+
+use super::file_format::{MrrFooter, MrrHeader, FOOTER_SIZE};
+
+/// Get the recordings directory path
+pub fn recordings_dir() -> PathBuf {
+    let project_dirs = get_project_dirs();
+    let mut path = project_dirs.data_dir().to_owned();
+    path.push("recordings");
+    path
+}
+
+/// Information about a recording file
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingInfo {
+    pub filename: String,
+    #[serde(skip_serializing)]
+    pub path: PathBuf,
+    pub size: u64,
+    pub duration_ms: u64,
+    pub frame_count: u32,
+    pub start_time_ms: u64,
+    pub modified_ms: u64,
+    pub radar_brand: u32,
+    pub spokes_per_rev: u32,
+    pub max_spoke_len: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subdirectory: Option<String>,
+}
+
+/// Directory information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirectoryInfo {
+    pub name: String,
+    pub recording_count: usize,
+    pub total_size: u64,
+}
+
+fn is_valid_name(name: &str) -> bool {
+    !name.contains('/') && !name.contains('\\') && !name.contains("..")
+}
+
+/// Manager for recording files
+pub struct RecordingManager {
+    base_dir: PathBuf,
+}
+
+impl RecordingManager {
+    pub fn new() -> Self {
+        let base_dir = recordings_dir();
+
+        if let Err(e) = fs::create_dir_all(&base_dir) {
+            error!("Failed to create recordings directory: {}", e);
+        } else {
+            debug!("Recordings directory: {}", base_dir.display());
+        }
+
+        Self { base_dir }
+    }
+
+    #[cfg(test)]
+    pub fn with_base_dir(base_dir: PathBuf) -> Self {
+        if let Err(e) = fs::create_dir_all(&base_dir) {
+            error!("Failed to create recordings directory: {}", e);
+        }
+        Self { base_dir }
+    }
+
+    pub fn base_dir(&self) -> &Path {
+        &self.base_dir
+    }
+
+    pub fn list_recordings(&self, subdirectory: Option<&str>) -> Vec<RecordingInfo> {
+        if let Some(sub) = subdirectory {
+            if !is_valid_name(sub) {
+                return Vec::new();
+            }
+        }
+
+        let dir = match subdirectory {
+            Some(sub) => self.base_dir.join(sub),
+            None => self.base_dir.clone(),
+        };
+
+        if !dir.exists() {
+            return Vec::new();
+        }
+
+        let mut recordings = Vec::new();
+
+        if let Ok(entries) = fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    if let Some(ext) = path.extension() {
+                        if ext == "mrr" {
+                            if let Some(info) = self.get_recording_info(&path, subdirectory) {
+                                recordings.push(info);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        recordings.sort_by(|a, b| b.modified_ms.cmp(&a.modified_ms));
+        recordings
+    }
+
+    pub fn list_directories(&self) -> Vec<DirectoryInfo> {
+        let mut dirs = Vec::new();
+
+        if let Ok(entries) = fs::read_dir(&self.base_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        let recordings = self.list_recordings(Some(name));
+                        let total_size: u64 = recordings.iter().map(|r| r.size).sum();
+                        dirs.push(DirectoryInfo {
+                            name: name.to_string(),
+                            recording_count: recordings.len(),
+                            total_size,
+                        });
+                    }
+                }
+            }
+        }
+
+        dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        dirs
+    }
+
+    pub fn get_recording_info(
+        &self,
+        path: &Path,
+        subdirectory: Option<&str>,
+    ) -> Option<RecordingInfo> {
+        let filename = path.file_name()?.to_str()?.to_string();
+
+        let metadata = fs::metadata(path).ok()?;
+        let size = metadata.len();
+        let modified_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let file = File::open(path).ok()?;
+        let mut reader = BufReader::new(file);
+
+        let header = MrrHeader::read(&mut reader).ok()?;
+
+        use std::io::{Seek, SeekFrom};
+        reader.seek(SeekFrom::End(-(FOOTER_SIZE as i64))).ok()?;
+        let footer = MrrFooter::read(&mut reader).ok()?;
+
+        Some(RecordingInfo {
+            filename,
+            path: path.to_path_buf(),
+            size,
+            duration_ms: footer.duration_ms,
+            frame_count: footer.frame_count,
+            start_time_ms: header.start_time_ms,
+            modified_ms,
+            radar_brand: header.radar_brand,
+            spokes_per_rev: header.spokes_per_rev,
+            max_spoke_len: header.max_spoke_len,
+            subdirectory: subdirectory.map(String::from),
+        })
+    }
+
+    pub fn get_recording(
+        &self,
+        filename: &str,
+        subdirectory: Option<&str>,
+    ) -> Option<RecordingInfo> {
+        let path = self.get_recording_path(filename, subdirectory);
+
+        if !self.is_safe_path(&path) {
+            return None;
+        }
+
+        if path.exists() {
+            self.get_recording_info(&path, subdirectory)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_recording_path(&self, filename: &str, subdirectory: Option<&str>) -> PathBuf {
+        match subdirectory {
+            Some(sub) => self.base_dir.join(sub).join(filename),
+            None => self.base_dir.join(filename),
+        }
+    }
+
+    pub fn delete_recording(
+        &self,
+        filename: &str,
+        subdirectory: Option<&str>,
+    ) -> Result<(), String> {
+        let path = self.get_recording_path(filename, subdirectory);
+
+        if !self.is_safe_path(&path) {
+            return Err("Invalid path".to_string());
+        }
+
+        if !path.exists() {
+            return Err(format!("Recording not found: {}", filename));
+        }
+
+        fs::remove_file(&path).map_err(|e| format!("Failed to delete: {}", e))?;
+        info!("Deleted recording: {}", path.display());
+        Ok(())
+    }
+
+    pub fn rename_recording(
+        &self,
+        filename: &str,
+        new_filename: &str,
+        subdirectory: Option<&str>,
+    ) -> Result<(), String> {
+        let new_filename = if new_filename.ends_with(".mrr") {
+            new_filename.to_string()
+        } else {
+            format!("{}.mrr", new_filename)
+        };
+
+        let old_path = self.get_recording_path(filename, subdirectory);
+        let new_path = self.get_recording_path(&new_filename, subdirectory);
+
+        if !self.is_safe_path(&old_path) || !self.is_safe_path(&new_path) {
+            return Err("Invalid path".to_string());
+        }
+
+        if !old_path.exists() {
+            return Err(format!("Recording not found: {}", filename));
+        }
+
+        if new_path.exists() {
+            return Err(format!("File already exists: {}", new_filename));
+        }
+
+        fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename: {}", e))?;
+        info!(
+            "Renamed recording: {} -> {}",
+            old_path.display(),
+            new_path.display()
+        );
+        Ok(())
+    }
+
+    pub fn create_directory(&self, name: &str) -> Result<(), String> {
+        if !is_valid_name(name) {
+            return Err("Invalid directory name".to_string());
+        }
+
+        let path = self.base_dir.join(name);
+
+        if path.exists() {
+            return Err(format!("Directory already exists: {}", name));
+        }
+
+        fs::create_dir_all(&path).map_err(|e| format!("Failed to create directory: {}", e))?;
+        info!("Created directory: {}", path.display());
+        Ok(())
+    }
+
+    pub fn delete_directory(&self, name: &str) -> Result<(), String> {
+        if !is_valid_name(name) {
+            return Err("Invalid directory name".to_string());
+        }
+
+        let path = self.base_dir.join(name);
+
+        if !path.exists() {
+            return Err(format!("Directory not found: {}", name));
+        }
+
+        if !path.is_dir() {
+            return Err(format!("Not a directory: {}", name));
+        }
+
+        let entries: Vec<_> = fs::read_dir(&path)
+            .map_err(|e| format!("Failed to read directory: {}", e))?
+            .flatten()
+            .collect();
+
+        if !entries.is_empty() {
+            return Err(format!(
+                "Directory not empty: {} ({} items)",
+                name,
+                entries.len()
+            ));
+        }
+
+        fs::remove_dir(&path).map_err(|e| format!("Failed to delete directory: {}", e))?;
+        info!("Deleted directory: {}", path.display());
+        Ok(())
+    }
+
+    pub fn generate_filename(&self, prefix: Option<&str>, subdirectory: Option<&str>) -> String {
+        let now = chrono::Utc::now();
+        let prefix = prefix
+            .filter(|p| is_valid_name(p))
+            .unwrap_or("recording");
+        let base_name = format!("{}_{}", prefix, now.format("%Y%m%d_%H%M%S"));
+
+        let dir = match subdirectory {
+            Some(sub) => self.base_dir.join(sub),
+            None => self.base_dir.clone(),
+        };
+
+        let mut name = format!("{}.mrr", base_name);
+        let mut counter = 1;
+        while dir.join(&name).exists() {
+            name = format!("{}_{}.mrr", base_name, counter);
+            counter += 1;
+        }
+
+        name
+    }
+
+    fn is_safe_path(&self, path: &Path) -> bool {
+        let canonical_base = match self.base_dir.canonicalize() {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+
+        match path.canonicalize() {
+            Ok(canonical) => canonical.starts_with(&canonical_base),
+            Err(_) => {
+                if let Some(parent) = path.parent() {
+                    match parent.canonicalize() {
+                        Ok(canonical_parent) => canonical_parent.starts_with(&canonical_base),
+                        Err(_) => false,
+                    }
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+impl Default for RecordingManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_manager() -> (RecordingManager, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = RecordingManager::with_base_dir(temp_dir.path().to_path_buf());
+        (manager, temp_dir)
+    }
+
+    #[test]
+    fn test_create_directory() {
+        let (manager, _temp) = create_test_manager();
+
+        assert!(manager.create_directory("test_dir").is_ok());
+        assert!(manager.base_dir.join("test_dir").exists());
+
+        // Creating again should fail
+        assert!(manager.create_directory("test_dir").is_err());
+    }
+
+    #[test]
+    fn test_delete_empty_directory() {
+        let (manager, _temp) = create_test_manager();
+
+        manager.create_directory("test_dir").unwrap();
+        assert!(manager.delete_directory("test_dir").is_ok());
+        assert!(!manager.base_dir.join("test_dir").exists());
+    }
+
+    #[test]
+    fn test_generate_filename() {
+        let (manager, _temp) = create_test_manager();
+
+        let name1 = manager.generate_filename(Some("radar1"), None);
+        assert!(name1.starts_with("radar1_"));
+        assert!(name1.ends_with(".mrr"));
+
+        fs::write(manager.base_dir.join(&name1), b"test").unwrap();
+
+        let name2 = manager.generate_filename(Some("radar1"), None);
+        assert_ne!(name1, name2);
+    }
+
+    #[test]
+    fn test_invalid_directory_names() {
+        let (manager, _temp) = create_test_manager();
+
+        assert!(manager.create_directory("../escape").is_err());
+        assert!(manager.create_directory("foo/bar").is_err());
+        assert!(manager.create_directory("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn test_list_empty_directory() {
+        let (manager, _temp) = create_test_manager();
+
+        let recordings = manager.list_recordings(None);
+        assert!(recordings.is_empty());
+
+        let dirs = manager.list_directories();
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn test_path_traversal_rejected() {
+        let (manager, _temp) = create_test_manager();
+
+        // Subdirectory traversal
+        assert!(manager.list_recordings(Some("../etc")).is_empty());
+
+        // Filename traversal
+        assert!(manager.get_recording("../../../etc/passwd", None).is_none());
+
+        // Delete traversal
+        assert!(manager.delete_recording("../../../etc/passwd", None).is_err());
+
+        // Delete directory traversal
+        assert!(manager.delete_directory("../escape").is_err());
+    }
+
+    #[test]
+    fn test_prefix_sanitization() {
+        let (manager, _temp) = create_test_manager();
+
+        // Malicious prefix falls back to "recording"
+        let name = manager.generate_filename(Some("../escape"), None);
+        assert!(name.starts_with("recording_"));
+    }
+}

--- a/src/lib/recording/mod.rs
+++ b/src/lib/recording/mod.rs
@@ -1,0 +1,38 @@
+//! Radar recording and playback module.
+//!
+//! Provides functionality to:
+//! - Record radar data to `.mrr` files (MaYaRa Radar Recording)
+//! - Play back recordings as virtual radars
+//! - Manage recording files (list, upload, download, delete)
+//!
+//! ## File Format
+//!
+//! The `.mrr` format is a binary format optimized for streaming:
+//!
+//! ```text
+//! ┌──────────────────────────┐
+//! │ Header (256 bytes)       │  magic "MRR1", version, radar metadata
+//! ├──────────────────────────┤
+//! │ Capabilities (JSON)      │  length-prefixed JSON
+//! ├──────────────────────────┤
+//! │ Initial State (JSON)     │  length-prefixed JSON (controls state)
+//! ├──────────────────────────┤
+//! │ Frame 0                  │  timestamp + protobuf RadarMessage
+//! │ Frame 1                  │
+//! │ ...                      │
+//! ├──────────────────────────┤
+//! │ Index (for seeking)      │  array of (timestamp, file_offset)
+//! ├──────────────────────────┤
+//! │ Footer (32 bytes)        │  index offset, frame count, duration
+//! └──────────────────────────┘
+//! ```
+
+pub mod file_format;
+pub mod manager;
+pub mod player;
+pub mod recorder;
+
+pub use file_format::{MrrFooter, MrrHeader, MrrReader, MrrWriter};
+pub use manager::{recordings_dir, RecordingInfo, RecordingManager};
+pub use player::{ActivePlayback, PlaybackSettings, PlaybackState, PlaybackStatus};
+pub use recorder::{ActiveRecording, RecordingState, RecordingStatus};

--- a/src/lib/recording/player.rs
+++ b/src/lib/recording/player.rs
@@ -1,0 +1,480 @@
+//! Radar playback - reads .mrr files and emits frames as a virtual radar.
+
+use log::{debug, error, info, warn};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{broadcast, RwLock};
+
+use crate::radar::settings::{ControlId, SharedControls, new_string};
+use crate::radar::SharedRadars;
+use crate::Brand;
+use crate::Cli;
+
+use super::file_format::MrrReader;
+use super::manager::RecordingManager;
+use super::recorder::id_to_brand;
+
+/// Playback state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaybackState {
+    Idle,
+    Loaded,
+    Playing,
+    Paused,
+    Stopped,
+}
+
+impl std::fmt::Display for PlaybackState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PlaybackState::Idle => write!(f, "idle"),
+            PlaybackState::Loaded => write!(f, "loaded"),
+            PlaybackState::Playing => write!(f, "playing"),
+            PlaybackState::Paused => write!(f, "paused"),
+            PlaybackState::Stopped => write!(f, "stopped"),
+        }
+    }
+}
+
+/// Playback status information
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlaybackStatus {
+    pub state: String,
+    pub filename: Option<String>,
+    pub radar_id: Option<String>,
+    pub position_ms: u64,
+    pub duration_ms: u64,
+    pub frame: u32,
+    pub frame_count: u32,
+    pub speed: f32,
+    pub loop_playback: bool,
+}
+
+impl Default for PlaybackStatus {
+    fn default() -> Self {
+        Self {
+            state: "idle".to_string(),
+            filename: None,
+            radar_id: None,
+            position_ms: 0,
+            duration_ms: 0,
+            frame: 0,
+            frame_count: 0,
+            speed: 1.0,
+            loop_playback: false,
+        }
+    }
+}
+
+/// Playback settings
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PlaybackSettings {
+    #[serde(default)]
+    pub speed: Option<f32>,
+    #[serde(default)]
+    pub loop_playback: Option<bool>,
+}
+
+/// Active playback handle
+pub struct ActivePlayback {
+    stop_flag: Arc<AtomicBool>,
+    pause_flag: Arc<AtomicBool>,
+    position_ms: Arc<AtomicU64>,
+    frame: Arc<AtomicU32>,
+    /// Playback speed stored as fixed point: 100 = 1.0x
+    speed: Arc<AtomicU32>,
+    loop_playback: Arc<AtomicBool>,
+    filename: String,
+    radar_key: String,
+    duration_ms: u64,
+    frame_count: u32,
+    state: Arc<RwLock<PlaybackState>>,
+    seek_target: Arc<RwLock<Option<u64>>>,
+}
+
+impl ActivePlayback {
+    pub fn stop(&self) {
+        self.stop_flag.store(true, Ordering::SeqCst);
+    }
+
+    pub fn pause(&self) {
+        self.pause_flag.store(true, Ordering::SeqCst);
+    }
+
+    pub fn resume(&self) {
+        self.pause_flag.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.pause_flag.load(Ordering::SeqCst)
+    }
+
+    pub fn is_stopped(&self) -> bool {
+        self.stop_flag.load(Ordering::SeqCst)
+    }
+
+    pub fn set_speed(&self, speed: f32) {
+        let speed_fixed = (speed * 100.0) as u32;
+        self.speed
+            .store(speed_fixed.clamp(10, 1000), Ordering::SeqCst);
+    }
+
+    pub fn get_speed(&self) -> f32 {
+        self.speed.load(Ordering::SeqCst) as f32 / 100.0
+    }
+
+    pub fn set_loop(&self, loop_playback: bool) {
+        self.loop_playback.store(loop_playback, Ordering::SeqCst);
+    }
+
+    pub async fn seek(&self, position_ms: u64) {
+        let mut target = self.seek_target.write().await;
+        *target = Some(position_ms);
+    }
+
+    pub fn radar_key(&self) -> &str {
+        &self.radar_key
+    }
+
+    pub fn filename(&self) -> &str {
+        &self.filename
+    }
+
+    pub async fn status(&self) -> PlaybackStatus {
+        let state = self.state.read().await;
+        PlaybackStatus {
+            state: state.to_string(),
+            filename: Some(self.filename.clone()),
+            radar_id: Some(self.radar_key.clone()),
+            position_ms: self.position_ms.load(Ordering::Relaxed),
+            duration_ms: self.duration_ms,
+            frame: self.frame.load(Ordering::Relaxed),
+            frame_count: self.frame_count,
+            speed: self.get_speed(),
+            loop_playback: self.loop_playback.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Create minimal controls for a playback radar (read-only)
+fn playback_controls(
+    radar_id: String,
+    sk_client_tx: broadcast::Sender<crate::stream::SignalKDelta>,
+    args: &Cli,
+) -> SharedControls {
+    let mut controls = HashMap::new();
+
+    new_string(ControlId::UserName).build(&mut controls);
+    controls
+        .get_mut(&ControlId::UserName)
+        .unwrap()
+        .set_string(format!("Playback: {}", radar_id));
+
+    new_string(ControlId::ModelName).build(&mut controls);
+    controls
+        .get_mut(&ControlId::ModelName)
+        .unwrap()
+        .set_string("Recording Playback".to_string());
+
+    SharedControls::new(radar_id, sk_client_tx, args, controls)
+}
+
+/// Load a recording and prepare for playback
+pub async fn load_recording(
+    args: &Cli,
+    radars: &SharedRadars,
+    filename: &str,
+    subdirectory: Option<&str>,
+) -> Result<ActivePlayback, String> {
+    let manager = RecordingManager::new();
+    let path = manager.get_recording_path(filename, subdirectory);
+
+    if !path.exists() {
+        return Err(format!("Recording not found: {}", filename));
+    }
+
+    info!("Loading recording: {}", path.display());
+
+    let file = File::open(&path).map_err(|e| format!("Failed to open file: {}", e))?;
+    let reader = BufReader::new(file);
+    let mrr_reader =
+        MrrReader::open(reader).map_err(|e| format!("Failed to parse recording: {}", e))?;
+
+    let header = mrr_reader.header();
+    let footer = mrr_reader.footer();
+
+    let brand = id_to_brand(header.radar_brand).unwrap_or(Brand::Playback);
+    let _ = brand; // Original brand recorded, but we register as Playback
+
+    let base_name = filename.trim_end_matches(".mrr");
+    let serial_no = format!("PB-{}", base_name);
+    let fake_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+
+    let info = crate::radar::RadarInfo::new(
+        radars,
+        args,
+        Brand::Playback,
+        Some(&serial_no),
+        None,
+        header.pixel_values as u8,
+        header.spokes_per_rev as usize,
+        header.max_spoke_len as usize,
+        fake_addr,
+        Ipv4Addr::LOCALHOST,
+        fake_addr,
+        fake_addr,
+        fake_addr,
+        |id, tx| playback_controls(id, tx, args),
+        false,
+    );
+
+    let radar_key = info.key();
+
+    // Remove any existing playback radar with the same key
+    radars.remove(&radar_key);
+
+    if let Some(mut info) = radars.add(info) {
+        // Set ranges so the radar appears as active in the GUI
+        let ranges = crate::radar::range::Ranges::new_by_distance(
+            &vec![header.max_spoke_len as i32],
+        );
+        info.set_ranges(ranges);
+
+        // Set power to transmit so GUI shows radar as active
+        let _ = info.controls.set(
+            &ControlId::Power,
+            crate::radar::Power::Transmit as i32 as f64,
+            None,
+        );
+
+        radars.update(&mut info);
+
+        let message_tx = info.message_tx.clone();
+
+        info!(
+            "Registered playback radar: {} ({}ms, {} frames)",
+            radar_key, footer.duration_ms, footer.frame_count
+        );
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let pause_flag = Arc::new(AtomicBool::new(true)); // Start paused
+        let position_ms = Arc::new(AtomicU64::new(0));
+        let frame = Arc::new(AtomicU32::new(0));
+        let speed = Arc::new(AtomicU32::new(100)); // 1.0x
+        let loop_playback = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(RwLock::new(PlaybackState::Loaded));
+        let seek_target = Arc::new(RwLock::new(None));
+
+        let active = ActivePlayback {
+            stop_flag: stop_flag.clone(),
+            pause_flag: pause_flag.clone(),
+            position_ms: position_ms.clone(),
+            frame: frame.clone(),
+            speed: speed.clone(),
+            loop_playback: loop_playback.clone(),
+            filename: filename.to_string(),
+            radar_key: radar_key.clone(),
+            duration_ms: footer.duration_ms,
+            frame_count: footer.frame_count,
+            state: state.clone(),
+            seek_target: seek_target.clone(),
+        };
+
+        let path_clone = path.clone();
+        tokio::spawn(async move {
+            playback_task(
+                path_clone,
+                message_tx,
+                stop_flag,
+                pause_flag,
+                position_ms,
+                frame,
+                speed,
+                loop_playback,
+                state,
+                seek_target,
+            )
+            .await;
+        });
+
+        Ok(active)
+    } else {
+        Err(format!(
+            "Failed to register playback radar '{}'",
+            radar_key
+        ))
+    }
+}
+
+async fn playback_task(
+    path: PathBuf,
+    message_tx: broadcast::Sender<Vec<u8>>,
+    stop_flag: Arc<AtomicBool>,
+    pause_flag: Arc<AtomicBool>,
+    position_ms: Arc<AtomicU64>,
+    frame_counter: Arc<AtomicU32>,
+    speed: Arc<AtomicU32>,
+    loop_playback: Arc<AtomicBool>,
+    state: Arc<RwLock<PlaybackState>>,
+    seek_target: Arc<RwLock<Option<u64>>>,
+) {
+    debug!("Playback task started for {}", path.display());
+
+    loop {
+        if stop_flag.load(Ordering::SeqCst) {
+            break;
+        }
+
+        if pause_flag.load(Ordering::SeqCst) {
+            {
+                let mut s = state.write().await;
+                if *s == PlaybackState::Playing {
+                    *s = PlaybackState::Paused;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            continue;
+        }
+
+        {
+            let mut s = state.write().await;
+            if *s == PlaybackState::Loaded || *s == PlaybackState::Paused {
+                *s = PlaybackState::Playing;
+            }
+        }
+
+        let file = match File::open(&path) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Failed to open file for playback: {}", e);
+                break;
+            }
+        };
+
+        let reader = BufReader::new(file);
+        let mut mrr_reader = match MrrReader::open(reader) {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Failed to parse recording for playback: {}", e);
+                break;
+            }
+        };
+
+        {
+            let mut target = seek_target.write().await;
+            let seek_ms = target
+                .take()
+                .unwrap_or_else(|| position_ms.load(Ordering::Relaxed));
+            if seek_ms > 0 {
+                if let Err(e) = mrr_reader.seek_to_timestamp(seek_ms) {
+                    warn!("Seek to {}ms failed: {}", seek_ms, e);
+                }
+            }
+        }
+
+        let mut playback_start = Instant::now();
+        let mut first_frame_ts: Option<u64> = None;
+        let mut frames_played = 0u32;
+
+        loop {
+            if stop_flag.load(Ordering::SeqCst) {
+                break;
+            }
+
+            if pause_flag.load(Ordering::SeqCst) {
+                break;
+            }
+
+            {
+                let mut target = seek_target.write().await;
+                if let Some(seek_ms) = target.take() {
+                    if let Err(e) = mrr_reader.seek_to_timestamp(seek_ms) {
+                        warn!("Seek failed: {}", e);
+                    }
+                    first_frame_ts = None;
+                    playback_start = Instant::now();
+                    continue;
+                }
+            }
+
+            let frame = match mrr_reader.read_frame() {
+                Ok(Some(f)) => f,
+                Ok(None) => {
+                    if loop_playback.load(Ordering::SeqCst) {
+                        if let Err(e) = mrr_reader.rewind() {
+                            error!("Failed to rewind: {}", e);
+                            break;
+                        }
+                        first_frame_ts = None;
+                        playback_start = Instant::now();
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to read frame: {}", e);
+                    break;
+                }
+            };
+
+            let speed_factor = speed.load(Ordering::SeqCst) as f64 / 100.0;
+            let frame_ts = frame.timestamp_ms;
+
+            if first_frame_ts.is_none() {
+                first_frame_ts = Some(frame_ts);
+            }
+
+            let relative_ts = frame_ts - first_frame_ts.unwrap();
+            let target_elapsed = Duration::from_millis((relative_ts as f64 / speed_factor) as u64);
+            let actual_elapsed = playback_start.elapsed();
+
+            if target_elapsed > actual_elapsed {
+                let wait_time = target_elapsed - actual_elapsed;
+                let max_wait = Duration::from_millis(100);
+                if wait_time > max_wait {
+                    tokio::time::sleep(max_wait).await;
+                    continue;
+                }
+                tokio::time::sleep(wait_time).await;
+            }
+
+            if let Err(e) = message_tx.send(frame.data) {
+                log::trace!("No receivers for playback frame: {}", e);
+            }
+
+            position_ms.store(frame_ts, Ordering::Relaxed);
+            frames_played += 1;
+            frame_counter.store(frames_played, Ordering::Relaxed);
+        }
+
+        if stop_flag.load(Ordering::SeqCst) {
+            break;
+        }
+        if !pause_flag.load(Ordering::SeqCst) && !loop_playback.load(Ordering::SeqCst) {
+            break;
+        }
+    }
+
+    stop_flag.store(true, Ordering::SeqCst);
+    {
+        let mut s = state.write().await;
+        *s = PlaybackState::Stopped;
+    }
+
+    info!("Playback finished for {}", path.display());
+}
+
+/// Unregister a playback radar
+pub fn unregister_playback_radar(radars: &SharedRadars, radar_key: &str) {
+    info!("Unregistering playback radar: key={}", radar_key);
+    radars.remove(radar_key);
+}

--- a/src/lib/recording/recorder.rs
+++ b/src/lib/recording/recorder.rs
@@ -1,0 +1,328 @@
+//! Radar recorder - subscribes to radar broadcast and writes to .mrr file.
+
+use log::{debug, error, info, warn};
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::broadcast;
+
+use crate::radar::RadarInfo;
+use crate::Brand;
+
+use super::file_format::{MrrFrame, MrrWriter};
+use super::manager::{recordings_dir, RecordingManager};
+
+/// Recording state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordingState {
+    Idle,
+    Recording,
+    Stopping,
+}
+
+/// Recording status information
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingStatus {
+    pub state: String,
+    pub radar_id: Option<String>,
+    pub filename: Option<String>,
+    pub subdirectory: Option<String>,
+    pub frame_count: u32,
+    pub duration_ms: u64,
+    pub size_bytes: u64,
+    pub start_time_ms: Option<u64>,
+}
+
+impl Default for RecordingStatus {
+    fn default() -> Self {
+        Self {
+            state: "idle".to_string(),
+            radar_id: None,
+            filename: None,
+            subdirectory: None,
+            frame_count: 0,
+            duration_ms: 0,
+            size_bytes: 0,
+            start_time_ms: None,
+        }
+    }
+}
+
+/// Active recording handle
+pub struct ActiveRecording {
+    stop_flag: Arc<AtomicBool>,
+    radar_id: String,
+    filename: String,
+    subdirectory: Option<String>,
+    frame_count: Arc<AtomicU32>,
+    duration_ms: Arc<AtomicU64>,
+    size_bytes: Arc<AtomicU64>,
+    start_time_ms: u64,
+}
+
+impl ActiveRecording {
+    pub fn stop(&self) {
+        self.stop_flag.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_running(&self) -> bool {
+        !self.stop_flag.load(Ordering::SeqCst)
+    }
+
+    pub fn status(&self) -> RecordingStatus {
+        RecordingStatus {
+            state: "recording".to_string(),
+            radar_id: Some(self.radar_id.clone()),
+            filename: Some(self.filename.clone()),
+            subdirectory: self.subdirectory.clone(),
+            frame_count: self.frame_count.load(Ordering::Relaxed),
+            duration_ms: self.duration_ms.load(Ordering::Relaxed),
+            size_bytes: self.size_bytes.load(Ordering::Relaxed),
+            start_time_ms: Some(self.start_time_ms),
+        }
+    }
+
+    pub fn radar_id(&self) -> &str {
+        &self.radar_id
+    }
+
+    pub fn filename(&self) -> &str {
+        &self.filename
+    }
+}
+
+/// Start recording from a radar
+fn is_valid_name(name: &str) -> bool {
+    !name.contains('/') && !name.contains('\\') && !name.contains("..")
+}
+
+pub async fn start_recording(
+    radar_info: &RadarInfo,
+    radar_key: &str,
+    filename: Option<&str>,
+    subdirectory: Option<&str>,
+    capabilities_json: &[u8],
+    initial_state_json: &[u8],
+) -> Result<ActiveRecording, String> {
+    // Validate inputs before any filesystem operations
+    if let Some(f) = filename {
+        if !is_valid_name(f) {
+            return Err("Invalid filename".to_string());
+        }
+    }
+    if let Some(sub) = subdirectory {
+        if !is_valid_name(sub) {
+            return Err("Invalid subdirectory".to_string());
+        }
+    }
+
+    let manager = RecordingManager::new();
+
+    let filename = match filename {
+        Some(f) => {
+            let f = if f.ends_with(".mrr") {
+                f.to_string()
+            } else {
+                format!("{}.mrr", f)
+            };
+            let path = manager.get_recording_path(&f, subdirectory);
+            if path.exists() {
+                return Err(format!("File already exists: {}", f));
+            }
+            f
+        }
+        None => {
+            let prefix = radar_info
+                .controls
+                .user_name()
+                .replace(' ', "_");
+            let prefix = if prefix.is_empty() {
+                format!("radar-{}", radar_key)
+            } else {
+                prefix
+            };
+            manager.generate_filename(Some(&prefix), subdirectory)
+        }
+    };
+
+    if let Some(sub) = subdirectory {
+        let sub_path = recordings_dir().join(sub);
+        if !sub_path.exists() {
+            std::fs::create_dir_all(&sub_path)
+                .map_err(|e| format!("Failed to create subdirectory: {}", e))?;
+        }
+    }
+
+    let path = manager.get_recording_path(&filename, subdirectory);
+    info!("Starting recording to: {}", path.display());
+
+    let file = File::create(&path).map_err(|e| format!("Failed to create file: {}", e))?;
+    let writer = BufWriter::new(file);
+
+    let brand_id = brand_to_id(radar_info.brand);
+    let mrr_writer = MrrWriter::new(
+        writer,
+        brand_id,
+        radar_info.spokes_per_revolution as u32,
+        radar_info.max_spoke_len as u32,
+        radar_info.pixel_values as u32,
+        capabilities_json,
+        initial_state_json,
+    )
+    .map_err(|e| format!("Failed to create MRR writer: {}", e))?;
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let frame_count = Arc::new(AtomicU32::new(0));
+    let duration_ms = Arc::new(AtomicU64::new(0));
+    let size_bytes = Arc::new(AtomicU64::new(0));
+
+    let start_time_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+
+    let active = ActiveRecording {
+        stop_flag: stop_flag.clone(),
+        radar_id: radar_key.to_string(),
+        filename: filename.clone(),
+        subdirectory: subdirectory.map(String::from),
+        frame_count: frame_count.clone(),
+        duration_ms: duration_ms.clone(),
+        size_bytes: size_bytes.clone(),
+        start_time_ms,
+    };
+
+    let message_rx = radar_info.message_tx.subscribe();
+
+    let path_clone = path.clone();
+    tokio::spawn(async move {
+        recording_task(
+            mrr_writer,
+            message_rx,
+            stop_flag,
+            frame_count,
+            duration_ms,
+            size_bytes,
+            path_clone,
+        )
+        .await;
+    });
+
+    Ok(active)
+}
+
+async fn recording_task(
+    mut writer: MrrWriter<BufWriter<File>>,
+    mut message_rx: broadcast::Receiver<Vec<u8>>,
+    stop_flag: Arc<AtomicBool>,
+    frame_count: Arc<AtomicU32>,
+    duration_ms: Arc<AtomicU64>,
+    size_bytes: Arc<AtomicU64>,
+    path: PathBuf,
+) {
+    let start = std::time::Instant::now();
+    let mut frames = 0u32;
+    let mut approx_size = 0u64;
+
+    debug!("Recording task started for {}", path.display());
+
+    loop {
+        if stop_flag.load(Ordering::SeqCst) {
+            debug!("Recording stop flag detected");
+            break;
+        }
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_millis(100), message_rx.recv()).await;
+
+        match result {
+            Ok(Ok(data)) => {
+                let timestamp_ms = start.elapsed().as_millis() as u64;
+                let frame = MrrFrame::new(timestamp_ms, data);
+
+                approx_size += frame.size() as u64;
+
+                if let Err(e) = writer.write_frame(&frame) {
+                    error!("Failed to write frame: {}", e);
+                    break;
+                }
+
+                frames += 1;
+
+                if frames % 10 == 0 {
+                    frame_count.store(frames, Ordering::Relaxed);
+                    duration_ms.store(timestamp_ms, Ordering::Relaxed);
+                    size_bytes.store(approx_size, Ordering::Relaxed);
+                }
+            }
+            Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
+                warn!("Recording lagged, missed {} messages", n);
+            }
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                info!("Radar broadcast channel closed");
+                break;
+            }
+            Err(_) => {
+                // Timeout - check stop flag
+            }
+        }
+    }
+
+    let final_duration = start.elapsed().as_millis() as u64;
+    frame_count.store(frames, Ordering::Relaxed);
+    duration_ms.store(final_duration, Ordering::Relaxed);
+    size_bytes.store(approx_size, Ordering::Relaxed);
+
+    match writer.finish() {
+        Ok(()) => {
+            info!(
+                "Recording finished: {} frames, {}ms duration, {} bytes (approx)",
+                frames, final_duration, approx_size
+            );
+        }
+        Err(e) => {
+            error!("Failed to finish recording: {}", e);
+        }
+    }
+
+    stop_flag.store(true, Ordering::SeqCst);
+}
+
+/// Build initial state JSON from radar controls
+pub fn build_initial_state(radar_info: &RadarInfo) -> Vec<u8> {
+    let controls = radar_info.controls.get_controls();
+    let mut state = std::collections::BTreeMap::new();
+    for (id, control) in &controls {
+        if let Some(value) = control.value() {
+            state.insert(format!("{:?}", id), value);
+        }
+    }
+    serde_json::to_vec(&state).unwrap_or_else(|_| b"{}".to_vec())
+}
+
+pub fn brand_to_id(brand: Brand) -> u32 {
+    match brand {
+        Brand::Furuno => 1,
+        Brand::Garmin => 2,
+        Brand::Navico => 3,
+        Brand::Raymarine => 4,
+        Brand::Emulator => 5,
+        Brand::Playback => 6,
+    }
+}
+
+pub fn id_to_brand(id: u32) -> Option<Brand> {
+    match id {
+        1 => Some(Brand::Furuno),
+        2 => Some(Brand::Garmin),
+        3 => Some(Brand::Navico),
+        4 => Some(Brand::Raymarine),
+        5 => Some(Brand::Emulator),
+        6 => Some(Brand::Playback),
+        _ => None,
+    }
+}

--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -287,8 +287,6 @@ export function isPlaybackRadar(radarId) {
 
 // ============================================================================
 // Recordings API
-// NOTE: The recordings API was removed in v3. These functions are kept for
-// compatibility with v2 GUI code but will not work with the v3 backend.
 // ============================================================================
 
 const RECORDINGS_API = "/v2/api/vessels/self/radars/recordings";

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -783,7 +783,7 @@ function showActionButtons() {
       a(
         {
           href: "recordings.html",
-          class: "myr_radar_link myr_radar_link_secondary myr_strikethrough",
+          class: "myr_radar_link myr_radar_link_secondary",
         },
         "Recordings"
       )


### PR DESCRIPTION
## Summary

- Port radar recording and playback from v2, adapted to the current architecture
- Record radar data to `.mrr` binary files with seek index for efficient navigation
- Play back recordings as virtual `Brand::Playback` radars with speed/loop/seek control
- REST API at `/v2/api/vessels/self/radars/recordings/` matching the existing frontend
- Enable the existing recordings UI (remove strikethrough, fix stale API comment)

Closes #19

## Details

**Recording** subscribes to a radar's broadcast channel and writes protobuf RadarMessage frames to `.mrr` files in real-time, tracking frame count, duration and size via atomics.

**Playback** loads `.mrr` files, registers a virtual radar with `SharedRadars`, and sends stored frames to connected WebSocket clients with timing derived from recorded timestamps.

**File management** stores recordings in the OS data directory (`~/.local/share/mayara/recordings/`), with list, delete, rename, and streaming download endpoints.

**Security**: path traversal protection on all file operations (canonicalized base dir comparison), filename validation at the HTTP boundary, bounds-checked allocations when parsing MRR files, Content-Disposition header sanitization.

## Test plan

- [x] `cargo test` — 114 tests pass (99 lib + 15 integration), including new roundtrip, path traversal, and prefix sanitization tests
- [x] Manual testing: recorded Furuno DRS4D-NXT radar, verified `.mrr` files written to disk
- [x] Recordings UI loads radar list, starts/stops recording, shows file list
- [x] CodeRabbit review: 16 → 3 → 0 findings across three review passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end radar recording and playback: record to disk, replay with play/pause/seek/speed/loop controls, live status, and a synthetic playback radar
  * REST Recordings API: start/stop recordings, control playback, list/download/rename/delete recordings and directories, and fetch statuses
  * New binary .mrr recording format and safe filename/subdirectory validation with unique name generation

* **Chores**
  * Restored Recordings UI link
  * Added a development-only dependency for testing/tools
<!-- end of auto-generated comment: release notes by coderabbit.ai -->