### PR TITLE
chore(release): add version management script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,7 +99,7 @@ jobs:
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
-          type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
           type=ref,event=branch
           type=semver,pattern={{version}}
           type=sha,prefix=

--- a/release.sh
+++ b/release.sh
@@ -32,6 +32,7 @@ get_version() {
 set_version() {
     local new="$1"
     sedi "s/^version = \".*\"/version = \"${new}\"/" "$CARGO_TOML"
+    cargo update --workspace
     echo "Version set to $new"
 }
 
@@ -72,7 +73,7 @@ ensure_on_main() {
 
 check_changelog() {
     local version="$1"
-    if grep -q "## \[Unreleased\]" CHANGELOG.md; then
+    if [ -f CHANGELOG.md ] && grep -q "## \[Unreleased\]" CHANGELOG.md; then
         echo "Note: CHANGELOG.md [Unreleased] section exists."
         echo "      CI (git-cliff) will generate the [${version}] entry on merge."
     fi
@@ -83,10 +84,10 @@ check_changelog() {
 create_release_pr() {
     local version="$1"
     local tag="v${version}"
-    local branch="release/${version}"
+    local branch="release-${version}"
 
     git checkout -b "$branch"
-    git add "$CARGO_TOML"
+    git add "$CARGO_TOML" Cargo.lock
     git commit -m "chore(release): ${version}"
     git push -u origin "$branch"
 
@@ -155,9 +156,9 @@ bump_to_dev() {
 
     set_version "$dev_version"
 
-    local branch="post-release/${dev_version}"
+    local branch="post-release-${dev_version}"
     git checkout -b "$branch"
-    git add "$CARGO_TOML"
+    git add "$CARGO_TOML" Cargo.lock
     git commit -m "chore(release): begin ${dev_version}"
     git push -u origin "$branch"
 
@@ -268,9 +269,9 @@ do_bump() {
 
     set_version "$new_version"
 
-    local branch="bump/${new_version}"
+    local branch="bump-${new_version}"
     git checkout -b "$branch"
-    git add "$CARGO_TOML"
+    git add "$CARGO_TOML" Cargo.lock
     git commit -m "chore(release): bump to ${new_version}"
     git push -u origin "$branch"
 

--- a/release.sh
+++ b/release.sh
@@ -142,7 +142,7 @@ create_release_pr() {
     git pull origin main
     git tag "$tag" "$merge_sha"
     git push origin "$tag"
-    git branch -d "$branch"
+    git branch -D "$branch" 2>/dev/null || true
     echo "Tagged and pushed ${tag}"
 }
 
@@ -213,7 +213,7 @@ do_beta() {
     local last_beta
     last_beta=$(git tag -l "v${base}-beta.*" \
         | sed "s/v${base}-beta\.//" \
-        | grep -E '^[0-9]+$' \
+        | awk '/^[0-9]+$/' \
         | sort -n | tail -1)
     local next_beta
     if [ -z "$last_beta" ]; then
@@ -323,7 +323,7 @@ Commands:
   --beta        Create a beta pre-release:
                   • strips suffix, appends -beta.N (auto-incremented)
                   • creates a PR, waits for merge, tags the result
-                  • opens a follow-up PR to bump to next -dev version
+                  • opens a follow-up PR to return to <base>-dev
 
   --major       Bump major version (N+1.0.0-dev) via PR
   --minor       Bump minor version (x.N+1.0-dev) via PR

--- a/release.sh
+++ b/release.sh
@@ -56,7 +56,7 @@ confirm() {
 }
 
 ensure_clean() {
-    if ! git diff --quiet || ! git diff --cached --quiet; then
+    if [ -n "$(git status --porcelain)" ]; then
         echo "Error: working tree is not clean. Commit or stash changes first."
         exit 1
     fi
@@ -128,7 +128,8 @@ create_release_pr() {
 
     if [ $elapsed -ge 1800 ]; then
         echo "Timeout waiting for PR merge. Tag manually with:"
-        echo "  git tag ${tag} origin/main && git push origin ${tag}"
+        echo "  merge_sha=\$(gh pr view \"$branch\" --json mergeCommit -q '.mergeCommit.oid')"
+        echo "  git tag ${tag} \"\$merge_sha\" && git push origin ${tag}"
         git checkout main
         git branch -D "$branch" 2>/dev/null || true
         exit 1
@@ -231,7 +232,25 @@ do_beta() {
     create_release_pr "$beta_version"
 
     echo ""
-    bump_to_dev "$base"
+    set_version "${base}-dev"
+
+    local dev_version="${base}-dev"
+    local dev_branch="post-beta-${dev_version}"
+    git checkout -b "$dev_branch"
+    git add "$CARGO_TOML" Cargo.lock
+    git commit -m "chore(release): resume ${dev_version}"
+    git push -u origin "$dev_branch"
+
+    gh pr create \
+        --base main \
+        --head "$dev_branch" \
+        --title "chore(release): resume ${dev_version}" \
+        --body "Return version to ${dev_version} after beta ${beta_version}."
+
+    git checkout main
+    echo ""
+    echo "Development version PR created for $dev_version."
+    echo "Merge it to continue development."
 }
 
 do_bump() {
@@ -314,7 +333,7 @@ Workflow:
   1. ./release.sh --minor       # PR: 3.4.2 → 3.5.0-dev
   2. (development happens)
   3. ./release.sh --release     # PR: 3.5.0, tag v3.5.0, PR: 3.5.1-dev
-  4. ./release.sh --beta        # PR: 3.5.0-beta.1, tag, PR: 3.5.1-dev
+  4. ./release.sh --beta        # PR: 3.5.0-beta.1, tag, PR: 3.5.0-dev
 
 Requires: gh CLI (authenticated)
 EOF

--- a/release.sh
+++ b/release.sh
@@ -203,6 +203,7 @@ do_release() {
 do_beta() {
     ensure_clean
     ensure_on_main
+    git fetch --tags --quiet
 
     local current
     current=$(get_version)

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CARGO_TOML="Cargo.toml"
+
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI not found. Install from https://cli.github.com/"
+    exit 1
+fi
+if ! gh auth status &>/dev/null; then
+    echo "Error: gh is not authenticated. Run 'gh auth login' first."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Portable in-place sed (macOS vs GNU)
+sedi() {
+    if sed --version &>/dev/null; then
+        sed -i "$@"    # GNU
+    else
+        sed -i '' "$@" # BSD
+    fi
+}
+
+get_version() {
+    grep '^version = ' "$CARGO_TOML" | head -1 | sed 's/version = "\(.*\)"/\1/'
+}
+
+set_version() {
+    local new="$1"
+    sedi "s/^version = \".*\"/version = \"${new}\"/" "$CARGO_TOML"
+    echo "Version set to $new"
+}
+
+# Strip any suffix (-dev, -beta.N, etc.) → pure semver
+strip_suffix() {
+    echo "${1%%-*}"
+}
+
+# Parse M.m.p from a (possibly suffixed) version
+parse_major() { echo "${1%%.*}"; }
+parse_minor() { local tmp="${1#*.}"; echo "${tmp%%.*}"; }
+parse_patch() { local tmp="${1%%-*}"; echo "${tmp##*.}"; }
+
+confirm() {
+    local prompt="$1"
+    read -r -p "$prompt [type 'yes' to continue]: " answer
+    if [ "$answer" != "yes" ]; then
+        echo "Aborted."
+        exit 1
+    fi
+}
+
+ensure_clean() {
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "Error: working tree is not clean. Commit or stash changes first."
+        exit 1
+    fi
+}
+
+ensure_on_main() {
+    local branch
+    branch=$(git branch --show-current)
+    if [ "$branch" != "main" ]; then
+        echo "Error: must be on 'main' branch (currently on '$branch')."
+        exit 1
+    fi
+}
+
+check_changelog() {
+    local version="$1"
+    if grep -q "## \[Unreleased\]" CHANGELOG.md; then
+        echo "Note: CHANGELOG.md [Unreleased] section exists."
+        echo "      CI (git-cliff) will generate the [${version}] entry on merge."
+    fi
+}
+
+# Create a PR branch, commit, push, open PR, wait for merge, then
+# tag the merge commit on main.
+create_release_pr() {
+    local version="$1"
+    local tag="v${version}"
+    local branch="release/${version}"
+
+    git checkout -b "$branch"
+    git add "$CARGO_TOML"
+    git commit -m "chore(release): ${version}"
+    git push -u origin "$branch"
+
+    echo ""
+    echo "Creating PR for ${version}..."
+    local pr_url
+    pr_url=$(gh pr create \
+        --base main \
+        --head "$branch" \
+        --title "chore(release): ${version}" \
+        --body "Release ${version}. Merge this PR, then the tag will be created automatically.")
+
+    echo "PR created: $pr_url"
+
+    # Enable auto-merge so the PR merges as soon as checks pass
+    gh pr merge "$branch" --auto --squash || true
+
+    echo ""
+    echo "Waiting for PR to be merged..."
+
+    # Poll until merged (check every 10s, timeout after 30min)
+    local elapsed=0
+    while [ $elapsed -lt 1800 ]; do
+        local state
+        state=$(gh pr view "$branch" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+        if [ "$state" = "MERGED" ]; then
+            echo "PR merged!"
+            break
+        elif [ "$state" = "CLOSED" ]; then
+            echo "Error: PR was closed without merging. Aborting."
+            git checkout main
+            git branch -D "$branch" 2>/dev/null || true
+            exit 1
+        fi
+        sleep 10
+        elapsed=$((elapsed + 10))
+    done
+
+    if [ $elapsed -ge 1800 ]; then
+        echo "Timeout waiting for PR merge. Tag manually with:"
+        echo "  git tag ${tag} origin/main && git push origin ${tag}"
+        git checkout main
+        git branch -D "$branch" 2>/dev/null || true
+        exit 1
+    fi
+
+    # Tag the exact merge commit, not whatever HEAD happens to be
+    local merge_sha
+    merge_sha=$(gh pr view "$branch" --json mergeCommit -q '.mergeCommit.oid')
+    git checkout main
+    git pull origin main
+    git tag "$tag" "$merge_sha"
+    git push origin "$tag"
+    git branch -d "$branch"
+    echo "Tagged and pushed ${tag}"
+}
+
+bump_to_dev() {
+    local base="$1"
+    local major minor patch
+    major=$(parse_major "$base")
+    minor=$(parse_minor "$base")
+    patch=$(parse_patch "$base")
+    local next_patch=$((patch + 1))
+    local dev_version="${major}.${minor}.${next_patch}-dev"
+
+    set_version "$dev_version"
+
+    local branch="post-release/${dev_version}"
+    git checkout -b "$branch"
+    git add "$CARGO_TOML"
+    git commit -m "chore(release): begin ${dev_version}"
+    git push -u origin "$branch"
+
+    gh pr create \
+        --base main \
+        --head "$branch" \
+        --title "chore(release): begin ${dev_version}" \
+        --body "Bump version to ${dev_version} for next development cycle."
+
+    git checkout main
+    echo ""
+    echo "Development version PR created for $dev_version."
+    echo "Merge it to continue development."
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+do_release() {
+    ensure_clean
+    ensure_on_main
+
+    local current
+    current=$(get_version)
+    local release_version
+    release_version=$(strip_suffix "$current")
+
+    echo "Current version: $current"
+    echo "Release version: $release_version"
+    confirm "Create release $release_version?"
+
+    check_changelog "$release_version"
+    set_version "$release_version"
+    create_release_pr "$release_version"
+
+    echo ""
+    bump_to_dev "$release_version"
+}
+
+do_beta() {
+    ensure_clean
+    ensure_on_main
+
+    local current
+    current=$(get_version)
+    local base
+    base=$(strip_suffix "$current")
+
+    # Find next beta number from existing tags (only numeric suffixes)
+    local last_beta
+    last_beta=$(git tag -l "v${base}-beta.*" \
+        | sed "s/v${base}-beta\.//" \
+        | grep -E '^[0-9]+$' \
+        | sort -n | tail -1)
+    local next_beta
+    if [ -z "$last_beta" ]; then
+        next_beta=1
+    else
+        next_beta=$((last_beta + 1))
+    fi
+    local beta_version="${base}-beta.${next_beta}"
+
+    echo "Current version: $current"
+    echo "Beta version:    $beta_version"
+    confirm "Create beta $beta_version?"
+
+    check_changelog "$beta_version"
+    set_version "$beta_version"
+    create_release_pr "$beta_version"
+
+    echo ""
+    bump_to_dev "$base"
+}
+
+do_bump() {
+    local part="$1"
+
+    ensure_clean
+    ensure_on_main
+
+    local current
+    current=$(get_version)
+    local major minor patch
+    major=$(parse_major "$current")
+    minor=$(parse_minor "$current")
+    patch=$(parse_patch "$current")
+
+    case "$part" in
+        major)
+            major=$((major + 1))
+            minor=0
+            patch=0
+            ;;
+        minor)
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        patch)
+            patch=$((patch + 1))
+            ;;
+    esac
+
+    local new_version="${major}.${minor}.${patch}-dev"
+    echo "Current version: $current"
+    echo "New version:     $new_version"
+    confirm "Bump to $new_version?"
+
+    set_version "$new_version"
+
+    local branch="bump/${new_version}"
+    git checkout -b "$branch"
+    git add "$CARGO_TOML"
+    git commit -m "chore(release): bump to ${new_version}"
+    git push -u origin "$branch"
+
+    gh pr create \
+        --base main \
+        --head "$branch" \
+        --title "chore(release): bump to ${new_version}" \
+        --body "Bump version to ${new_version}."
+
+    git checkout main
+    echo ""
+    echo "PR created for version bump to $new_version. Merge it to apply."
+}
+
+do_help() {
+    local current
+    current=$(get_version)
+    cat <<EOF
+release.sh — version management for mayara-server (PR-based flow)
+
+Current version: $current
+
+Commands:
+  --release     Release the current version:
+                  • strips any suffix (-dev, -beta.N)
+                  • creates a PR, waits for merge, tags the result
+                  • opens a follow-up PR to bump to next -dev version
+                  (CHANGELOG.md is generated by git-cliff in CI)
+
+  --beta        Create a beta pre-release:
+                  • strips suffix, appends -beta.N (auto-incremented)
+                  • creates a PR, waits for merge, tags the result
+                  • opens a follow-up PR to bump to next -dev version
+
+  --major       Bump major version (N+1.0.0-dev) via PR
+  --minor       Bump minor version (x.N+1.0-dev) via PR
+  --patch       Bump patch version (x.y.N+1-dev) via PR
+
+Workflow:
+  1. ./release.sh --minor       # PR: 3.4.2 → 3.5.0-dev
+  2. (development happens)
+  3. ./release.sh --release     # PR: 3.5.0, tag v3.5.0, PR: 3.5.1-dev
+  4. ./release.sh --beta        # PR: 3.5.0-beta.1, tag, PR: 3.5.1-dev
+
+Requires: gh CLI (authenticated)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+    --release)  do_release ;;
+    --beta)     do_beta ;;
+    --major)    do_bump major ;;
+    --minor)    do_bump minor ;;
+    --patch)    do_bump patch ;;
+    *)          do_help ;;
+esac


### PR DESCRIPTION
A small helper to simplify release handling.

Handles release, beta, and version bump workflows:
  --release: tag current version, push, bump to next -dev
  --beta: tag beta pre-release with auto-incremented N
  --major/--minor/--patch: bump version with -dev suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds release.sh, a Bash CLI that automates semantic-version tagging, PR creation, and follow-up version bumps for the Rust crate, and tightens Docker tag logic in GitHub Actions so only full releases receive the latest tag.

Core behavior
- Enforces strict Bash settings (set -euo pipefail), requires gh authentication, and prints usage/help with the current version.
- Provides a portable sedi helper and parses the version from Cargo.toml, stripping any -suffix to obtain the base semver and extracting major/minor/patch.
- Ensures a clean git working tree and that the current branch is main before performing release actions.
- Guards changelog checks so a missing CHANGELOG.md does not cause failure and warns when an [Unreleased] section is present.
- Runs cargo update --workspace after modifying Cargo.toml and stages Cargo.lock alongside Cargo.toml to keep the lockfile in sync.
- Normalizes generated branch names by replacing / with - to avoid tooling issues with slash-based branch names.

User workflows
- --release: confirms with the user, strips pre-release suffixes, updates Cargo.toml to the release version, creates a release-<version> branch, commits/pushes Cargo.toml and Cargo.lock, opens a PR to main and attempts auto-merge, polls until merged, tags the merge commit as v<version>, pushes the tag, deletes the release branch, and opens a post-release-<next>-dev PR to bump to <major>.<minor>.<patch+1>-dev.
- --beta: computes the next -beta.N by scanning existing v<base>-beta.* tags, confirms, sets Cargo.toml to <base>-beta.N, runs the PR+tag flow, and creates a follow-up PR to resume development at <base>-dev (beta flow does not increment the patch after tagging).
- --major / --minor / --patch: computes the next semantic increment, appends -dev, creates bump-<new_version> branches (hyphenated), commits and pushes changes, and opens PRs to main.
- All destructive flows require explicit confirmation ("yes").

Reviewer fixes and behavioral clarifications
- Ensures Cargo.lock is updated (cargo update --workspace) and staged after version changes to avoid stale lockfiles in CI.
- Replaces '/' with '-' in generated branch names (examples: release-3.5.0, post-release-3.5.1-dev, bump-3.6.0-dev).
- Adds a file-existence guard for CHANGELOG.md so set -e does not cause failures when the file is absent.
- Adjusts Docker metadata rules so the raw latest tag is emitted only when the Git ref starts with refs/tags/v and does not contain '-' (pre-release tags like -beta or -dev are excluded); beta/dev tags still publish versioned tags.
- Improves ensure_clean() to detect untracked/staged changes, refines beta/tag parsing and messaging, and updates timeout fallback instructions to reference tagging by merge SHA.
- Ensures tags are fetched before computing next beta numbers to avoid collisions from stale local tags and applies other CI robustness and edge-case fixes from reviewer commits.

Files added/changed
- release.sh (executable script implementing release, beta, and bump flows)
- .github/workflows/docker.yml (adjust Docker latest tagging condition to exclude pre-release tags)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->