### PR TITLE
ci: add cargo caching to speed up Windows builds (fixes #53)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - uses: swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.target }}
+
     - name: Install Cross
       run: cargo install cross
 
@@ -47,6 +51,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+
+    - uses: swatinem/rust-cache@v2
 
     - name: Build
       run: cargo build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,10 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - uses: swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.target }}
+
     - name: Install Cross
       run: cargo install cross
 
@@ -40,6 +44,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: swatinem/rust-cache@v2
     - name: Build
       run: cargo build --release
     - name: Run tests


### PR DESCRIPTION
## Summary

- Add `swatinem/rust-cache@v2` to all build jobs in rust.yml and release.yml
- Caches cargo registry, git checkouts, and compiled target directory between runs
- Windows builds currently take ~17 min vs ~5 min for Linux (3.2x slower)
- Expected to drop to ~7-8 min on cache hits (~50-60% reduction)
- First run after merge populates the cache, subsequent runs benefit

Fixes #53

## Tested

- CR review --plain: no findings
- Timings measured from run 24261244755: Linux 310s, Windows 1006s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Rust build caching in continuous integration workflows for Linux and Windows environments to improve build performance and reduce compilation time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->