### PR TITLE
fix(ci): fall back to immediate merge when auto-merge not needed

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -50,5 +50,5 @@ jobs:
           git commit -m "docs: update CHANGELOG.md"
           git push --set-upstream origin "$BRANCH"
           PR_URL="$(gh pr create --title "docs: update CHANGELOG.md" --body "Auto-generated changelog update after merge to main." --base main --head "$BRANCH")"
-          gh pr merge "$PR_URL" --squash --delete-branch --auto
+          gh pr merge "$PR_URL" --squash --delete-branch --auto || gh pr merge "$PR_URL" --squash --delete-branch
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}"
           git push --set-upstream origin "$BRANCH"
           PR_URL="$(gh pr create --title "docs: update CHANGELOG.md for ${{ github.ref_name }}" --body "Auto-generated changelog update." --base main --head "$BRANCH")"
-          gh pr merge "$PR_URL" --squash --delete-branch --auto
+          gh pr merge "$PR_URL" --squash --delete-branch --auto || gh pr merge "$PR_URL" --squash --delete-branch
         fi
 
   docker:


### PR DESCRIPTION
## Summary

- The changelog PR auto-merge fails with "Pull request is in clean status" when no required status checks exist
- Try `--auto` first (future-proof for when checks are added), fall back to immediate `--squash` merge
- Applies to both changelog.yml and release.yml

## Tested

- Root cause confirmed from failed run logs (attempt 2 of run 24261055785)