### PR TITLE
Fix: Show all IPv4 addresses per interface

### DIFF
--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -328,7 +328,7 @@ impl Locator {
                                 if avoid_wifi && network::is_wireless_interface(&itf.name) {
                                     log::trace!("Ignoring wireless interface '{}'", itf.name);
                                     if_api.insert(
-                                        InterfaceId::new(&itf.name),
+                                        InterfaceId::new(&itf.name, Some(nic_ip)),
                                         RadarInterfaceApi::new(
                                             InterfaceStatus::WirelessIgnored,
                                             Some(nic_ip),
@@ -425,7 +425,7 @@ impl Locator {
                                 }
 
                                 if_api.insert(
-                                    InterfaceId::new(&itf.name),
+                                    InterfaceId::new(&itf.name, Some(nic_ip)),
                                     RadarInterfaceApi::new(
                                         InterfaceStatus::Ok,
                                         Some(nic_ip),
@@ -462,7 +462,7 @@ impl Locator {
                             }
                         }
                         if_api.insert(
-                            InterfaceId::new(&itf.name),
+                            InterfaceId::new(&itf.name, None),
                             RadarInterfaceApi::new(
                                 InterfaceStatus::NoIPv4Address,
                                 None,

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -241,11 +241,13 @@ struct RadarInterfaceApi {
     listeners: Option<HashMap<Brand, String>>,
 }
 
-/// Network interface identifier (e.g., "en0", "eth0")
-#[derive(Clone, Eq, PartialEq, Hash, ToSchema)]
-#[schema(as = String, example = "en0")]
+/// Network interface identifier (e.g., "eth0 (192.168.1.100)")
+///
+/// Serialized as a string: "name (ip)" when IP is present, or just "name" when not.
+#[derive(Clone, Eq, PartialEq, Hash)]
 struct InterfaceId {
     name: String,
+    ip: Option<Ipv4Addr>,
 }
 
 /// API response containing network interface information for radar detection
@@ -253,8 +255,8 @@ struct InterfaceId {
 #[schema(example = json!({
     "brands": ["Navico", "Furuno"],
     "interfaces": {
-        "en0": {
-            "status": "up",
+        "en0 (192.168.1.100)": {
+            "status": "Ok",
             "ip": "192.168.1.100",
             "netmask": "255.255.255.0",
             "listeners": {
@@ -263,7 +265,7 @@ struct InterfaceId {
             }
         },
         "en1": {
-            "status": "Wireless ignored"
+            "status": "WirelessIgnored"
         }
     }
 }))]
@@ -293,9 +295,10 @@ impl RadarInterfaceApi {
 }
 
 impl InterfaceId {
-    fn new(name: &str) -> Self {
+    fn new(name: &str, ip: Option<Ipv4Addr>) -> Self {
         Self {
             name: name.to_owned(),
+            ip,
         }
     }
 }
@@ -305,7 +308,10 @@ impl Serialize for InterfaceId {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.name.as_str())
+        match &self.ip {
+            Some(ip) => serializer.serialize_str(&format!("{} ({})", self.name, ip)),
+            None => serializer.serialize_str(self.name.as_str()),
+        }
     }
 }
 

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -694,7 +694,7 @@ async function showInterfacesPopup() {
         let row = van.add(table, tr());
         van.add(
           row,
-          td({ class: "myr_interface_name" }, name + " (" + data.ip + ")")
+          td({ class: "myr_interface_name" }, name)
         );
         d.brands.forEach((b) => {
           let status = data.listeners[b];


### PR DESCRIPTION
## Summary

- Fix interface API only showing the last IPv4 address when an interface has multiple addresses
- Include IP in the `InterfaceId` HashMap key so each (name, IP) pair gets its own entry
- Each address gets its own row in the Interfaces modal with correct per-IP listener statuses

Fixes #32

## Details

The `if_api` HashMap was keyed by interface name only (`InterfaceId` contained just a `name: String`). When iterating through multiple addresses on the same interface, each `if_api.insert()` overwrote the previous entry. Socket creation and radar discovery already worked correctly for all addresses — only the reporting was broken.

The fix adds an `ip: Option<Ipv4Addr>` field to `InterfaceId`, which is included in `Hash`/`Eq` for uniqueness and in `Serialize` to produce keys like `"eth0 (192.168.0.148)"`. The UI already iterates `Object.keys(interfaces)` so no structural changes are needed there — just removed the redundant IP append since the key now includes it.

## Image
<img width="805" height="361" alt="image" src="https://github.com/user-attachments/assets/2593ffc8-ebdb-4ec2-8332-d93f65105912" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated interface identifier structure to include IPv4 address information for improved internal tracking
  * Adjusted interface display in the UI to show interface names only, removing previously appended IP addresses from the interface table

<!-- end of auto-generated comment: release notes by coderabbit.ai -->