### PR TITLE
fix(recordings): add missing upload endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 - GUI showed DISCONNECTED in Firefox after server restart due to unnecessary state reset when spoke stream reconnect triggered a redundant state stream reconnect
 - Heading extracted from spoke data for GUI when no external heading source available
 - Furuno spoke data sockets retry on failure instead of silently staying dead
+- Recording file upload from the GUI (add missing `POST /recordings/files/upload` route)
 - Accept 0xc2 as valid Navico spoke status for HALO20+ compatibility (#27)
 - Move inline `display: none` style to CSS for WebGPU warning element
 - `NoSuchRadar` returns 404 (was 500), response includes list of valid radar IDs

--- a/src/bin/mayara-server/web/recordings.rs
+++ b/src/bin/mayara-server/web/recordings.rs
@@ -3,11 +3,13 @@
 use axum::{
     Json,
     body::Body,
-    extract::{Path, Query, State},
-    http::StatusCode,
+    extract::{DefaultBodyLimit, Path, Query, State},
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{delete, get, post, put},
 };
+use futures_util::StreamExt;
+use tokio::io::AsyncWriteExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -82,6 +84,9 @@ struct RecordableRadar {
 
 const RECORDINGS_BASE: &str = "/v2/api/vessels/self/radars/recordings";
 
+/// Maximum size for an uploaded recording file (2 GiB).
+const MAX_UPLOAD_SIZE: usize = 2 * 1024 * 1024 * 1024;
+
 fn validate_filename(filename: &str) -> Result<(), &'static str> {
     if filename.is_empty()
         || filename.contains("..")
@@ -93,6 +98,32 @@ fn validate_filename(filename: &str) -> Result<(), &'static str> {
         return Err("Invalid filename");
     }
     Ok(())
+}
+
+fn validate_upload_filename(filename: &str) -> Result<(), &'static str> {
+    validate_filename(filename)?;
+    let lower = filename.to_ascii_lowercase();
+    if !lower.ends_with(".mrr") && !lower.ends_with(".gz") {
+        return Err("Invalid file extension (expected .mrr or .gz)");
+    }
+    Ok(())
+}
+
+/// Extract the filename from a Content-Disposition header value.
+///
+/// Supports the common `attachment; filename="foo.mrr"` form used by the GUI.
+/// Only a quoted `filename` parameter is recognized.
+fn parse_content_disposition_filename(value: &str) -> Option<String> {
+    for part in value.split(';') {
+        let part = part.trim();
+        if let Some(rest) = part.strip_prefix("filename=") {
+            let trimmed = rest.trim().trim_matches('"');
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
 }
 
 fn sanitize_for_header(filename: &str) -> String {
@@ -164,6 +195,11 @@ pub fn routes(router: axum::Router<Web>) -> axum::Router<Web> {
         .route(
             &format!("{}/files/{{filename}}/download", RECORDINGS_BASE),
             get(download_recording_handler),
+        )
+        .route(
+            &format!("{}/files/upload", RECORDINGS_BASE),
+            post(upload_recording_handler)
+                .layer(DefaultBodyLimit::max(MAX_UPLOAD_SIZE)),
         )
         .route(
             &format!("{}/directories", RECORDINGS_BASE),
@@ -611,4 +647,128 @@ async fn download_recording_handler(
         )
             .into_response(),
     }
+}
+
+async fn upload_recording_handler(headers: HeaderMap, body: Body) -> impl IntoResponse {
+    let filename = headers
+        .get(axum::http::header::CONTENT_DISPOSITION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_content_disposition_filename);
+
+    let filename = match filename {
+        Some(f) => f,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!(
+                    {"error": "Missing or invalid Content-Disposition filename"}
+                )),
+            );
+        }
+    };
+
+    if let Err(e) = validate_upload_filename(&filename) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": e})),
+        );
+    }
+
+    let manager = RecordingManager::new();
+    let target_path = manager.get_recording_path(&filename, None);
+
+    if target_path.exists() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "File already exists"})),
+        );
+    }
+
+    let tmp_path = target_path.with_file_name(format!("{}.upload", filename));
+    let mut file = match tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)
+        .await
+    {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({"error": "Upload already in progress"})),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!(
+                    {"error": format!("Failed to create file: {}", e)}
+                )),
+            );
+        }
+    };
+
+    let mut stream = body.into_data_stream();
+    let mut total: u64 = 0;
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!(
+                        {"error": format!("Failed to read upload body: {}", e)}
+                    )),
+                );
+            }
+        };
+        total += chunk.len() as u64;
+        if total > MAX_UPLOAD_SIZE as u64 {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(serde_json::json!({"error": "Upload exceeds 2 GiB limit"})),
+            );
+        }
+        if let Err(e) = file.write_all(&chunk).await {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!(
+                    {"error": format!("Failed to write file: {}", e)}
+                )),
+            );
+        }
+    }
+
+    if let Err(e) = file.sync_data().await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(
+                {"error": format!("Failed to sync file: {}", e)}
+            )),
+        );
+    }
+    drop(file);
+
+    if let Err(e) = tokio::fs::rename(&tmp_path, &target_path).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(
+                {"error": format!("Failed to finalize upload: {}", e)}
+            )),
+        );
+    }
+
+    log::info!("Uploaded recording: {} ({} bytes)", filename, total);
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "filename": filename,
+            "size": total,
+        })),
+    )
 }


### PR DESCRIPTION
## Summary

The GUI POSTs uploaded `.mrr`/`.mrr.gz` files to `/recordings/files/upload`, but no handler for that route existed. The request hit axum's default 2 MiB body limit and the connection was torn down mid-upload (HAR showed status 0 after ~540 KB of a 5 MB file).

Add a streaming upload handler that reads the filename from `Content-Disposition`, writes to a temp file, and atomically renames on success. Body limit is raised to 2 GiB on this route only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored GUI recording file upload.
  * Enforces a 2 GiB upload limit and aborts oversized transfers.
  * Validates uploaded filenames and restricts allowed file extensions; rejects invalid uploads with clear errors.
  * Returns a conflict response for duplicate recordings.
  * Improves error handling for failed uploads and returns a success response with filename and size on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->