### PR TITLE
fix(cliff): anchor CodeRabbit-fixup skip rules to commit subject

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -63,8 +63,14 @@ commit_parsers = [
     { message = "^chore\\(release\\)", skip = true },
     { message = "^chore\\(deps\\)", skip = true },
     { message = "^docs(\\(changelog\\))?: update CHANGELOG", skip = true },
-    { message = "address.*CR.*findings", skip = true },
-    { message = "address.*CodeRabbit", skip = true },
+    # Skip "address CR findings" / "address CodeRabbit findings" fixup commits.
+    # The pattern is anchored to the start of the commit message and requires a
+    # conventional-commit prefix, so it only matches fixup-commit SUBJECTS. An
+    # unanchored version would also match squash-merge commit BODIES that
+    # concatenate intermediate commit subjects, silently dropping whole PRs
+    # from the changelog (see regression in PR #95 against the previous
+    # pattern `address.*CodeRabbit`).
+    { message = "^[a-z]+(\\([a-z]+\\))?: address .*(CR|CodeRabbit)", skip = true },
     { message = "^feat", group = "Added" },
     { message = "^fix", group = "Fixed" },
     { message = "^refactor", group = "Changed" },


### PR DESCRIPTION
## Motivation

`cliff.toml` had two unanchored skip rules:

```toml
{ message = "address.*CR.*findings", skip = true },
{ message = "address.*CodeRabbit", skip = true },
```

These were intended to skip fixup commits whose subject is "address CR findings" / "address CodeRabbit findings". But without a `^` anchor they match **anywhere** in the commit text, including the body of a GitHub squash-merge commit that concatenates all intermediate commit subjects.

Any PR that goes through a CodeRabbit review round typically ends up with a fixup commit titled `fix(foo): address CodeRabbit findings`. On squash-merge, GitHub puts that title into the final commit's body alongside the real deliverable title. The unanchored rule then skips the whole squashed commit from the changelog, silently dropping the PR.

**This hit PR #95.** Its squash commit `docs(contributing): add workflow guide, CodeRabbit config, scoped changelog (#95)` is missing from the `[Unreleased]` section on main because its body contains `docs(contributing): address CodeRabbit findings` and `docs(contributing): address second round of CodeRabbit findings` from earlier fixup commits in the branch. The `Update Changelog` workflow ran, git-cliff dropped the commit, and because the regenerated `CHANGELOG.md` was byte-identical to the stale one, no auto-changelog PR was opened — the regression was silent.

This is a **pre-existing bug**, not introduced by #95. Any past PR with a similar fixup-commit history pattern was likely also silently dropped.

## Approach

Merge the two old rules into one anchored rule that requires a conventional-commit prefix at the start of the subject line:

```toml
{ message = "^[a-z]+(\\([a-z]+\\))?: address .*(CR|CodeRabbit)", skip = true },
```

- Anchored with `^` → only matches the start of a commit message, not body lines.
- Requires `<type>(<scope>)?: address ...(CR|CodeRabbit)...` → only real fixup commits match.
- Merges both old patterns into one.

Added a comment above the rule explaining *why* it must stay anchored so the next person doesn't un-fix it.

No `CHANGELOG.md` touch-up is needed. The next release will regenerate the changelog from full history with the anchored rule in place, and PR #95 will reappear in the output — AGENTS.md says never edit CHANGELOG.md manually, and this is not a recovery scenario worth breaking that rule for.

## Tested

Regex validated against 10 cases before committing:

```
[OK] expect=True   fix(furuno): address CodeRabbit findings
[OK] expect=True   fix(furuno): address CR findings
[OK] expect=True   docs(contributing): address CodeRabbit findings
[OK] expect=True   refactor(ci): address CodeRabbit review feedback
[OK] expect=False  docs(contributing): add workflow guide, CodeRabbit config, scoped changelog (#95)
[OK] expect=False  <full PR #95 squash body with "address CodeRabbit" in body>
[OK] expect=False  fix(furuno): restore DRS4W short ranges (as flagged by CodeRabbit)
[OK] expect=False  feat(furuno): add guard zone support
[OK] expect=False  docs(changelog): update CHANGELOG.md
[OK] expect=False  docs: update CHANGELOG.md
```

- `cargo build --all` passes
- `cargo test` passes (150 unit tests + 15 websocket integration tests, 0 failures)
- `git-cliff` itself cannot be validated locally (not installed); the first changelog run after merge is the real test. If wrong, fallout is cosmetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## cliff.toml

This PR fixes a skip rule bug in `cliff.toml` by replacing two unanchored commit message patterns with a single anchored pattern.

### Changes
Merges two existing skip rules (`address.*CR.*findings` and `address.*CodeRabbit`) into a single anchored conventional-commit regex: `^[a-z]+(\\([a-z]+\\))?: address .*(CR|CodeRabbit)`. This change restricts matching to only commit subjects that start with a conventional-commit type (optionally with a scope) followed by "address" and either "CR" or "CodeRabbit", rather than matching those substrings anywhere in the commit message.

Adds an explanatory comment documenting why anchoring is required. Without anchoring, the patterns would incorrectly match squash-merge commit bodies that concatenate intermediate commit subjects, causing entire pull requests to be silently omitted from the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->