### PR TITLE
ci(release): auto-generate changelog with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ jobs:
       contents: write
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
     - name: Download all artifacts
       uses: actions/download-artifact@v8
       with:
@@ -76,14 +81,41 @@ jobs:
     - name: List artifacts
       run: find artifacts -type f
 
+    - name: Generate release notes
+      uses: orhun/git-cliff-action@v4
+      with:
+        config: cliff.toml
+        args: --latest --strip header --tag ${{ github.ref_name }}
+      env:
+        OUTPUT: CHANGES.md
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate full changelog
+      uses: orhun/git-cliff-action@v4
+      with:
+        config: cliff.toml
+        args: --output CHANGELOG.md --tag ${{ github.ref_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Append historical changelog
+      run: cat CHANGELOG.manual.md >> CHANGELOG.md
+
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        generate_release_notes: true
+        body_path: CHANGES.md
         files: |
           artifacts/mayara-server-x86_64-unknown-linux-musl/*.tar.gz
           artifacts/mayara-server-aarch64-unknown-linux-musl/*.tar.gz
           artifacts/mayara-server-windows/*.zip
+
+    - name: Commit changelog
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add CHANGELOG.md
+        git diff --staged --quiet || (git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}" && git push origin HEAD:main)
 
   docker:
     name: Publish Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,14 @@ jobs:
 
     - name: Commit changelog
       run: |
+        cp CHANGELOG.md /tmp/CHANGELOG.md
+        git fetch origin main
+        git switch -C main origin/main
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+        cp /tmp/CHANGELOG.md CHANGELOG.md
         git add CHANGELOG.md
-        git diff --staged --quiet || (git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}" && git push origin HEAD:main)
+        git diff --staged --quiet || (git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}" && git push origin main)
 
   docker:
     name: Publish Docker Image

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ Keep commits small and atomic - one logical change per commit. Split unrelated c
 Before opening a PR:
 
 - Branch from latest `master`
-- Run `cargo test` - all checks must pass
+- Run `cargo test` - all tests must pass
+- If `cr` (CodeRabbit CLI) is available, run `cr review --plain` and address any findings before creating the PR
 - Rebase and clean up commit history (squash intermediate commits)
 - Self-review your changes
 - **NEVER change version numbers** - maintainers will update versions when publishing releases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Use conventional format: `<type>(<scope>): <subject>` where type = feat|fix|docs
 
 Keep commits small and atomic - one logical change per commit. Split unrelated changes into separate commits. The commit history tells a story; each commit should be a meaningful, self-contained step.
 
-**MANDATORY:** Always add a one line update to CHANGELOG.md for each set of commits pertaining to a separate issue, PR or general change.
+**DO NOT** edit CHANGELOG.md — it is auto-generated from conventional commits at release time by git-cliff.
 **MANDATORY:** Never amend commits that have already been pushed to GitHub. Only amend local, unpushed commits.
 **MANDATORY:** Always rebase and clean up commit history before creating a PR or pushing changes. Amend fixes and corrections to the relevant existing commit instead of creating chains of "fix typo" or "oops" commits. The final history should contain only intentional, complete commits - no work-in-progress artifacts.
 
@@ -57,7 +57,7 @@ Before opening a PR:
 - Self-review your changes
 - **NEVER change version numbers** - maintainers will update versions when publishing releases
 
-PR titles are used to generate release notes. Make them **descriptive, informative, and easy to understand**. Ask yourself: "If someone only read the title, would they understand what this PR does?"
+PR titles are used to auto-generate the changelog and release notes. They **must** follow the same conventional commit format as commits: `<type>(<scope>): <subject>` (e.g., `feat(furuno): add guard zone support`). With squash merge, the PR title becomes the commit message on `main`, so it directly becomes the changelog entry. Make them **descriptive, informative, and easy to understand**. Ask yourself: "If someone only read the title, would they understand what this PR does?"
 
 PR descriptions must be **succinct and straight to the point**. Explain the motivation (why) and summarize the solution approach (how), but not the mechanics (what) - the diff shows what changed. Do not pad descriptions with unnecessary detail, verbose explanations, or self-congratulatory comments. If there are breaking changes, mention them explicitly. If a PR description includes a test plan with checkboxes, **all items must be checked** before the PR is ready for review - remove or complete any unchecked items.
 

--- a/CHANGELOG.manual.md
+++ b/CHANGELOG.manual.md
@@ -1,0 +1,178 @@
+
+## [3.4.1]
+
+### Added
+
+- Optional TLS support (`--tls-cert` and `--tls-key` flags) (#36, #37)
+- Furuno DRS4W model detection and full spoke support (#48)
+- ARPA target tracking documentation (`docs/arpa.md`)
+- Furuno range units support: Nautical (NM) and Metric (km) modes with per-model range tables
+- Furuno dual range support for NXT models: two independent radar instances (Range A/B) with shared TCP/UDP connections
+- Furuno per-model capability system: controls are now enabled based on the detected radar model
+- Furuno tuning control (auto/manual) for all models that support it
+- New Furuno command IDs: PulseWidth, Tune, TrailMode, RingSuppression, Heartbeat, NN3Command
+- Timed idle (watchman) controls for Furuno NXT radars: on/off toggle and transmit period
+- Navico HALO antenna offset controls (forward/starboard) — read from StateProperties (0xC406) and settable via 0xC130 tag 4
+- Navico spoke positions are now adjusted by the antenna offset (rotated by vessel heading) so ARPA targets appear at the antenna's actual ground position
+- Navico protocol constants collected in a dedicated `protocol.rs` module with named opcode/command/multicast constants
+
+### Changed
+
+- Navico beacon parsing uses dynamic device/service format for all models (BR24, 3G, 4G, HALO) — replaces the previous fixed-size struct discrimination by length
+- Navico state packet structs renamed to match the NRP protocol names (StateMode, StateSetup, StateConfig, StateFeatures, StateProperties, StateInstallation)
+- Navico antenna height now uses i32 (was u16) — matches the wire protocol and supports heights >65 m
+- Navico HALO heading/navigation/speed transmitter rewritten to match the radar_pi reference implementation: correct heading scale (0..0xF800 = 0..360°), correct SOG units (cm/s for navigation, dm/s for speed), separate timers per packet type (heading 100 ms, navigation 250 ms, speed 250 ms), 10-second listen-and-defer timeout
+- GUI uses numeric input instead of sliders for meter and degree valued controls
+- Emulator loops continuously: boat and targets reverse course when targets leave radar range, then turn back at the starting position (closes #38)
+- Web server listens on IPv6 dual-stack socket, accepting both IPv4 and IPv6 connections
+- WebSocket URLs use `wss://` scheme when TLS is enabled
+- Client examples accept `--insecure`/`-k` flag for self-signed certificates (opt-in, no longer default)
+
+### Fixed
+
+- Target tracker pegged one CPU core on noisy feeds: the blob detector now uses a single detector-wide `(spoke, pixel) -> blob id` spatial index, so adjacency and contour lookups are O(1) in both blob size and number of active blobs
+- Target tracker reported wrong size and center for blobs spanning spoke 0: `BlobInProgress` tracked spoke extents with linear min/max, so a wrap-around blob would report a center on the opposite side of the revolution and a size covering nearly the whole circle. Replaced with on-demand smallest-covering-arc computation that handles the circular spoke domain correctly (#58)
+- Furuno DRS4D-NXT: raised FURUNO_SPOKE_LEN from 883 to 1024 — the DRS4D-NXT reports sweep_len=884, so each spoke's last sample overflowed into the next angle's slot and produced a slowly rotating ring/moiré pattern on the PPI
+- Furuno DRS4D-NXT: Reduce processor calibration now counts unique angles — the radar sends each angle twice in consecutive sweeps, so the old count was roughly 2× the true unique-angle count and left every other reduced-buffer slot empty, producing tangential striping across rendered targets
+- Furuno range zoom was stuck at 1/16 NM (116m) after the closest-match `lookup_wire_index` change: the 125m km-table entry was misclassified as nautical by the metric heuristic and polluted the nautical range list, so zooming out from 116m sent 125m which then mapped back to wire index 21 (116m) — a no-op. 125m is now special-cased as metric
+- Furuno dual range: Route TCP report responses (Status, Gain, Sea, Rain, Tune) to the correct range (A or B) based on dual_range_id in the response
+- Furuno dual range: correct drid field positions for all per-range commands (Status, Gain, Sea, Rain) — verified against live Wireshark captures
+- Furuno dual range: Range response now correctly reads unit from field 1 (was field 2, which is actually drid)
+- Furuno spoke header: dual_range_id is at byte 15 bit 6 (was incorrectly at byte 11 bits 6-7, which are always 0b11)
+- Furuno dual range: Range B spoke interleaving is no longer auto-activated at init; it starts after the first explicit Range B range command sent by the client
+- Furuno tune control max increased from 100 to 2000 to accommodate raw radar values
+- Furuno DRS4W: pad short spokes to sweep_len — compressed data on compact WiFi radars can produce fewer samples than expected (#48)
+- Furuno spoke distance rendering: use the `scale` field from the UDP frame header (bytes 14-15) as the effective sample count instead of `sweep_len`. The radar always transmits `sweep_len` total samples but only the first `scale` of them cover the configured display range — using `sweep_len` caused targets to render at `scale/sweep_len` (~56%) of their true radial distance on all Furuno models (#48)
+- Furuno DRS4W/DRS echo intensity: apply 2× software gain to compensate for the lower raw echo values produced by low-power magnetron antennas (max ~124 vs NXT's ~252), so the full color palette (blue→green→yellow→red) is utilised instead of only the lower half (#48)
+- Furuno Gain/Sea/Rain control definitions now preserve runtime state (value, auto) when updated at model-detection time
+- Furuno dual range: Range B ModelName is now vendor-accurate (the " B" suffix is only in UserName)
+- Furuno spoke header: heading_valid now correctly read from byte 11 bit 5 (was reading byte 15 bits 4-5)
+- Furuno spoke header: range wire index masked to 6 bits, angle/heading masked to 13 bits
+- Furuno frequent heartbeat ($NAF) and NN3 diagnostic ($NF5) messages no longer cause log noise
+- Raymarine HD main bang suppression control was missing, causing error in logs (#35)
+- Multicast reception on multi-homed interfaces (multiple IPs on one NIC) (#51)
+- Furuno range report no longer rejects radars set to km or sm display units
+- All control values now include timestamps in state broadcasts
+- Button controls (clearTrails, clearTargets) no longer sent in state broadcasts
+- Unchanged control values no longer re-broadcast to clients
+- Blob detection no longer blocks spoke broadcasting to clients
+- Navico doppler lookup used wrong nibble for HighBoth mode
+- Spoke pixel validation checks full legend size, not just normal colors
+- Spoke pixel validation no longer panics in debug builds, logs error and clamps instead
+- GUI shows "DISCONNECTED" when server connection is lost
+- GUI standby overlay always shows ON-TIME/TX-TIME
+- GUI WebSocket reconnect no longer creates duplicate connections
+- Target controls (guard zones, exclusion zones) are writable in replay mode
+- GUI target acquire used wrong REST endpoint URL
+- Guard zones, exclusion rects, and other target controls returned 400 despite succeeding
+- NMEA HDT heading was sent in degrees instead of radians
+- NMEA VTG COG was sent in degrees instead of radians
+- Slow/stationary targets repeatedly lost and reacquired due to turn rejection using noisy measured speed instead of Kalman-estimated speed
+- Targets now require 4 updates before being promoted to tracking and displayed, reducing noise from clutter blobs
+- Large vessels no longer produce multiple duplicate tracks; young targets within 100m are merged at each revolution end
+- Lost targets deleted after 4 revolutions (was 30s); stationary targets after 10 revolutions
+- Blob detection now requires strong return (not medium) and at least 25 pixels to suppress wave/clutter arcs
+- Doppler-approaching targets tracked everywhere when doppler_auto_track is enabled, not only inside guard zones
+- clearTargets button now actually clears all targets immediately from both backend and GUI
+- doppler_auto_track setting is now persisted across restarts
+- GUI do_change no longer crashes with TypeError when a control is changed before its state is received from the server
+- GUI clears all displayed targets when radar connection is lost
+- GUI showed DISCONNECTED in Firefox after server restart due to unnecessary state reset when spoke stream reconnect triggered a redundant state stream reconnect
+- Heading extracted from spoke data for GUI when no external heading source available
+- Furuno spoke data sockets retry on failure instead of silently staying dead
+- Recording file upload from the GUI (add missing `POST /recordings/files/upload` route)
+- Accept 0xc2 as valid Navico spoke status for HALO20+ compatibility (#27)
+- Move inline `display: none` style to CSS for WebGPU warning element
+- `NoSuchRadar` returns 404 (was 500), response includes list of valid radar IDs
+- `InvalidControlId` returns 404 (was 400/500)
+- Unmatched `/signalk/` paths return 404 with list of all valid API endpoints (generated from OpenAPI spec)
+- Empty spoke messages no longer broadcast to WebSocket clients
+- Spoke WebSocket stream no longer disconnects on broadcast lag (#31)
+
+### Removed
+
+- Duplicate protobuf.js library copies in `web/imports/` and `web/protobuf/` (only `web/gui/protobuf/` is used)
+
+## [3.4.0]
+
+### Changed
+
+- **API version bumped to 3.2.0** (Signal K Radar API)
+- `GET /signalk/v2/api/vessels/self/radars` returns bare radar map (removed `version`/`radars` wrapper)
+- All REST endpoints now return unwrapped responses — no wrapper on any endpoint
+- OpenAPI schema: `allowed`, `error`, and `timestamp` fields on ControlValue marked `readOnly`
+- OpenAPI schema: renamed `RadarApiV3` to `RadarInfo`, `ArpaTargetApi` to `ArpaTarget`
+
+### Removed
+
+- `RadarsResponse`, `FullSignalKResponse`, and `wrap_response()` — no longer needed
+
+## [3.3.0]
+
+### Added
+
+- `timestamp` field on control values, set whenever a value changes
+- `hasSparseSpokes` capability field
+- `GET /quit` endpoint for clean server shutdown
+- `GET /signalk` endpoint for Signal K service discovery
+- `SIGNALK_RADAR_API_VERSION` constant in `Cargo.toml [package.metadata]`, used at compile time
+- Docker support: Dockerfile, Dockerfile.ci, docker-compose.yml, GitHub Actions workflow for multi-arch builds (#28)
+- Integration test suite: 18 REST API tests and 10 WebSocket stream tests
+- `tests/run-integration.sh` to start emulator, run all tests, and stop server
+- `make test` now runs full integration tests against the emulator
+- Client examples: Python, JavaScript, and Bash (`client-examples/`)
+- `CLIENT.md` documenting the client examples
+- Server logs PID on startup for test harness
+- OpenAPI spec version patched at runtime from `SIGNALK_RADAR_API_VERSION`
+- Network IPv4 requirements documented in USAGE.md
+
+### Changed
+
+- **API version bumped to 3.1.0** (Signal K Radar API)
+- `GET /` redirects to `/gui/` instead of content-negotiating HTML vs JSON
+- `GET /signalk` serves the endpoints JSON (moved from `/`)
+- Unwrapped REST responses for consistency:
+  - `GET .../interfaces` returns bare `InterfaceApi` instead of `{ version, radars: { interfaces: ... } }`
+  - `GET .../{id}/capabilities` returns bare `Capabilities` instead of `{ version, radars: { id: { capabilities: ... } } }`
+  - `GET .../{id}/controls` returns bare controls map instead of `{ version, radars: { id: { controls: ... } } }`
+  - `GET .../{id}/controls/{control_id}` returns bare `ControlValue` (unchanged, was already unwrapped)
+  - `GET .../{id}/targets` returns bare array instead of `{ timestamp, targets: [...] }`
+- Only `GET /signalk/v2/api/vessels/self/radars` retains the `{ version, radars }` wrapper
+- Renamed `lastChanged` to `timestamp` on control values
+- GUI `api.js` and `mayara.js` updated for unwrapped responses
+- Updated link to releases page in USAGE.md (#25)
+
+### Removed
+
+- Dead code cleanup
+
+### Fixed
+
+- Emulator `/interfaces` endpoint returns empty JSON instead of error text
+
+## [3.2.0]
+
+### Fixed
+
+- Fix recursive call of error handler (#23)
+
+### Added
+
+- Garmin support for old Garmin radars (HD, xHD) (#21)
+
+## [3.1.0]
+
+First semver version. From here on all additions and fixes will be
+logged as GitHub issues.
+
+### Added
+
+- Target tracking
+
+## Versions
+
+[3.4.1]: https://github.com/MarineYachtRadar/mayara-server/compare/v3.4.0...v3.4.1
+[3.4.0]: https://github.com/MarineYachtRadar/mayara-server/compare/v3.3.0...v3.4.0
+[3.3.0]: https://github.com/MarineYachtRadar/mayara-server/compare/v3.2.0...v3.3.0
+[3.2.0]: https://github.com/MarineYachtRadar/mayara-server/compare/v3.1.0...v3.2.0
+[3.1.0]: https://github.com/MarineYachtRadar/mayara-server/compare/v3.0.0...v3.1.0

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #   make demo     - Rebuild the docker demo image
 #   make clean    - Clean build artifacts
 
-.PHONY: all release debug dev docs run run-dev clean test docker demo
+.PHONY: all release debug dev docs run run-dev clean test docker demo changelog
 
 # Default: build release with embedded docs
 all: release
@@ -95,6 +95,11 @@ docker:
 # Docker demo
 demo:
 	./demo/build.sh
+
+# Generate changelog (requires git-cliff: cargo install git-cliff)
+changelog:
+	git-cliff --output CHANGELOG.md
+	cat CHANGELOG.manual.md >> CHANGELOG.md
 
 # Clean build artifacts
 clean:

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,83 @@
+# git-cliff configuration
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/MarineYachtRadar/mayara-server
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}\
+{% if commit.remote.pr_number %} ([PR #{{ commit.remote.pr_number }}](https://github.com/MarineYachtRadar/mayara-server/pull/{{ commit.remote.pr_number }})){% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{%- macro remote_url() -%}
+  https://github.com/MarineYachtRadar/mayara-server
+{%- endmacro -%}
+
+{% for release in releases -%}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: {{ self::remote_url() }}/compare/{{ release.previous.version }}...{{ release.version }}
+        {% else -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: {{ self::remote_url() }}/compare/v3.4.0...{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        {% if release.previous.version -%}
+            [Unreleased]: {{ self::remote_url() }}/compare/{{ release.previous.version }}...HEAD
+        {% else -%}
+            [Unreleased]: {{ self::remote_url() }}/compare/v3.4.0...HEAD
+        {% endif -%}
+    {% endif -%}
+{% endfor %}
+"""
+trim = true
+
+[remote.github]
+owner = "MarineYachtRadar"
+repo = "mayara-server"
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^docs: update CHANGELOG", skip = true },
+    { message = "address.*CR.*findings", skip = true },
+    { message = "address.*CodeRabbit", skip = true },
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^perf", group = "Changed" },
+    { message = "^docs", group = "Changed" },
+    { message = "^style", skip = true },
+    { message = "^test", skip = true },
+    { message = "^chore", skip = true },
+    { message = "^ci", skip = true },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = "v(0\\.|3\\.[0-3]\\.|3\\.4\\.0)"
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,13 +38,13 @@ footer = """
         {% if release.previous.version -%}
             [{{ release.version | trim_start_matches(pat="v") }}]: {{ self::remote_url() }}/compare/{{ release.previous.version }}...{{ release.version }}
         {% else -%}
-            [{{ release.version | trim_start_matches(pat="v") }}]: {{ self::remote_url() }}/compare/v3.4.0...{{ release.version }}
+            [{{ release.version | trim_start_matches(pat="v") }}]: {{ self::remote_url() }}/compare/v3.4.1...{{ release.version }}
         {% endif -%}
     {% else -%}
         {% if release.previous.version -%}
             [Unreleased]: {{ self::remote_url() }}/compare/{{ release.previous.version }}...HEAD
         {% else -%}
-            [Unreleased]: {{ self::remote_url() }}/compare/v3.4.0...HEAD
+            [Unreleased]: {{ self::remote_url() }}/compare/v3.4.1...HEAD
         {% endif -%}
     {% endif -%}
 {% endfor %}
@@ -77,7 +77,7 @@ commit_parsers = [
 ]
 filter_commits = false
 tag_pattern = "v[0-9].*"
-skip_tags = "v(0\\.|3\\.[0-3]\\.|3\\.4\\.0)"
+skip_tags = "v(0\\.|3\\.[0-3]\\.|3\\.4\\.[0-1])"
 ignore_tags = ""
 topo_order = false
 sort_commits = "oldest"


### PR DESCRIPTION
## Summary

- Replace manual CHANGELOG.md maintenance with git-cliff, which auto-generates the changelog from conventional commits at release time
- Each changelog entry links back to its PR via GitHub API integration
- Hand-curated history (v3.1.0-v3.4.1) preserved in CHANGELOG.manual.md and appended during generation
- PR titles must now follow conventional commit format since squash merge makes them the commit message on main
- Added `make changelog` target for local preview

## Setup required after merge

- Enable branch protection on `main`: require PRs, require status checks
- Set merge strategy to squash merge only
- Add `github-actions[bot]` to the branch protection bypass list (for the changelog commit)

## Tested

- Installed git-cliff locally and verified output against existing CHANGELOG.md
- Confirmed PR links render correctly via GitHub API (e.g. `[PR #33]`, `[PR #71]`)
- Verified historical entries from CHANGELOG.manual.md append correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated per-release changelog and release-note generation using a full-repo history; release body sourced from generated notes and pushed to releases.
  * CI can append maintained manual release history and commit updated consolidated changelog back to main when changed.
* **Documentation**
  * Contribution guidance clarified: changelog is auto-generated and should not be edited; PR titles must follow conventional commit format.
  * Added a maintained release-history document with past release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->