### PR TITLE
fix(furuno): accept non-NM range display units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 
 ### Fixed
 
+- Furuno range report no longer rejects radars set to km or sm display units
 - All control values now include timestamps in state broadcasts
 - Button controls (clearTrails, clearTargets) no longer sent in state broadcasts
 - Unchanged control values no longer re-broadcast to clients

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -465,11 +465,10 @@ impl FurunoReportReceiver {
                         numbers.len()
                     );
                 }
-                if numbers[2] != 0. {
-                    bail!("Cannot handle radar not set to NM range");
-                }
                 // CRITICAL: numbers[0] is a WIRE INDEX (non-sequential: 21, 0-15, 19)
                 // NOT an array position! Must convert to meters first.
+                // numbers[2] is the display unit (0=NM, 1=km, 2=sm) but the wire
+                // index maps to meters regardless of display unit.
                 let wire_index = numbers[0] as i32;
                 let range_meters =
                     super::command::wire_index_to_meters(wire_index).with_context(|| {


### PR DESCRIPTION
## Summary

- Remove `bail!("Cannot handle radar not set to NM range")` from the Range report handler
- The wire index maps to meters regardless of the radar's display unit (NM/km/sm), so the conversion works correctly in all cases
- This setting persists in the radar's flash memory from previous sessions (e.g. with TimeZero or other MFD software), causing Mayara to reject range reports on every startup until the unit is manually changed back

