### PR TITLE
feat(furuno): add anti-jamming filter control (0xE8)

### DIFF
--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -208,6 +208,9 @@ impl Command {
         self.send(CommandMode::Request, CommandId::BlindSector, &[])
             .await?; // $R77
 
+        self.send(CommandMode::Request, CommandId::JammingAble, &[])
+            .await?; // $RE8
+
         // STC (Sensitivity Time Control) curves
         if self.controls.contains_key(&ControlId::NearStcCurve) {
             self.send(CommandMode::Request, CommandId::NearSTC, &[])
@@ -483,6 +486,11 @@ impl CommandSender for Command {
                 cmd.push(value);
                 cmd.push(0); // screen: 0=Primary
                 CommandId::BirdMode
+            }
+            ControlId::AntiJamming => {
+                // Format: $SE8,{value}  (0=Off, 1=On)
+                cmd.push(value);
+                CommandId::JammingAble
             }
             ControlId::Doppler => {
                 // Format: $SEF,{enabled},{mode},0

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -394,6 +394,8 @@ pub enum CommandId {
     CustomATFSettings = 0xE0,
     /// `0xE3` — Alive check (keepalive ping).
     AliveCheck = 0xE3,
+    /// `0xE8` — Anti-jamming filter: `$SE8,<value>`. Supported on all Furuno models.
+    JammingAble = 0xE8,
     /// `0xEA` — ATF settings (NXT, 6 params).
     ATFSettings = 0xEA,
     /// `0xED` — Bird mode (NXT: 0 = Off, 1 = Low, 2 = Med, 3 = High).

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -718,6 +718,15 @@ impl FurunoReportReceiver {
                 }
                 self.common.set_value(&ControlId::BirdMode, numbers[0]);
             }
+            CommandId::JammingAble => {
+                if numbers.is_empty() {
+                    bail!(
+                        "Insufficient ({}) arguments for JammingAble command",
+                        numbers.len()
+                    );
+                }
+                self.common.set_value(&ControlId::AntiJamming, numbers[0]);
+            }
             CommandId::TargetAnalyzer => {
                 // Response format: $NEF,{enabled},{mode},{screen}
                 // Wire format: enabled=0/1, mode=0(Target)/1(Rain)

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -282,6 +282,9 @@ pub fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, version:
     // StcRange ($RD2) is not registered: DRS4D-NXT does not respond to $RD2.
     // Re-enable when a model that supports it is available for testing.
 
+    info.controls
+        .add(new_list(ControlId::AntiJamming, &["Off", "On"]));
+
     // Tuning
     if cap.tune {
         info.controls.add(new_auto(

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -172,6 +172,7 @@ pub enum ControlId {
     MiddleStcCurve,
     FarStcCurve,
     StcRange,
+    AntiJamming,
 }
 
 impl Display for ControlId {
@@ -281,7 +282,8 @@ impl ControlId {
             | ControlId::NearStcCurve
             | ControlId::MiddleStcCurve
             | ControlId::FarStcCurve
-            | ControlId::StcRange => Category::Advanced,
+            | ControlId::StcRange
+            | ControlId::AntiJamming => Category::Advanced,
         }
     }
 
@@ -378,6 +380,7 @@ impl ControlId {
             ControlId::MiddleStcCurve => "Middle-range STC suppression curve",
             ControlId::FarStcCurve => "Far-range STC suppression curve",
             ControlId::StcRange => "Distance boundary between STC range bands",
+            ControlId::AntiJamming => "Anti-jamming filter reduces interference from other radars on the same frequency",
         }
     }
 
@@ -470,6 +473,7 @@ impl ControlId {
             ControlId::MiddleStcCurve => "Middle STC curve",
             ControlId::FarStcCurve => "Far STC curve",
             ControlId::StcRange => "STC range",
+            ControlId::AntiJamming => "Anti-jamming",
         }
     }
 
@@ -554,6 +558,7 @@ impl ControlId {
             ControlId::MiddleStcCurve => ControlDestination::Command,
             ControlId::FarStcCurve => ControlDestination::Command,
             ControlId::StcRange => ControlDestination::Command,
+            ControlId::AntiJamming => ControlDestination::Command,
         }
     }
 }


### PR DESCRIPTION
## Summary

Expose the Furuno anti-jamming filter (command `0xE8`, `JammingAble`) as a user control. The wire grammar is `$SE8,<value>` and the official Furuno DRS4W app queries `$RE8` at connect time, so this is a standard control on all current Furuno radar models — DRS4W, DRS-NXT, and FAR series — and is registered unconditionally rather than capability-gated.

Exposed as a binary Off/On list control in the Advanced category, following the `NoiseRejection` pattern. An unconditional `$RE8` init query is added to `init()` so the current state is reflected in the UI on connect.

Builds on #100 and #101. Once those merge, this branch can be rebased to show only the anti-jamming delta.

## Verified

- `cargo build --all` and `cargo test` pass
- Verified on real DRS4D-NXT: `$RE8` → `$NE8,0` round-trip confirmed, control appears in the UI Advanced section as "Anti-jamming" with Off/On options
- REST API returns `{"value":0}` at `/controls/antiJamming`