### PR TITLE
fix(stream): dedupe per-client radar metadata tracking

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -11,7 +11,11 @@ use http::StatusCode;
 use hyper;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, net::Ipv4Addr, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    net::Ipv4Addr,
+    str::FromStr,
+};
 use strum::EnumCount;
 use tokio::sync::{
     broadcast::{self},
@@ -1180,7 +1184,7 @@ async fn ws_signalk_delta(
 ) -> Result<(), RadarError> {
     let mut broadcast_control_rx = radars.new_sk_client_subscription();
     let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel::<ControlValue>(ControlId::COUNT);
-    let mut meta_radar_data_sent = Vec::new();
+    let mut meta_radar_data_sent: HashSet<String> = HashSet::new();
 
     log::debug!(
         "Starting /signalk/v1/stream websocket subscribe={:?} send_cached_values={:?}",

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::min,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     str::FromStr,
     time::{Duration, SystemTime},
 };
@@ -44,7 +44,7 @@ impl SignalKDelta {
     //
     // Used when starting a websocket, we always check radars for unsent
     //
-    pub fn add_meta_updates(&mut self, radars: &SharedRadars, meta_sent: &mut Vec<String>) {
+    pub fn add_meta_updates(&mut self, radars: &SharedRadars, meta_sent: &mut HashSet<String>) {
         if let Some(updates) = get_meta_delta(radars, meta_sent) {
             self.updates.push(updates);
         }
@@ -53,7 +53,11 @@ impl SignalKDelta {
     //
     // Every time we send a SignalKDelta, we check for unsent meta data
     //
-    pub fn add_meta_from_updates(&mut self, radars: &SharedRadars, meta_sent: &mut Vec<String>) {
+    pub fn add_meta_from_updates(
+        &mut self,
+        radars: &SharedRadars,
+        meta_sent: &mut HashSet<String>,
+    ) {
         let mut needs_meta = false;
         for update in &self.updates {
             for dv in &update.values {
@@ -64,7 +68,7 @@ impl SignalKDelta {
                     continue;
                 }
                 if let Some(radar_id) = path.split('.').nth(1) {
-                    if !meta_sent.iter().any(|x| x == radar_id) {
+                    if !meta_sent.contains(radar_id) {
                         // Found a radar whose meta hasn't been sent yet
                         needs_meta = true;
                         break;
@@ -269,11 +273,17 @@ pub struct DeltaMeta {
     value: ControlDefinition,
 }
 
-fn get_meta_delta(radars: &SharedRadars, meta_sent: &mut Vec<String>) -> Option<DeltaUpdate> {
+fn get_meta_delta(
+    radars: &SharedRadars,
+    meta_sent: &mut HashSet<String>,
+) -> Option<DeltaUpdate> {
     let mut meta = Vec::new();
 
     for radar in radars.get_active() {
         let radar_id = radar.key();
+        if !meta_sent.insert(radar_id.clone()) {
+            continue;
+        }
         let controls = radar.controls.get_controls();
 
         for (k, v) in controls.iter() {
@@ -281,7 +291,6 @@ fn get_meta_delta(radars: &SharedRadars, meta_sent: &mut Vec<String>) -> Option<
             let value = v.item().clone();
             meta.push(DeltaMeta { path, value });
         }
-        meta_sent.push(radar_id);
     }
 
     if meta.len() == 0 {


### PR DESCRIPTION
## Motivation

Long-lived Signal K WebSocket connections leak memory proportional to the number of radar (re)connection events over the session's lifetime. On a vessel with intermittent radar connectivity (Wi-Fi dropouts, power-cycled radars, mDNS flap) the per-connection \`meta_radar_data_sent\` buffer grows steadily over a voyage, and the per-delta linear scan over it adds creeping CPU overhead.

## Root cause

\`get_meta_delta\` in \`src/lib/stream.rs\` was intended as a memo table: track which radar IDs have already had their control schema pushed to a given client, so the schema is only sent once per radar per connection. The \`meta_sent: &mut Vec<String>\` parameter carried that state.

The implementation did not actually check the memo — it unconditionally \`push\`ed every active radar on every call. When \`add_meta_from_updates\` detected an update for a radar not yet in \`meta_sent\` (triggered by any new or reconnecting radar), it re-pushed the entire active radar set, duplicating every existing entry. Each reconnect event therefore appended \`N\` duplicates, where \`N\` is the active radar count.

Secondary effect: \`add_meta_from_updates\` scans \`meta_sent\` with \`iter().any()\` on every broadcast delta, which becomes O(n) over the unbounded Vec.

## Fix

Change \`meta_sent\` from \`Vec<String>\` to \`HashSet<String>\` and skip radars already present inside \`get_meta_delta\` via \`HashSet::insert\`'s return value. Size is now bounded by the number of distinct radar IDs ever seen on the connection, and the membership check is O(1).

## Tested

- \`cargo build\` clean
- \`cargo test\` — 162 tests pass (147 unit + 15 AIS integration), no regressions
- \`cr review --plain\` — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized metadata tracking for radar data, improving lookup efficiency in SignalK operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->