### PR TITLE
fix(stream): handle navigation and target paths in desubscribe

### DIFF
--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -367,10 +367,13 @@ impl ActiveSubscriptions {
                     radar_id,
                     target_pattern
                 );
-                self.target_subscriptions
+                let patterns = self
+                    .target_subscriptions
                     .entry(radar_id.to_string())
-                    .or_default()
-                    .push(target_pattern.to_string());
+                    .or_default();
+                if !patterns.iter().any(|p| p == target_pattern) {
+                    patterns.push(target_pattern.to_string());
+                }
                 continue;
             }
 
@@ -439,6 +442,30 @@ impl ActiveSubscriptions {
         self.mode = Subscribe::Some;
         for path_desubscription in subscription.desubscribe {
             let path = &path_desubscription.path;
+
+            // Handle navigation desubscriptions (e.g., "navigation.headingTrue")
+            if path.starts_with("navigation.") {
+                log::debug!("Desubscribing from navigation path: {}", path);
+                self.navigation_subscriptions.retain(|p| p != path);
+                continue;
+            }
+
+            // Handle target desubscriptions (e.g., "radars.nav1.targets.*")
+            if path.contains(".targets.") {
+                let (radar_id, target_pattern) = extract_path(path);
+                log::debug!(
+                    "Desubscribing from targets for radar '{}' pattern '{}'",
+                    radar_id,
+                    target_pattern
+                );
+                if let Some(patterns) = self.target_subscriptions.get_mut(radar_id) {
+                    patterns.retain(|p| p != target_pattern);
+                    if patterns.is_empty() {
+                        self.target_subscriptions.remove(radar_id);
+                    }
+                }
+                continue;
+            }
 
             // Handle vessel (AIS) desubscriptions (e.g., "vessels.*")
             if path.starts_with("vessels.") {
@@ -864,5 +891,75 @@ mod test {
                 panic!("{}", e);
             }
         }
+    }
+
+    fn path(p: &str) -> PathSubscribe {
+        PathSubscribe {
+            path: p.to_string(),
+            period: None,
+            policy: None,
+            min_period: None,
+            last_sent: None,
+        }
+    }
+
+    #[test]
+    fn target_subscribe_dedupes_repeated_patterns() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::Some);
+        for _ in 0..100 {
+            subs.subscribe(Subscription {
+                subscribe: vec![path("radars.nav1.targets.*")],
+            })
+            .unwrap();
+        }
+        let patterns = subs.target_subscriptions.get("nav1").unwrap();
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0], "targets.*");
+    }
+
+    #[test]
+    fn target_desubscribe_removes_pattern_and_empty_bucket() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::Some);
+        subs.subscribe(Subscription {
+            subscribe: vec![
+                path("radars.nav1.targets.*"),
+                path("radars.nav1.targets.5"),
+            ],
+        })
+        .unwrap();
+        assert_eq!(subs.target_subscriptions.get("nav1").unwrap().len(), 2);
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("radars.nav1.targets.*")],
+        })
+        .unwrap();
+        let remaining = subs.target_subscriptions.get("nav1").unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0], "targets.5");
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("radars.nav1.targets.5")],
+        })
+        .unwrap();
+        assert!(!subs.target_subscriptions.contains_key("nav1"));
+    }
+
+    #[test]
+    fn navigation_desubscribe_removes_path() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::Some);
+        subs.subscribe(Subscription {
+            subscribe: vec![
+                path("navigation.headingTrue"),
+                path("navigation.position"),
+            ],
+        })
+        .unwrap();
+        assert_eq!(subs.navigation_subscriptions.len(), 2);
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("navigation.headingTrue")],
+        })
+        .unwrap();
+        assert_eq!(subs.navigation_subscriptions, vec!["navigation.position"]);
     }
 }


### PR DESCRIPTION
## Motivation

\`ActiveSubscriptions::subscribe\` routes incoming paths into four separate stores — \`navigation_subscriptions\`, \`target_subscriptions\`, \`vessel_subscriptions\`, and control \`paths\` — but \`desubscribe\` only handled vessels and controls. Two concrete bugs result:

1. **Nav and target desubscribes are no-ops and also abort the batch.** A desubscribe for \`navigation.headingTrue\` or \`radars.nav1.targets.*\` fell through to the control branch, where \`extract_path\` produced a string that failed \`ControlId::from_str\` and returned \`CannotParseControlId\` — aborting the entire desubscribe batch mid-loop. The original entry stayed, any later entries in the same batch were silently dropped, and period-change patterns like \"desub then re-sub\" silently did the wrong thing.

2. **Target subscribe had no dedup.** Unlike the vessel and navigation branches, the target branch unconditionally \`push\`ed into the inner \`Vec\` without a \`contains\` check, so a client re-subscribing to the same pattern accumulated duplicate entries for the lifetime of the connection. No client cooperation beyond \"repeat the same subscribe\" is required to trigger the growth.

Net effect: long-lived Signal K WebSocket clients leak \`navigation_subscriptions\` and \`target_subscriptions\` entries over a session, and downstream filter checks (\`is_subscribed_target_path\`) walk ever-longer Vecs.

## Fix

- Add \`navigation.\` and \`.targets.\` branches to \`desubscribe\`, mirroring the vessel branch.
- When a target radar\'s pattern Vec becomes empty, remove the outer \`HashMap\` entry so that subscribing and unsubscribing across many radar_ids does not leave empty buckets behind.
- Add a \`contains\` check to the target subscribe push so repeated subscribes to the same pattern are idempotent.

## Tested

- \`cargo build\` clean
- \`cargo test\` — 165 tests pass (was 162; added three new unit tests covering target subscribe dedup, target desub with empty-bucket cleanup, and navigation desub)
- New tests live in the existing \`mod test\` in \`src/lib/stream.rs\` and exercise \`ActiveSubscriptions\` directly, no running server required

## Relationship to #87

Independent fix, different call site and different mechanism. This PR does not depend on #87 and vice versa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate subscription handling when repeated subscription requests are made.
  * Improved desubscription support for navigation and target paths.

* **Tests**
  * Enhanced test coverage for subscription and desubscription logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->