### PR TITLE
Fix failing radar_error_into_response test

### DIFF
--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -983,7 +983,7 @@ mod tests {
         let response = error.into_response();
 
         // If we reach here, no stack overflow occurred
-        assert_eq!(response.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
     }
 }
 


### PR DESCRIPTION
The test asserts `INTERNAL_SERVER_ERROR` but `NoSuchRadar` now correctly returns `NOT_FOUND` after the status code improvements in main. Updates the assertion to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP error responses to return 404 (Not Found) when radar data is missing or control IDs are invalid, instead of 500 (Internal Server Error).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->