### PR TITLE
fix(furuno): handle 0xAF as ARPA alarm, not heartbeat

### DIFF
--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -377,8 +377,8 @@ pub enum CommandId {
     ConningPosition = 0xAA,
     /// `0xAC` — Wake-up count.
     WakeUpCount = 0xAC,
-    /// `0xAF` — Frequent radar heartbeat (`$NAF,256`).
-    Heartbeat = 0xAF,
+    /// `0xAF` — ARPA subsystem alarm/status bitmask: `$NAF,<bits>`.
+    ArpaAlarm = 0xAF,
 
     /// `0xD2` — STC range.
     STCRange = 0xD2,

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -797,6 +797,17 @@ impl FurunoReportReceiver {
                 }
             }
 
+            CommandId::ArpaAlarm => {
+                // $NAF,<bitmask> — ARPA subsystem status bits. Bit meanings not yet decoded.
+                if let Some(&bits) = numbers.first() {
+                    log::debug!(
+                        "{}: ARPA alarm status 0x{:04x}",
+                        self.common.key,
+                        bits as u32
+                    );
+                }
+            }
+
             CommandId::GuardStatus => {
                 // $N70,<count>,<status0>,<status1> — log on state change only
                 if numbers.len() >= 3 {
@@ -843,7 +854,6 @@ impl FurunoReportReceiver {
 
             // Silently handled (no state to update)
             CommandId::AliveCheck
-            | CommandId::Heartbeat
             | CommandId::NN3Command
             | CommandId::CustomPictureAll
             | CommandId::AntennaType


### PR DESCRIPTION
## Summary

The `0xAF` notification is not a connection heartbeat — it is the ARPA subsystem alarm/status bitmask `$NAF,<bits>`. No connection-liveness logic depends on it; the real keepalive is `AliveCheck` (`0xE3`) sent periodically from `command.rs::send_report_requests()`. The value `$NAF,256` that made it look periodic is a benign single-bit status indicator.

Rename the `CommandId` variant to `ArpaAlarm` and log the bitmask at debug level so it is observable without polluting the default log stream.

Builds on #100 (includes the `0x7D Alarm` rename from that PR). Once #100 merges, this branch can be rebased to show only the `ArpaAlarm` delta.

## Verified

- `cargo build --all` and `cargo test` pass
- Verified on real DRS4D-NXT hardware: `$NAF,256` → `ARPA alarm status 0x0100` logged at debug level, ~1/sec, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR corrects the interpretation of two Furuno radar protocol notifications:

### Changes to protocol opcodes

The `CommandId` enum in `src/lib/brand/furuno/protocol.rs` reclassifies two notification types:

- **`0x7D` (Alarm)**: Renamed from `DRS4WHeartbeat` to `Alarm`, properly identifying it as a generic radar alarm command with format `$N7D,<type>,<d1>,<d2>,<d3>` (idle state: `$N7D,0,0,0,0`). This command applies across all Furuno models, not just DRS4W.

- **`0xAF` (ArpaAlarm)**: Renamed from `Heartbeat` to `ArpaAlarm`, correctly identifying it as the ARPA subsystem alarm/status bitmask with format `$NAF,<bits>`. The periodic observed value `$NAF,256` (0x0100) is a benign single-bit status indicator, not a connection heartbeat.

### Changes to report handling

The `FurunoReportReceiver` in `src/lib/brand/furuno/report.rs` adds:

- A new `alarm_active: bool` field to track radar alarm state transitions.

- **Alarm handler** (`CommandId::Alarm`): Logs at `warn` level when alarm_type is non-zero with full details (type and three parameter fields), sets `alarm_active = true`. Logs at `info` level when alarm clears (type = 0 after being active), sets `alarm_active = false`.

- **ArpaAlarm handler** (`CommandId::ArpaAlarm`): Logs the ARPA alarm status bitmask at `debug` level (format: `"ARPA alarm status 0x{:04x}"`), making the status observable without increasing default log noise.

### Connection keepalive clarification

The actual connection liveness check is `AliveCheck` (0xE3), sent periodically via `command.rs::send_report_requests()`. Neither 0x7D nor 0xAF are used for connection keepalive logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->