### PR TITLE
docs(furuno): add FAR radar setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ The following radars are fully supported right now:
 
 * Navico: all digital models e.g. BR24, 3G, 4G, HALO20, HALO24, HALO3/4/6, HALO3000+. 
 * Raymarine Quantum 2 (Q24C, Q24D).
+* Furuno DRS-NXT series (DRS4D-NXT, DRS6A-NXT, DRS12A-NXT, DRS25A-NXT) including dual range.
+* Furuno DRS4W WiFi radar ("1st Watch").
+* Furuno FAR-2xx7 series (see [FAR setup guide](docs/furuno-far-setup.md) for network and IMO mode requirements).
 
 We are working on:
 
-* Furuno, many models, but certainly and primarily DRS4D-NXT. Seems to work but needs extensive testing.
+* Furuno DRS, DRS4DL, DRS6A X-Class, FAR-15x3, FAR-3000 — implemented but need testing with real hardware.
 * Garmin HD, xHD, xHD2, xHD3, Fantom, and Fantom Pro. All models are supported including dual range, MotionScope/Doppler, and per-model feature detection. Needs testing with real hardware — PCAP files welcome!
 * Raymarine HD digital radars are likewise implemented but fully untested.
 

--- a/docs/furuno-far-setup.md
+++ b/docs/furuno-far-setup.md
@@ -1,0 +1,74 @@
+# Furuno FAR Radar Setup
+
+This guide covers connecting mayara to Furuno FAR-series commercial radars
+(FAR-2xx7, FAR-15x3, FAR-3000).
+
+## Network Requirements
+
+Furuno radars use the `172.31.0.0/16` subnet for all communication. The
+machine running mayara **must** have an IP address on this subnet.
+
+Recommended configuration:
+- IP address: `172.31.3.150` (or any unused address in `172.31.x.x`)
+- Subnet mask: `255.255.0.0`
+- No default gateway required (local subnet only)
+
+The radar broadcasts discovery beacons on `172.31.255.255:10010` and echo
+data on `172.31.255.255:10024` (or multicast `239.255.0.2:10024`). If the
+mayara machine is not on the `172.31.0.0/16` subnet, it will not receive
+these broadcasts and the radar will not be detected.
+
+## FAR-2xx7 IMO Mode Configuration
+
+The FAR-2xx7 must be set to **IMO Mode B, C, or W** for network
+connectivity with external software. Mode W is recommended.
+
+If the radar is in Mode A (standalone), it will not respond to network
+commands and will not be detected by mayara.
+
+To change the IMO mode on the FAR-2xx7:
+1. Hold the **HL OFF** button
+2. While holding HL OFF, press **MENU** 5 times
+3. Navigate to **Installation** → **Type**
+4. Select **W** (recommended), **B**, or **C**
+5. Restart the radar for the change to take effect
+
+## Model Detection
+
+Mayara identifies the radar model from the 7-digit part code in the `$N96`
+Modules response. Known FAR part codes:
+
+| Part Code | Model |
+|-----------|-------|
+| 0359204 | FAR-21x7 |
+| 0359560 | FAR-21x7 |
+| 0359321 | FAR-14x7 |
+| 0359397 | FAR-14x6 |
+| 0359344 | FAR-15x3 |
+| 0359281 | FAR-3000 |
+| 0359286 | FAR-3000 |
+| 0359477 | FAR-3000 |
+
+If your radar reports an unrecognized part code, mayara will still detect
+and operate the radar with default capabilities. Please report the part
+code and model name so it can be added to the lookup table.
+
+## Troubleshooting
+
+**Radar not detected:**
+1. Verify the mayara machine has a `172.31.x.x` IP address
+2. Check that the Ethernet cable is connected to the radar's network port
+3. For FAR-2xx7: verify IMO mode is set to W (not A)
+4. Check firewall rules — UDP ports 10010 and 10024 must be open
+5. Run `tcpdump -i <interface> udp port 10010` to verify beacon packets
+   are arriving
+
+**Radar detected but shows "Unknown" model:**
+The part code is not in the lookup table. The radar will work with default
+capabilities. Report the part code (from the log output) so it can be
+added.
+
+**No echo data:**
+Verify UDP port 10024 is not blocked. FAR radars use multicast
+`239.255.0.2:10024` — the network interface must support multicast and
+the OS must allow multicast group joins.

--- a/docs/furuno-far-setup.md
+++ b/docs/furuno-far-setup.md
@@ -13,10 +13,11 @@ Recommended configuration:
 - Subnet mask: `255.255.0.0`
 - No default gateway required (local subnet only)
 
-The radar broadcasts discovery beacons on `172.31.255.255:10010` and echo
-data on `172.31.255.255:10024` (or multicast `239.255.0.2:10024`). If the
-mayara machine is not on the `172.31.0.0/16` subnet, it will not receive
-these broadcasts and the radar will not be detected.
+The radar broadcasts discovery beacons on `172.31.255.255:10010` and streams
+echo data via multicast on `239.255.0.2:10024`. Login and control commands
+use TCP on port 10010. If the mayara machine is not on the `172.31.0.0/16`
+subnet, it will not receive beacon broadcasts and the radar will not be
+detected.
 
 ## FAR-2xx7 IMO Mode Configuration
 
@@ -59,7 +60,7 @@ code and model name so it can be added to the lookup table.
 1. Verify the mayara machine has a `172.31.x.x` IP address
 2. Check that the Ethernet cable is connected to the radar's network port
 3. For FAR-2xx7: verify IMO mode is set to W (not A)
-4. Check firewall rules — UDP ports 10010 and 10024 must be open
+4. Check firewall rules — UDP 10010/10024 and TCP 10010 must be open
 5. Run `tcpdump -i <interface> udp port 10010` to verify beacon packets
    are arriving
 

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -238,6 +238,7 @@ impl RadarModel {
             "0359355" => RadarModel::DRS6AXCLASS,
             "0359344" => RadarModel::FAR15x3,
             "0359397" => RadarModel::FAR14x6,
+            "0359560" => RadarModel::FAR21x7,
             _ => RadarModel::Unknown,
         }
     }


### PR DESCRIPTION
Network requirements (172.31.x.x subnet), FAR-2xx7 IMO mode configuration, known part codes, and troubleshooting steps for users connecting FAR-series commercial radars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition/support for an additional FAR-2xx7 radar variant so it is correctly identified.
  * Updated README to list newly supported Furuno families (DRS-NXT, DRS4W “1st Watch”, FAR-2xx7) and broadened the implemented-models list.

* **Documentation**
  * Added a comprehensive Furuno FAR-series setup/troubleshooting guide covering network/subnet and static IP recommendations, IMO mode steps, discovery/control/echo endpoints and ports, model-detection behavior, and troubleshooting checks for detection, echo data, firewall, and multicast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->