### PR TITLE
fix(emulator): propagate RangeUnits set_value errors

### DIFF
--- a/src/lib/brand/emulator/command.rs
+++ b/src/lib/brand/emulator/command.rs
@@ -33,7 +33,9 @@ impl CommandSender for Command {
         // SharedControls since no emulator state loop echoes it back.
         if cv.id == ControlId::RangeUnits {
             if let Some(v) = cv.value.as_ref().and_then(|v| v.as_f64()) {
-                let _ = controls.set_value(&ControlId::RangeUnits, v.into());
+                controls
+                    .set_value(&ControlId::RangeUnits, v.into())
+                    .map_err(RadarError::ControlError)?;
             }
         }
         // Emulator just acknowledges the command - actual state is managed in report.rs


### PR DESCRIPTION
Closes #62

Propagate set_value() errors through RadarError instead of swallowing them with `let _ =`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for control value persistence. Errors that previously went unreported are now properly propagated, ensuring the system correctly identifies and communicates failures when setting certain control parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->