### PR TITLE
fix(furuno): handle 0x7D as radar alarm, not DRS4W heartbeat

### DIFF
--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -332,8 +332,9 @@ pub enum CommandId {
     TuneIndicator = 0x76,
     /// `0x77` — No-transmit sector (sector blanking).
     BlindSector = 0x77,
-    /// `0x7D` — DRS4W-specific heartbeat (~1 Hz).
-    DRS4WHeartbeat = 0x7D,
+    /// `0x7D` — Radar alarm: `$N7D,<type>,<d1>,<d2>,<d3>`.
+    /// Generic across all Furuno models; idle = `$N7D,0,0,0,0`.
+    Alarm = 0x7D,
 
     /// `0x80` — Attenuation.
     Att = 0x80,

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -75,6 +75,7 @@ pub struct FurunoReportReceiver {
     prev_spoke: [Vec<u8>; 2],
     prev_angle: [u16; 2],
     guard_zone_alarm: [bool; 2],
+    alarm_active: bool,
 }
 
 impl FurunoReportReceiver {
@@ -113,6 +114,7 @@ impl FurunoReportReceiver {
             prev_spoke: [Vec::new(), Vec::new()],
             prev_angle: [0, 0],
             guard_zone_alarm: [false, false],
+            alarm_active: false,
         }
     }
 
@@ -773,6 +775,28 @@ impl FurunoReportReceiver {
                 }
             }
 
+            CommandId::Alarm => {
+                // $N7D,<type>,<d1>,<d2>,<d3> — generic radar alarm; idle = all zero.
+                // Bit meanings not yet decoded; log raw values on state change.
+                if numbers.len() >= 4 {
+                    let alarm_type = numbers[0] as u32;
+                    if alarm_type != 0 {
+                        log::warn!(
+                            "{}: radar alarm type {} details {} {} {}",
+                            self.common.key,
+                            alarm_type,
+                            numbers[1] as u32,
+                            numbers[2] as u32,
+                            numbers[3] as u32,
+                        );
+                        self.alarm_active = true;
+                    } else if self.alarm_active {
+                        log::info!("{}: radar alarm cleared", self.common.key);
+                        self.alarm_active = false;
+                    }
+                }
+            }
+
             CommandId::GuardStatus => {
                 // $N70,<count>,<status0>,<status1> — log on state change only
                 if numbers.len() >= 3 {
@@ -831,7 +855,6 @@ impl FurunoReportReceiver {
             | CommandId::ATFSettings
             | CommandId::AutoAcquire
             | CommandId::TuneIndicator
-            | CommandId::DRS4WHeartbeat
             | CommandId::GuardMode
             | CommandId::GuardFan => {}
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -780,7 +780,7 @@ impl FurunoReportReceiver {
                 // Bit meanings not yet decoded; log raw values on state change.
                 if numbers.len() >= 4 {
                     let alarm_type = numbers[0] as u32;
-                    if alarm_type != 0 {
+                    if alarm_type != 0 && !self.alarm_active {
                         log::warn!(
                             "{}: radar alarm type {} details {} {} {}",
                             self.common.key,


### PR DESCRIPTION
## Summary

The `0x7D` notification is not a DRS4W-specific heartbeat — it is the general radar alarm notification used across all Furuno models, with wire grammar `$N7D,<type>,<d1>,<d2>,<d3>` and an idle value of `$N7D,0,0,0,0`. Because idle traffic looks periodic, the misinterpretation has gone unnoticed: real alarms with a nonzero type have been silently dropped by the existing no-op match arm in `report.rs`.

Rename the `CommandId` variant to `Alarm` and add a report handler that logs nonzero alarms at warn level and clear transitions at info level, matching the existing `GuardStatus` pattern.

## Verified

- `cargo build --all` and `cargo test` pass
- Runs cleanly against DRS4D-NXT with no regression (the DRS4D-NXT does not emit `$N7D` in practice, so the warn path is untested on hardware — it requires a FAR-class radar to exercise)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR corrects handling of the Furuno 0x7D notification. The opcode is the general radar alarm notification (wire grammar `$N7D,<type>,<d1>,<d2>,<d3>`, idle `$N7D,0,0,0,0`), not a DRS4W-specific heartbeat. Real alarms with nonzero type values are now handled instead of being silently dropped.

## Changes

### Protocol Definition
- src/lib/brand/furuno/protocol.rs
  - Renames `CommandId::DRS4WHeartbeat = 0x7D` to `CommandId::Alarm = 0x7D` and updates documentation to describe the `$N7D` alarm message format and idle semantics.

### Report Handler
- src/lib/brand/furuno/report.rs
  - Adds `alarm_active: bool` to `FurunoReportReceiver`, initialized to `false`.
  - Implements handling for `CommandId::Alarm`:
    - Interprets `numbers[0] != 0` as alarm activation and `numbers[0] == 0` as alarm clear.
    - Logs transitions only (avoids repeated logs for unchanged state).
    - Emits warn-level log on transition to an active alarm with alarm type and details (`numbers[1..=3]`).
    - Emits info-level log on alarm clear transition.
  - Removes the previous no-op handling of the 0x7D opcode so alarms are no longer dropped.

## Verification

- `cargo build --all` and `cargo test` pass.
- Runs cleanly against DRS4D-NXT with no regression.
- Note: the warn path requires a FAR-class radar to exercise because DRS4D-NXT does not emit `$N7D` in practice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->