### PR TITLE
ci: auto-update changelog on merge to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,48 @@
+name: Update Changelog
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    # Skip if the merge came from a changelog PR or is a changelog commit
+    if: "!startsWith(github.event.head_commit.message, 'docs: update CHANGELOG.md')"
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Generate changelog
+      uses: orhun/git-cliff-action@v4
+      with:
+        config: cliff.toml
+        args: --output CHANGELOG.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Append historical changelog
+      run: cat CHANGELOG.manual.md >> CHANGELOG.md
+
+    - name: Create changelog PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add CHANGELOG.md
+        if ! git diff --staged --quiet; then
+          BRANCH="docs-changelog-main-${{ github.run_id }}-${{ github.run_attempt }}"
+          git switch -C "$BRANCH"
+          git commit -m "docs: update CHANGELOG.md"
+          git push --set-upstream origin "$BRANCH"
+          PR_URL="$(gh pr create --title "docs: update CHANGELOG.md" --body "Auto-generated changelog update after merge to main." --base main --head "$BRANCH")"
+          gh pr merge "$PR_URL" --squash --delete-branch --auto
+        fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Append historical changelog
-      run: cat CHANGELOG.manual.md >> CHANGELOG.md
+      run: |
+        printf '\n' >> CHANGELOG.md
+        cat CHANGELOG.manual.md >> CHANGELOG.md
 
     - name: Create changelog PR
       env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: changelog-main
+  cancel-in-progress: true
+
 jobs:
   changelog:
     name: Update Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Append historical changelog
-      run: cat CHANGELOG.manual.md >> CHANGELOG.md
+      run: |
+        printf '\n' >> CHANGELOG.md
+        cat CHANGELOG.manual.md >> CHANGELOG.md
 
     - name: Create Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- New workflow that regenerates CHANGELOG.md after every merge to main
- Keeps the [Unreleased] section up to date between releases
- Skips changelog commits (message starts with "docs: update CHANGELOG.md") to avoid infinite loops
- Uses the same PR-based approach as the release workflow (unique branch, auto-merge)

## Tested

- CR review --plain: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to generate, open, and merge updates to the changelog so release notes are kept up to date.
  * Improved release scripting to ensure manual changelog entries are appended with correct spacing for consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->