### PR TITLE
feat(furuno): send guard zone geometry to radar hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 ### Added
 
 - Furuno pulse width display: shows current transmit pulse width (S1/S2/M1/M2/M3/L) as reported by the radar
+- Furuno hardware guard zone support: fan zone geometry is sent to the radar antenna processor when guard zones are configured in the GUI
 
 ### Fixed 
 

--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -3,9 +3,11 @@ use std::fmt::Write;
 use tokio::io::{AsyncWriteExt, WriteHalf};
 use tokio::net::TcpStream;
 
+use std::f64::consts::TAU;
+
 use super::protocol::{
-    CommandId, CommandMode, WIRE_UNIT_KM, WIRE_UNIT_NM, meters_to_wire_index_for_unit,
-    wire_unit_for_meters,
+    CommandId, CommandMode, GUARD_MODE_FAN, GUARD_MODE_OFF, SPOKES, WIRE_UNIT_KM, WIRE_UNIT_NM,
+    meters_to_wire_index_for_unit, wire_unit_for_meters,
 };
 use crate::brand::CommandSender;
 use crate::radar::range::Ranges;
@@ -488,6 +490,58 @@ impl CommandSender for Command {
                 CommandId::TargetAnalyzer
             }
 
+            ControlId::GuardZone1 | ControlId::GuardZone2 => {
+                let zone_index: i32 = if cv.id == ControlId::GuardZone1 {
+                    0
+                } else {
+                    1
+                };
+
+                if let Some(zone) = controls.guard_zone(&cv.id) {
+                    if zone.enabled {
+                        let start_spoke = radians_to_spokes(zone.start_angle);
+                        let end_spoke = radians_to_spokes(zone.end_angle);
+                        // TODO: verify range unit empirically on hardware
+                        let inner_range = zone.start_distance as i32;
+                        let outer_range = zone.end_distance as i32;
+
+                        self.send(
+                            CommandMode::Set,
+                            CommandId::GuardFan,
+                            &[zone_index, start_spoke, end_spoke, inner_range, outer_range],
+                        )
+                        .await?;
+                        self.send(
+                            CommandMode::Set,
+                            CommandId::GuardMode,
+                            &[GUARD_MODE_FAN, 0, zone_index],
+                        )
+                        .await?;
+                    } else {
+                        self.send(
+                            CommandMode::Set,
+                            CommandId::GuardMode,
+                            &[GUARD_MODE_OFF, 0, zone_index],
+                        )
+                        .await?;
+                    }
+                } else {
+                    self.send(
+                        CommandMode::Set,
+                        CommandId::GuardMode,
+                        &[GUARD_MODE_OFF, 0, zone_index],
+                    )
+                    .await?;
+                }
+
+                log::info!(
+                    "{}: Guard zone {} sent to hardware",
+                    self.key,
+                    zone_index + 1
+                );
+                return Ok(());
+            }
+
             // Non-hardware settings
             _ => return Err(RadarError::CannotSetControlId(cv.id)),
         };
@@ -508,4 +562,9 @@ impl CommandSender for Command {
         }
         Ok(())
     }
+}
+
+/// Convert an angle in radians to Furuno spoke units (0–8191).
+fn radians_to_spokes(radians: f64) -> i32 {
+    ((radians / TAU * SPOKES as f64).round() as i32).rem_euclid(SPOKES as i32)
 }

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -322,6 +322,9 @@ pub enum CommandId {
     /// `0x6E` — Antenna type (read-only, 7 params).
     AntennaType = 0x6E,
 
+    /// `0x70` — Guard zone alarm status: `$N70,<count>,<status0>,<status1>`.
+    GuardStatus = 0x70,
+
     /// `0x75` — Tuning: `$S75,<auto>,<value>,<drid>`.
     Tune = 0x75,
     /// `0x76` — Tune indicator feedback (read-only).
@@ -358,6 +361,11 @@ pub enum CommandId {
 
     /// `0x96` — Firmware/model query.
     Modules = 0x96,
+    /// `0x98` — Guard zone mode: `$S98,<mode>,<param>,<zoneIndex>`.
+    GuardMode = 0x98,
+    /// `0x99` — Guard zone fan parameters:
+    /// `$S99,<zoneNo>,<startAngle>,<endAngle>,<innerRange>,<outerRange>`.
+    GuardFan = 0x99,
 
     /// `0x9E` — Drift.
     Drift = 0x9E,
@@ -602,3 +610,13 @@ pub const ECHO_GAIN_LOW_POWER: u8 = 2;
 
 /// Software echo gain for full-power radars (NXT, FAR).
 pub const ECHO_GAIN_DEFAULT: u8 = 1;
+
+// =============================================================================
+// Guard zone constants
+// =============================================================================
+
+/// Guard mode value: zone disabled.
+pub const GUARD_MODE_OFF: i32 = 0;
+
+/// Guard mode value: fan (sector) zone.
+pub const GUARD_MODE_FAN: i32 = 1;

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -775,25 +775,24 @@ impl FurunoReportReceiver {
 
             CommandId::GuardStatus => {
                 // $N70,<count>,<status0>,<status1> — log on state change only
-                let alarms = [
-                    numbers.get(1).copied().unwrap_or(0.0) as i32 != 0,
-                    numbers.get(2).copied().unwrap_or(0.0) as i32 != 0,
-                ];
-                for (i, &active) in alarms.iter().enumerate() {
-                    if active != self.guard_zone_alarm[i] {
-                        self.guard_zone_alarm[i] = active;
-                        if active {
-                            log::warn!(
-                                "{}: Guard zone {} alarm ACTIVE",
-                                self.common.key,
-                                i + 1
-                            );
-                        } else {
-                            log::info!(
-                                "{}: Guard zone {} alarm cleared",
-                                self.common.key,
-                                i + 1
-                            );
+                if numbers.len() >= 3 {
+                    let alarms = [numbers[1] as i32 != 0, numbers[2] as i32 != 0];
+                    for (i, &active) in alarms.iter().enumerate() {
+                        if active != self.guard_zone_alarm[i] {
+                            self.guard_zone_alarm[i] = active;
+                            if active {
+                                log::warn!(
+                                    "{}: Guard zone {} alarm ACTIVE",
+                                    self.common.key,
+                                    i + 1
+                                );
+                            } else {
+                                log::info!(
+                                    "{}: Guard zone {} alarm cleared",
+                                    self.common.key,
+                                    i + 1
+                                );
+                            }
                         }
                     }
                 }

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -74,6 +74,7 @@ pub struct FurunoReportReceiver {
     // delta-decoded spoke after every switch.
     prev_spoke: [Vec<u8>; 2],
     prev_angle: [u16; 2],
+    guard_zone_alarm: [bool; 2],
 }
 
 impl FurunoReportReceiver {
@@ -111,6 +112,7 @@ impl FurunoReportReceiver {
             broadcast_socket: None,
             prev_spoke: [Vec::new(), Vec::new()],
             prev_angle: [0, 0],
+            guard_zone_alarm: [false, false],
         }
     }
 
@@ -771,6 +773,32 @@ impl FurunoReportReceiver {
                 }
             }
 
+            CommandId::GuardStatus => {
+                // $N70,<count>,<status0>,<status1> — log on state change only
+                let alarms = [
+                    numbers.get(1).copied().unwrap_or(0.0) as i32 != 0,
+                    numbers.get(2).copied().unwrap_or(0.0) as i32 != 0,
+                ];
+                for (i, &active) in alarms.iter().enumerate() {
+                    if active != self.guard_zone_alarm[i] {
+                        self.guard_zone_alarm[i] = active;
+                        if active {
+                            log::warn!(
+                                "{}: Guard zone {} alarm ACTIVE",
+                                self.common.key,
+                                i + 1
+                            );
+                        } else {
+                            log::info!(
+                                "{}: Guard zone {} alarm cleared",
+                                self.common.key,
+                                i + 1
+                            );
+                        }
+                    }
+                }
+            }
+
             // Silently handled (no state to update)
             CommandId::AliveCheck
             | CommandId::Heartbeat
@@ -785,7 +813,9 @@ impl FurunoReportReceiver {
             | CommandId::ATFSettings
             | CommandId::AutoAcquire
             | CommandId::TuneIndicator
-            | CommandId::DRS4WHeartbeat => {}
+            | CommandId::DRS4WHeartbeat
+            | CommandId::GuardMode
+            | CommandId::GuardFan => {}
 
             _ => {
                 log::debug!(

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -1262,8 +1262,24 @@ impl CommonRadar {
                 // Handle ARPA/target tracking and exclusion zone controls directly
                 match cv.id {
                     ControlId::GuardZone1 | ControlId::GuardZone2 => {
-                        // Guard zones are already updated above, just persist and return
                         self.update();
+                        // Send to hardware if the brand supports it (e.g. Furuno)
+                        if let Some(command_sender) = command_sender {
+                            match command_sender
+                                .set_control(&cv, &self.info.controls)
+                                .await
+                            {
+                                Ok(()) => {}
+                                Err(RadarError::CannotSetControlId(_)) => {}
+                                Err(e) => {
+                                    log::warn!(
+                                        "{}: guard zone hardware sync failed: {}",
+                                        self.key,
+                                        e
+                                    );
+                                }
+                            }
+                        }
                         return Ok(());
                     }
                     ControlId::ArpaDetectMaxSpeed => {


### PR DESCRIPTION
## Summary

- When guard zones are configured in the GUI, send fan zone parameters to the Furuno radar via `$S98` (guard mode) and `$S99` (fan zone angles/ranges)
- Parse `$N70` guard zone alarm status notifications from the radar (logged at warn level when active)
- Non-Furuno brands silently ignore the forwarded guard zone control updates

This is additive to the existing server-side blob detector — both detection paths run independently.

**DRS-NXT**: the antenna accepts and echoes back `$S98`/`$S99` but does not generate `$N70` alarms because the DRS-NXT is a sensor head without an onboard detection processor. Guard zone detection for DRS-NXT runs server-side only.

**FAR series** (FAR-2127, FAR-3000, FAR-15x3): these are self-contained radar processors with their own CPU running the full NavNet firmware stack. They likely can run hardware-side guard zone detection and generate `$N70` alarms independently. Not yet tested (no FAR unit available).

## Tested

- `cargo build` and `cargo test` pass (147 tests)
- Verified on DRS4D-NXT: `$S98,1,0,0` and `$S99,0,7646,1001,424,762` sent and confirmed via tcpdump (`$N98` and `$N99` echo-backs received)
- Range units for `$S99` need empirical verification on a FAR unit (TODO in code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Furuno guard-zone fan geometry is now sent to the radar antenna processor when zones are configured in the GUI.
  * Guard mode and fan controls are supported at hardware level, enabling on/off and fan-style protection per zone.
  * Radar reports per-zone status and emits alerts when a guard zone becomes active or clears; updates synchronize to hardware in real time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->