### PR TITLE
fix(ci): use PR for changelog commit to respect branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,12 +123,12 @@ jobs:
         cp /tmp/CHANGELOG.md CHANGELOG.md
         git add CHANGELOG.md
         if ! git diff --staged --quiet; then
-          BRANCH="docs-changelog-${{ github.ref_name }}"
+          BRANCH="docs-changelog-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}"
           git switch -C "$BRANCH"
           git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}"
-          git push origin "$BRANCH"
-          gh pr create --title "docs: update CHANGELOG.md for ${{ github.ref_name }}" --body "Auto-generated changelog update." --base main --head "$BRANCH"
-          gh pr merge "$BRANCH" --squash --delete-branch
+          git push --set-upstream origin "$BRANCH"
+          PR_URL="$(gh pr create --title "docs: update CHANGELOG.md for ${{ github.ref_name }}" --body "Auto-generated changelog update." --base main --head "$BRANCH")"
+          gh pr merge "$PR_URL" --squash --delete-branch --auto
         fi
 
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
     - name: Checkout
@@ -111,6 +112,8 @@ jobs:
           artifacts/mayara-server-windows/*.zip
 
     - name: Commit changelog
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cp CHANGELOG.md /tmp/CHANGELOG.md
         git fetch origin main
@@ -119,7 +122,14 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         cp /tmp/CHANGELOG.md CHANGELOG.md
         git add CHANGELOG.md
-        git diff --staged --quiet || (git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}" && git push origin main)
+        if ! git diff --staged --quiet; then
+          BRANCH="docs-changelog-${{ github.ref_name }}"
+          git switch -C "$BRANCH"
+          git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}"
+          git push origin "$BRANCH"
+          gh pr create --title "docs: update CHANGELOG.md for ${{ github.ref_name }}" --body "Auto-generated changelog update." --base main --head "$BRANCH"
+          gh pr merge "$BRANCH" --squash --delete-branch
+        fi
 
   docker:
     name: Publish Docker Image


### PR DESCRIPTION
## Summary

- The release workflow's changelog commit step used direct push to main, which is blocked by the new branch ruleset
- Changed to create a lightweight PR instead: push to temporary branch, create PR, squash-merge immediately, delete branch
- Added `pull-requests: write` permission to the release job

## Tested

- Verified release.yml syntax is valid
- CR review --plain: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow permissions expanded to allow changelog automation.
  * Changelog updates now trigger a conditional flow: if changes exist, a branch is created, a pull request is opened and merged (squash) automatically; if no changes, no action is taken.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->