### PR TITLE
feat(furuno): add STC curve controls for sea clutter suppression

### DIFF
--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -208,6 +208,16 @@ impl Command {
         self.send(CommandMode::Request, CommandId::BlindSector, &[])
             .await?; // $R77
 
+        // STC (Sensitivity Time Control) curves
+        if self.controls.contains_key(&ControlId::NearStcCurve) {
+            self.send(CommandMode::Request, CommandId::NearSTC, &[])
+                .await?; // $R85
+            self.send(CommandMode::Request, CommandId::MiddleSTC, &[])
+                .await?; // $R86
+            self.send(CommandMode::Request, CommandId::FarSTC, &[])
+                .await?; // $R87
+        }
+
         if self.controls.contains_key(&ControlId::BirdMode) {
             // NXT-specific features (query signal processing features)
             self.send(CommandMode::Request, CommandId::SignalProcessing, &[0, 3])
@@ -488,6 +498,27 @@ impl CommandSender for Command {
                 cmd.push(mode);
                 cmd.push(0); // screen: 0=Primary
                 CommandId::TargetAnalyzer
+            }
+
+            ControlId::NearStcCurve => {
+                cmd.push(value);
+                cmd.push(self.dual_range_id);
+                CommandId::NearSTC
+            }
+            ControlId::MiddleStcCurve => {
+                cmd.push(value);
+                cmd.push(self.dual_range_id);
+                CommandId::MiddleSTC
+            }
+            ControlId::FarStcCurve => {
+                cmd.push(value);
+                cmd.push(self.dual_range_id);
+                CommandId::FarSTC
+            }
+            ControlId::StcRange => {
+                cmd.push(value);
+                cmd.push(self.dual_range_id);
+                CommandId::STCRange
             }
 
             ControlId::GuardZone1 | ControlId::GuardZone2 => {

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -798,32 +798,22 @@ impl FurunoReportReceiver {
                 }
             }
 
-            CommandId::NearSTC => {
+            CommandId::NearSTC | CommandId::MiddleSTC | CommandId::FarSTC | CommandId::STCRange => {
                 if let Some(&value) = numbers.first() {
-                    let drid = self.extract_drid(&command_id, &numbers);
-                    self.common_for_range(drid)
-                        .set_value(&ControlId::NearStcCurve, value);
-                }
-            }
-            CommandId::MiddleSTC => {
-                if let Some(&value) = numbers.first() {
-                    let drid = self.extract_drid(&command_id, &numbers);
-                    self.common_for_range(drid)
-                        .set_value(&ControlId::MiddleStcCurve, value);
-                }
-            }
-            CommandId::FarSTC => {
-                if let Some(&value) = numbers.first() {
-                    let drid = self.extract_drid(&command_id, &numbers);
-                    self.common_for_range(drid)
-                        .set_value(&ControlId::FarStcCurve, value);
-                }
-            }
-            CommandId::STCRange => {
-                if let Some(&value) = numbers.first() {
-                    let drid = self.extract_drid(&command_id, &numbers);
-                    self.common_for_range(drid)
-                        .set_value(&ControlId::StcRange, value);
+                    // Single-field responses ($N85,2) have no drid — default to range A.
+                    // Multi-field responses include drid as the last field.
+                    let drid = if numbers.len() > 1 {
+                        self.extract_drid(&command_id, &numbers)
+                    } else {
+                        0
+                    };
+                    let control_id = match command_id {
+                        CommandId::NearSTC => ControlId::NearStcCurve,
+                        CommandId::MiddleSTC => ControlId::MiddleStcCurve,
+                        CommandId::FarSTC => ControlId::FarStcCurve,
+                        _ => ControlId::StcRange,
+                    };
+                    self.common_for_range(drid).set_value(&control_id, value);
                 }
             }
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -798,6 +798,35 @@ impl FurunoReportReceiver {
                 }
             }
 
+            CommandId::NearSTC => {
+                if let Some(&value) = numbers.first() {
+                    let drid = self.extract_drid(&command_id, &numbers);
+                    self.common_for_range(drid)
+                        .set_value(&ControlId::NearStcCurve, value);
+                }
+            }
+            CommandId::MiddleSTC => {
+                if let Some(&value) = numbers.first() {
+                    let drid = self.extract_drid(&command_id, &numbers);
+                    self.common_for_range(drid)
+                        .set_value(&ControlId::MiddleStcCurve, value);
+                }
+            }
+            CommandId::FarSTC => {
+                if let Some(&value) = numbers.first() {
+                    let drid = self.extract_drid(&command_id, &numbers);
+                    self.common_for_range(drid)
+                        .set_value(&ControlId::FarStcCurve, value);
+                }
+            }
+            CommandId::STCRange => {
+                if let Some(&value) = numbers.first() {
+                    let drid = self.extract_drid(&command_id, &numbers);
+                    self.common_for_range(drid)
+                        .set_value(&ControlId::StcRange, value);
+                }
+            }
+
             // Silently handled (no state to update)
             CommandId::AliveCheck
             | CommandId::Heartbeat

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -272,6 +272,16 @@ pub fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, version:
         info.controls.add(new_string(ControlId::PulseWidth));
     }
 
+    // STC (Sensitivity Time Control) — all models support this
+    info.controls
+        .add(new_list(ControlId::NearStcCurve, &["0", "1", "2", "3", "4"]));
+    info.controls
+        .add(new_list(ControlId::MiddleStcCurve, &["0", "1", "2", "3"]));
+    info.controls
+        .add(new_list(ControlId::FarStcCurve, &["0", "1", "2"]));
+    // StcRange ($RD2) is not registered: DRS4D-NXT does not respond to $RD2.
+    // Re-enable when a model that supports it is available for testing.
+
     // Tuning
     if cap.tune {
         info.controls.add(new_auto(

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -168,6 +168,10 @@ pub enum ControlId {
     ParkPosition,
     TransmitChannel,
     PulseWidth,
+    NearStcCurve,
+    MiddleStcCurve,
+    FarStcCurve,
+    StcRange,
 }
 
 impl Display for ControlId {
@@ -273,7 +277,11 @@ impl ControlId {
             | ControlId::SpokeProcessing
             | ControlId::DopplerSpeedThreshold
             | ControlId::TimedIdle
-            | ControlId::TimedRun => Category::Advanced,
+            | ControlId::TimedRun
+            | ControlId::NearStcCurve
+            | ControlId::MiddleStcCurve
+            | ControlId::FarStcCurve
+            | ControlId::StcRange => Category::Advanced,
         }
     }
 
@@ -366,6 +374,10 @@ impl ControlId {
             ControlId::ScanAverageSensitivity => "Threshold for scan averaging filter",
             ControlId::ParkPosition => "Antenna park position when entering standby",
             ControlId::TransmitChannel => "Transmit frequency channel selection (auto or manual)",
+            ControlId::NearStcCurve => "Near-range STC suppression curve",
+            ControlId::MiddleStcCurve => "Middle-range STC suppression curve",
+            ControlId::FarStcCurve => "Far-range STC suppression curve",
+            ControlId::StcRange => "Distance boundary between STC range bands",
         }
     }
 
@@ -454,6 +466,10 @@ impl ControlId {
             ControlId::ScanAverageSensitivity => "Scan average sensitivity",
             ControlId::ParkPosition => "Park position",
             ControlId::TransmitChannel => "Transmit channel",
+            ControlId::NearStcCurve => "Near STC curve",
+            ControlId::MiddleStcCurve => "Middle STC curve",
+            ControlId::FarStcCurve => "Far STC curve",
+            ControlId::StcRange => "STC range",
         }
     }
 
@@ -534,6 +550,10 @@ impl ControlId {
             ControlId::ScanAverageSensitivity => ControlDestination::Command,
             ControlId::ParkPosition => ControlDestination::Command,
             ControlId::TransmitChannel => ControlDestination::Command,
+            ControlId::NearStcCurve => ControlDestination::Command,
+            ControlId::MiddleStcCurve => ControlDestination::Command,
+            ControlId::FarStcCurve => ControlDestination::Command,
+            ControlId::StcRange => ControlDestination::Command,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Expose NearSTC (0-4), MiddleSTC (0-3), and FarSTC (0-2) as settable list controls for range-dependent sea clutter suppression
- Query current STC values on init ($R85, $R86, $R87) and parse $N85/$N86/$N87 responses with dual-range routing
- All Furuno models support STC — no capability gating needed

StcRange ($RD2) ControlId is defined in the enum and has command/report handlers, but is **not registered** for any model: DRS4D-NXT does not respond to $RD2. Will be enabled when a supporting model is available for testing.

## Tested

- cargo build and cargo test pass (147 tests)
- Verified on DRS4D-NXT via tcpdump: $R85→$N85,2, $R86→$N86,1, $R87→$N87,1 confirmed
- $RD2 sent but no response from DRS4D-NXT — StcRange registration removed to avoid showing stale default
- STC values accepted when set via GUI and echoed back by radar

## Image new Controls
<img width="235" height="240" alt="image" src="https://github.com/user-attachments/assets/b6432763-dd1d-4b30-8537-04fd84156b76" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added STC (Sensitivity Time Control) curve configuration for Furuno radar devices: near, middle, and far curves are now configurable with selectable options.
  * Added STC range control for enhanced sensitivity tuning on compatible devices.
  * Devices will now query and report STC settings so UI and hardware stay synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->