### PR TITLE
fix(furuno): retry spoke data sockets on creation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 
 ### Fixed
 
+- Furuno spoke data sockets retry on failure instead of silently staying dead
 - Accept 0xc2 as valid Navico spoke status for HALO20+ compatibility (#27)
 - Move inline `display: none` style to CSS for WebGPU warning element
 - `NoSuchRadar` returns 404 (was 500), response includes list of valid radar IDs

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -233,24 +233,38 @@ impl FurunoReportReceiver {
     }
 
     pub async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
-        self.start_data_socket().await?;
-        self.start_command_stream().await?;
         loop {
+            if let Err(e) = self.start_data_socket().await {
+                log::warn!("{}: Failed to start data sockets: {}", self.common.key, e);
+                tokio::select! {
+                    _ = subsys.on_shutdown_requested() => return Ok(()),
+                    _ = sleep(Duration::from_millis(1000)) => {}
+                }
+                continue;
+            }
+
+            if self.stream.is_none() && !self.common.replay {
+                self.login_to_radar()?;
+                self.start_command_stream().await?;
+            }
+
             if self.stream.is_some() || self.common.replay {
                 match self.data_loop(&subsys).await {
                     Err(RadarError::Shutdown) => {
                         return Ok(());
                     }
                     _ => {
-                        // Ignore, reopen socket
+                        // Reopen sockets on next iteration
                     }
                 }
                 self.stream = None;
-            } else {
-                sleep(Duration::from_millis(1000)).await;
-                self.login_to_radar()?;
-                self.start_command_stream().await?;
-                self.start_data_socket().await?;
+                self.multicast_socket = None;
+                self.broadcast_socket = None;
+            }
+
+            tokio::select! {
+                _ = subsys.on_shutdown_requested() => return Ok(()),
+                _ = sleep(Duration::from_millis(1000)) => {}
             }
         }
     }
@@ -669,18 +683,18 @@ impl FurunoReportReceiver {
                     &self.common.info.spoke_data_addr,
                     &self.common.info.nic_addr
                 );
+                Ok(())
             }
             Err(e) => {
-                sleep(Duration::from_millis(1000)).await;
-                log::debug!(
+                log::warn!(
                     "{} via {}: listen multicast failed: {}",
                     &self.common.info.spoke_data_addr,
                     &self.common.info.nic_addr,
                     e
                 );
+                Err(e)
             }
-        };
-        Ok(())
+        }
     }
 
     async fn start_broadcast_socket(&mut self) -> io::Result<()> {
@@ -696,29 +710,41 @@ impl FurunoReportReceiver {
                     &FURUNO_DATA_BROADCAST_ADDRESS,
                     &self.common.info.nic_addr
                 );
+                Ok(())
             }
             Err(e) => {
-                sleep(Duration::from_millis(1000)).await;
-                log::debug!(
+                log::warn!(
                     "{} via {}: listen broadcast failed: {}",
                     &FURUNO_DATA_BROADCAST_ADDRESS,
                     &self.common.info.nic_addr,
                     e
                 );
+                Err(e)
             }
-        };
-        Ok(())
+        }
     }
 
     async fn start_data_socket(&mut self) -> io::Result<()> {
+        let mut last_err = None;
+
         if self.receive_type != ReceiveAddressType::Broadcast && self.multicast_socket.is_none() {
-            self.start_multicast_socket().await?;
+            if let Err(e) = self.start_multicast_socket().await {
+                last_err = Some(e);
+            }
         }
         if self.receive_type != ReceiveAddressType::Multicast && self.broadcast_socket.is_none() {
-            self.start_broadcast_socket().await?;
+            if let Err(e) = self.start_broadcast_socket().await {
+                last_err = Some(e);
+            }
         }
 
-        Ok(())
+        if self.multicast_socket.is_some() || self.broadcast_socket.is_some() {
+            Ok(())
+        } else if let Some(e) = last_err {
+            Err(e)
+        } else {
+            Ok(())
+        }
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Furuno multicast/broadcast spoke data sockets now propagate errors instead of silently swallowing them
- The `run()` loop retries socket creation on failure, matching the resilient pattern used by Garmin and Navico brands
- Socket failures are logged at `warn` level (was `debug`) so they are visible at default log level

Without this fix, if the multicast join fails at startup (e.g. network interface not ready), the radar appears connected (TCP control channel works) but never receives spoke data — requiring a manual restart to recover.

## Manually tested

- Verified on hardware: start mayara-server before network is fully up, confirm it recovers and receives spokes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Furuno data sockets now retry on connection failures instead of silently stopping, improving recovery.
  * Improved socket initialization error handling so at least one data path is preserved when possible and failures are surfaced for retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->