### PR TITLE
fix(furuno): restore DRS4W short ranges (1/8, 1/4, 1/2 NM)

### DIFF
--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -514,9 +514,14 @@ static RANGE_TABLE_FAR_KM: &[i32] = &[
     96000, // 96 km
 ];
 
-/// Range table for DRS4W WiFi radar (wire indices 3-13 only, 0.75-24 NM)
-/// Extracted from FEC::DRS4WRanges() static array at kiss VA 0xdda388.
+/// Range table for DRS4W WiFi radar (1/8–24 NM).
+/// Matches the 14 ranges exposed by the Furuno DRS4W official app.
+/// Wire index 21 (1/16 NM) is not supported on DRS4W; 32/36 NM are
+/// out of reach for this 4 kW WiFi radar.
 static RANGE_TABLE_DRS4W: &[i32] = &[
+    231,   // 1/8 NM
+    463,   // 1/4 NM
+    926,   // 1/2 NM
     1389,  // 3/4 NM
     1852,  // 1 NM
     2778,  // 1.5 NM
@@ -530,8 +535,11 @@ static RANGE_TABLE_DRS4W: &[i32] = &[
     44448, // 24 NM
 ];
 
-/// Range table for DRS4W WiFi radar in km mode (wire indices 3-13 only)
+/// Range table for DRS4W WiFi radar in km mode (0.125–24 km).
 static RANGE_TABLE_DRS4W_KM: &[i32] = &[
+    125,   // 0.125 km
+    250,   // 0.25 km
+    500,   // 0.5 km
     750,   // 0.75 km
     1000,  // 1 km
     1500,  // 1.5 km
@@ -610,7 +618,7 @@ fn get_ranges_by_model(model: &RadarModel) -> Vec<i32> {
         | RadarModel::FAR14x6
         | RadarModel::FAR14x7 => (RANGE_TABLE_FAR, RANGE_TABLE_FAR_KM),
 
-        // DRS4W WiFi radar: restricted to wire indices 3-13 (0.75-24 NM)
+        // DRS4W WiFi radar: 1/8–24 NM (matches official DRS4W app)
         RadarModel::DRS4W => (RANGE_TABLE_DRS4W, RANGE_TABLE_DRS4W_KM),
 
         // Standard DRS series and unknown models


### PR DESCRIPTION
## Motivation

#67 restricted the DRS4W range table to wire indices 3–13 (0.75–24 NM) based on a reading of the `FEC::DRS4WRanges()` firmware constant. That reading was wrong: the DRS4W hardware actually exposes 14 ranges from 1/8 to 24 NM, matching the official Furuno DRS4W app (verified on real hardware: 24, 16, 12, 8, 6, 4, 3, 2, 1.5, 1, 0.75, 0.5, 0.25, 0.125 NM).

The three short ranges at wire indices 0, 1, 2 (1/8, 1/4, 1/2 NM) were silently dropped by #67 and need to come back.

## Approach

Expand `RANGE_TABLE_DRS4W` and `RANGE_TABLE_DRS4W_KM` in `src/lib/brand/furuno/settings.rs` to include the three short-range entries at the top. Keep the 24 NM / 24 km ceiling — that part of #67 is legitimate (a 4 kW WiFi radar has no business at 32/36 NM), and wire index 21 (1/16 NM) stays excluded because it is a genuinely unsupported out-of-sequence index on DRS4W.

No changes to `protocol.rs`, `command.rs`, `report.rs` or the dispatch in `get_ranges_by_model()` — the wire-index lookup path already handles indices 0, 1, 2 correctly; they just weren't being offered in the UI because they were absent from the DRS4W range table.

## Tested

- `cargo build --all` passes
- `cargo test` passes (150 unit tests + 15 websocket integration tests, 0 failures)
- `cr review --plain` — no findings
- Verified against the official Furuno DRS4W app on real hardware: same 14 ranges now offered by mayara

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Furuno DRS4W WiFi radar with additional smaller range options (1/8, 1/4, and 1/2 nautical miles), providing finer control over radar range selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->