### PR TITLE
feat(furuno): 252-level palette, Tile echo decoder, and EchoFormat control

### DIFF
--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -493,7 +493,6 @@ impl CommandSender for Command {
                 CommandId::JammingAble
             }
             ControlId::EchoFormat => {
-                // Format: $SC8,{value}  (0=IMO, 1=Tile)
                 cmd.push(value);
                 CommandId::ImoEchoSwitch
             }

--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -492,6 +492,11 @@ impl CommandSender for Command {
                 cmd.push(value);
                 CommandId::JammingAble
             }
+            ControlId::EchoFormat => {
+                // Format: $SC8,{value}  (0=IMO, 1=Tile)
+                cmd.push(value);
+                CommandId::ImoEchoSwitch
+            }
             ControlId::Doppler => {
                 // Format: $SEF,{enabled},{mode},0
                 // Target Analyzer: value 0=Off, 1=Target, 2=Rain

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -248,6 +248,19 @@ impl RadarModel {
             _ => RadarModel::Unknown,
         }
     }
+
+    /// Whether this model belongs to the DRS-NXT family and supports the
+    /// Tile echo format via `ImoEchoSwitch`.
+    pub fn is_nxt(&self) -> bool {
+        matches!(
+            self,
+            RadarModel::DRS4DNXT
+                | RadarModel::DRS6ANXT
+                | RadarModel::DRS12ANXT
+                | RadarModel::DRS25ANXT
+                | RadarModel::DRS6AXCLASS
+        )
+    }
 }
 
 // =============================================================================
@@ -385,6 +398,11 @@ pub enum CommandId {
     WakeUpCount = 0xAC,
     /// `0xAF` — ARPA subsystem alarm/status bitmask: `$NAF,<bits>`.
     ArpaAlarm = 0xAF,
+
+    /// `0xB8` — IMO/Tile echo format switch (NXT only).
+    /// `$SB8,1` = request Tile format, `$SB8,0` = request IMO format.
+    /// From firmware `rmMakeComImoEchoSwitch` at libNAVNETDLL.so.
+    ImoEchoSwitch = 0xB8,
 
     /// `0xD2` — STC range.
     STCRange = 0xD2,
@@ -609,6 +627,20 @@ pub const ENCODING_3_REPEAT_DEFAULT: usize = 0x40;
 /// Bitmask for rounding consumed bytes up to 4-byte alignment:
 /// `used = (used + 3) & SPOKE_ALIGNMENT_MASK`.
 pub const SPOKE_ALIGNMENT_MASK: usize = !3;
+
+// =============================================================================
+// Tile echo format (NXT only)
+// =============================================================================
+
+/// Bits 29-31 of the first header word must equal this value for a Tile frame.
+pub const TILE_MAGIC: u32 = 2;
+
+/// Tile echo format uses a hardcoded scale of 496 at all ranges.
+/// From `DecodeTileEchoFormat` in libNAVNETDLL.so (Ghidra decompilation).
+pub const TILE_SCALE: u32 = 496;
+
+/// Tile RLE: a zero repeat count (low 7 bits) means 128 repeats.
+pub const TILE_REPEAT_DEFAULT: usize = 128;
 
 // =============================================================================
 // Guard zone constants

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -258,7 +258,6 @@ impl RadarModel {
                 | RadarModel::DRS6ANXT
                 | RadarModel::DRS12ANXT
                 | RadarModel::DRS25ANXT
-                | RadarModel::DRS6AXCLASS
         )
     }
 }

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -44,8 +44,14 @@ pub const SPOKES: usize = 8192;
 /// round upper bound that accommodates all known Furuno models.
 pub const SPOKE_LEN: usize = 1024;
 
-/// Number of colors in the echo palette.
-pub const PIXEL_VALUES: u8 = 64;
+/// Number of echo intensity levels in the palette.
+///
+/// Encoding 3 uses 8-bit values with the two LSBs as a marker field, so the
+/// maximum literal value is 0xFC = 252. Raw echo bytes pass straight through
+/// to the palette — no shift, no gain. The `default_legend()` function may
+/// cap the effective palette size if reserved slots (ARPA, Doppler, history)
+/// would push the total beyond 255.
+pub const PIXEL_VALUES: u8 = 252;
 
 // =============================================================================
 // Network — ports and addresses
@@ -603,17 +609,6 @@ pub const ENCODING_3_REPEAT_DEFAULT: usize = 0x40;
 /// Bitmask for rounding consumed bytes up to 4-byte alignment:
 /// `used = (used + 3) & SPOKE_ALIGNMENT_MASK`.
 pub const SPOKE_ALIGNMENT_MASK: usize = !3;
-
-// =============================================================================
-// Echo processing
-// =============================================================================
-
-/// Software echo gain for low-power radars (DRS4W 2.2 kW, DRS).
-/// Applied as a multiplier before the `>> 2` palette shift.
-pub const ECHO_GAIN_LOW_POWER: u8 = 2;
-
-/// Software echo gain for full-power radars (NXT, FAR).
-pub const ECHO_GAIN_DEFAULT: u8 = 1;
 
 // =============================================================================
 // Guard zone constants

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -251,7 +251,7 @@ impl RadarModel {
 
     /// Whether this model belongs to the DRS-NXT family and supports the
     /// Tile echo format via `ImoEchoSwitch`.
-    pub fn is_nxt(&self) -> bool {
+    pub(crate) fn is_nxt(&self) -> bool {
         matches!(
             self,
             RadarModel::DRS4DNXT

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -627,6 +627,10 @@ pub const ENCODING_3_REPEAT_DEFAULT: usize = 0x40;
 /// `used = (used + 3) & SPOKE_ALIGNMENT_MASK`.
 pub const SPOKE_ALIGNMENT_MASK: usize = !3;
 
+/// Minimum palette index for non-zero echo values. Skips the dimmest
+/// indices so weak returns are visually distinct from transparent black.
+pub const ECHO_FLOOR: u16 = 10;
+
 // =============================================================================
 // Tile echo format (NXT only)
 // =============================================================================

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -13,7 +13,7 @@ use tokio_graceful_shutdown::SubsystemHandle;
 
 use super::command::Command;
 use super::protocol::{
-    CommandId, DATA_BROADCAST_ADDRESS, ENCODING_1_REPEAT_DEFAULT,
+    CommandId, DATA_BROADCAST_ADDRESS, ECHO_FLOOR, ENCODING_1_REPEAT_DEFAULT,
     ENCODING_3_REPEAT_DEFAULT, FRAME_DUAL_RANGE_BIT, FRAME_ENCODING_MASK, FRAME_ENCODING_SHIFT,
     FRAME_HEADING_VALID_BIT, FRAME_MAGIC, FRAME_SCALE_HIGH_MASK, FRAME_SPOKE_DATA_LEN_HIGH_BIT,
     FRAME_SWEEP_LEN_HIGH_MASK, FRAME_WIRE_INDEX_MASK, PIXEL_VALUES, RadarModel,
@@ -215,11 +215,10 @@ impl FurunoReportReceiver {
                                     first_report_received = true;
                                 }
 
-                                // NXT models support Tile echo format via ImoEchoSwitch (0xC8).
-                                // Not auto-switched: the radar may not respond to this command
-                                // on all firmware versions. The user can try switching manually
-                                // via the EchoFormat control. If the radar does switch, the
-                                // Tile frame detector and decoder in process_frame() handle it.
+                                // NXT models support Tile echo format via ImoEchoSwitch (0xB8).
+                                // Not auto-switched: the DRS4D-NXT (fw v01.05) acknowledges
+                                // but does not change format. The user can experiment via the
+                                // EchoFormat control; process_frame() detects and decodes Tile.
                             }
                             line.clear();
                         }
@@ -1300,6 +1299,9 @@ impl FurunoReportReceiver {
     }
 
     /// Decode a Tile-format bit-twisted literal: rotates bit 0 to bit 7.
+    /// Only 7 input bits are used (bit 7 is the RLE marker), so the output
+    /// has bit 6 always zero — max value is 191, giving 128 distinct levels.
+    /// This is inherent to the Tile wire format, not a bug.
     #[inline]
     fn tile_literal(byte: u8) -> u8 {
         (byte & 0x7F) >> 1 | (byte & 1) << 7
@@ -1479,7 +1481,6 @@ impl FurunoReportReceiver {
         // making raw values 1-20 near-invisible. Map the raw 0-252 range into
         // a narrower palette window that skips the dimmest indices.
         // Index 0 stays transparent; everything else starts at ECHO_FLOOR.
-        const ECHO_FLOOR: u16 = 10;
         let usable = pixel_max.saturating_sub(ECHO_FLOOR);
 
         for (i, b) in sweep.iter().enumerate() {

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -1206,7 +1206,9 @@ impl FurunoReportReceiver {
             self.common.new_spoke_message();
         }
 
-        // Per-spoke records start after the header words (byte offset 24)
+        // Per-spoke records start after the header words (byte offset 24).
+        // The firmware loop condition is `offset <= content_length + 7` where
+        // offset starts at 8, so content_length + 7 is the frame boundary.
         let mut pos: usize = 24;
         let frame_end = (content_length + 7).min(data.len());
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -1227,7 +1227,7 @@ impl FurunoReportReceiver {
             let pixel_count = if flag & 0x80 != 0 { 256 } else { 64 };
 
             // First pixel is a bit-twisted literal from `flag` bits 0-6
-            let first_pixel = (flag & 0x7F) >> 1 | (flag & 1) << 7;
+            let first_pixel = Self::tile_literal(flag);
             let mut spoke = Vec::with_capacity(pixel_count);
             spoke.push(first_pixel);
 
@@ -1237,9 +1237,7 @@ impl FurunoReportReceiver {
                 pos += 1;
 
                 if byte & 0x80 == 0 {
-                    // Literal: bit-twist the 7-bit value
-                    let value = (byte & 0x7F) >> 1 | (byte & 1) << 7;
-                    spoke.push(value);
+                    spoke.push(Self::tile_literal(byte));
                 } else {
                     // RLE: repeat previous value
                     let mut count = (byte & 0x7F) as usize;
@@ -1256,10 +1254,11 @@ impl FurunoReportReceiver {
                 }
             }
 
-            // Pad to pixel_count if decoder ran short
-            spoke.resize(pixel_count, 0);
+            // Pad to TILE_SCALE samples: the first pixel_count are echo data,
+            // the rest are zero (outside display range), matching IMO's scale
+            // semantics where only the first `scale` samples cover 0..range.
+            spoke.resize(TILE_SCALE as usize, 0);
 
-            // Stretch to SPOKE_LEN using TILE_SCALE as the effective sample count
             let send_spoke = Self::stretch_spoke(&spoke, TILE_SCALE as usize, SPOKE_LEN);
 
             let metadata = FurunoSpokeMetadata {
@@ -1298,6 +1297,12 @@ impl FurunoReportReceiver {
         } else {
             self.common.send_spoke_message();
         }
+    }
+
+    /// Decode a Tile-format bit-twisted literal: rotates bit 0 to bit 7.
+    #[inline]
+    fn tile_literal(byte: u8) -> u8 {
+        (byte & 0x7F) >> 1 | (byte & 1) << 7
     }
 
     fn decode_sweep_encoding_0(sweep: &[u8]) -> (Vec<u8>, usize) {
@@ -1466,7 +1471,7 @@ impl FurunoReportReceiver {
             heading.map(|h| (h * SPOKES as f64 / TAU) as u16)
         };
 
-        let pixel_max = common.info.legend.pixel_colors.saturating_sub(1) as u16;
+        let pixel_max = common.info.pixel_colors().saturating_sub(1) as u16;
         let mut data = vec![0; sweep.len()];
 
         // Furuno-specific: lift weak echoes so they are visually distinct from

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -1183,20 +1183,22 @@ impl FurunoReportReceiver {
         let header_word = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
         let content_length = (header_word & 0x7FF) as usize; // bits 0-10
 
-        // Read range from the control state (updated by $N62 on the TCP stream).
-        // Tile format doesn't carry wire_index in its header the same way IMO does.
-        let range = self
-            .common
-            .info
-            .controls
-            .get(&ControlId::Range)
-            .and_then(|c| c.value)
-            .unwrap_or(0.0) as u32;
-
         // Dual range ID: check byte 15 bit 6, same position as IMO format.
         // If this turns out wrong for Tile, we fall back to Range A only.
         let radar_no = (data[15] >> 6) & 0x01;
         let is_range_b = radar_no == 1 && self.common_b.is_some();
+
+        // Read range from the correct control state (A or B) since Tile
+        // format doesn't carry wire_index in its header like IMO does.
+        let range_controls = if is_range_b {
+            &self.common_b.as_ref().unwrap().info.controls
+        } else {
+            &self.common.info.controls
+        };
+        let range = range_controls
+            .get(&ControlId::Range)
+            .and_then(|c| c.value)
+            .unwrap_or(0.0) as u32;
 
         if is_range_b {
             self.common_b.as_mut().unwrap().new_spoke_message();
@@ -1208,7 +1210,7 @@ impl FurunoReportReceiver {
         let mut pos: usize = 24;
         let frame_end = (content_length + 7).min(data.len());
 
-        while pos + 3 <= frame_end {
+        while pos + 4 <= frame_end {
             // Per-spoke sub-header: angle, heading/flags, first pixel + strip size
             let angle = ((data[pos] as u16) | ((data[pos + 1] as u16 & 0x1F) << 8)) as u16;
             let heading = ((data[pos + 2] as u16) | ((data[pos + 3] as u16 & 0x1F) << 8)) as u16;

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -13,12 +13,12 @@ use tokio_graceful_shutdown::SubsystemHandle;
 
 use super::command::Command;
 use super::protocol::{
-    CommandId, DATA_BROADCAST_ADDRESS, ECHO_GAIN_DEFAULT, ECHO_GAIN_LOW_POWER,
-    ENCODING_1_REPEAT_DEFAULT, ENCODING_3_REPEAT_DEFAULT, FRAME_DUAL_RANGE_BIT,
-    FRAME_ENCODING_MASK, FRAME_ENCODING_SHIFT, FRAME_HEADING_VALID_BIT, FRAME_MAGIC,
-    FRAME_SCALE_HIGH_MASK, FRAME_SPOKE_DATA_LEN_HIGH_BIT, FRAME_SWEEP_LEN_HIGH_MASK,
-    FRAME_WIRE_INDEX_MASK, RadarModel, SPOKE_ALIGNMENT_MASK, SPOKE_ANGLE_HIGH_MASK, SPOKE_LEN,
-    SPOKES, WIRE_UNIT_KM, WIRE_UNIT_NM, wire_index_to_meters_for_unit,
+    CommandId, DATA_BROADCAST_ADDRESS, ENCODING_1_REPEAT_DEFAULT, ENCODING_3_REPEAT_DEFAULT,
+    FRAME_DUAL_RANGE_BIT, FRAME_ENCODING_MASK, FRAME_ENCODING_SHIFT, FRAME_HEADING_VALID_BIT,
+    FRAME_MAGIC, FRAME_SCALE_HIGH_MASK, FRAME_SPOKE_DATA_LEN_HIGH_BIT,
+    FRAME_SWEEP_LEN_HIGH_MASK, FRAME_WIRE_INDEX_MASK, PIXEL_VALUES, RadarModel,
+    SPOKE_ALIGNMENT_MASK, SPOKE_ANGLE_HIGH_MASK, SPOKE_LEN, SPOKES, WIRE_UNIT_KM, WIRE_UNIT_NM,
+    wire_index_to_meters_for_unit,
 };
 use super::settings;
 use crate::Cli;
@@ -1116,17 +1116,6 @@ impl FurunoReportReceiver {
                 SPOKE_LEN,
             );
 
-            // Low-power radars (DRS4W: 2.2 kW WiFi) produce raw echo values
-            // well below the encoding maximum (~124 vs 252), so the 64-color
-            // palette is only half-utilised and targets appear uniformly blue.
-            // A software gain of 2× doubles the palette spread without
-            // affecting full-power models (NXT, FAR) where values already
-            // reach the encoding ceiling.
-            let echo_gain: u8 = match self.model {
-                RadarModel::DRS4W | RadarModel::DRS => ECHO_GAIN_LOW_POWER,
-                _ => ECHO_GAIN_DEFAULT,
-            };
-
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1134,7 +1123,6 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
-                    echo_gain,
                 );
             } else {
                 Self::add_spoke_to_common(
@@ -1143,7 +1131,6 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
-                    echo_gain,
                 );
             }
 
@@ -1304,7 +1291,6 @@ impl FurunoReportReceiver {
         angle: SpokeBearing,
         heading: SpokeBearing,
         sweep: &[u8],
-        echo_gain: u8,
     ) {
         if common.replay {
             let _ = common
@@ -1325,21 +1311,24 @@ impl FurunoReportReceiver {
             heading.map(|h| (h * SPOKES as f64 / TAU) as u16)
         };
 
-        let pixel_max = common.info.pixel_values.saturating_sub(1) as u16;
+        let pixel_max = common.info.legend.pixel_colors.saturating_sub(1) as u16;
         let mut data = vec![0; sweep.len()];
 
+        // Furuno-specific: lift weak echoes so they are visually distinct from
+        // black. With 219 palette entries the linear blue ramp has ~72 levels,
+        // making raw values 1-20 near-invisible. Map the raw 0-252 range into
+        // a narrower palette window that skips the dimmest indices.
+        // Index 0 stays transparent; everything else starts at ECHO_FLOOR.
+        const ECHO_FLOOR: u16 = 10;
+        let usable = pixel_max.saturating_sub(ECHO_FLOOR);
+
         for (i, b) in sweep.iter().enumerate() {
-            // Map raw echo byte to palette index. The raw value range depends
-            // on the encoding (max 252 for encoding 3, 254 for encoding 1/2).
-            // Low-power radars (DRS4W: 2.2 kW) produce values well below the
-            // hardware maximum, so echo_gain > 1 applies software amplification
-            // before the palette mapping. Clamped to pixel_max (63 for the
-            // default 64-color palette).
-            let amplified = (*b as u16 * echo_gain as u16) >> 2;
-            data[i] = amplified.min(pixel_max) as u8;
-        }
-        if common.replay {
-            data[sweep.len() - 1] = 64;
+            let raw = *b as u16;
+            data[i] = if raw == 0 {
+                0
+            } else {
+                (ECHO_FLOOR + raw * usable / PIXEL_VALUES as u16).min(pixel_max) as u8
+            };
         }
 
         log::trace!(

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -1186,6 +1186,11 @@ impl FurunoReportReceiver {
         // If this turns out wrong for Tile, we fall back to Range A only.
         let radar_no = (data[15] >> 6) & 0x01;
         let is_range_b = radar_no == 1 && self.common_b.is_some();
+        let range_idx = if is_range_b { 1 } else { 0 };
+
+        // Tile frames don't participate in IMO delta decoding. Clear the
+        // previous-spoke history so a switch back to IMO starts fresh.
+        self.prev_spoke[range_idx].clear();
 
         // Read range from the correct control state (A or B) since Tile
         // format doesn't carry wire_index in its header like IMO does.
@@ -1288,7 +1293,7 @@ impl FurunoReportReceiver {
                 );
             }
 
-            self.prev_angle[if is_range_b { 1 } else { 0 }] = angle;
+            self.prev_angle[range_idx] = angle;
         }
 
         if is_range_b {

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -13,12 +13,12 @@ use tokio_graceful_shutdown::SubsystemHandle;
 
 use super::command::Command;
 use super::protocol::{
-    CommandId, DATA_BROADCAST_ADDRESS, ENCODING_1_REPEAT_DEFAULT, ENCODING_3_REPEAT_DEFAULT,
-    FRAME_DUAL_RANGE_BIT, FRAME_ENCODING_MASK, FRAME_ENCODING_SHIFT, FRAME_HEADING_VALID_BIT,
-    FRAME_MAGIC, FRAME_SCALE_HIGH_MASK, FRAME_SPOKE_DATA_LEN_HIGH_BIT,
+    CommandId, DATA_BROADCAST_ADDRESS, ENCODING_1_REPEAT_DEFAULT,
+    ENCODING_3_REPEAT_DEFAULT, FRAME_DUAL_RANGE_BIT, FRAME_ENCODING_MASK, FRAME_ENCODING_SHIFT,
+    FRAME_HEADING_VALID_BIT, FRAME_MAGIC, FRAME_SCALE_HIGH_MASK, FRAME_SPOKE_DATA_LEN_HIGH_BIT,
     FRAME_SWEEP_LEN_HIGH_MASK, FRAME_WIRE_INDEX_MASK, PIXEL_VALUES, RadarModel,
-    SPOKE_ALIGNMENT_MASK, SPOKE_ANGLE_HIGH_MASK, SPOKE_LEN, SPOKES, WIRE_UNIT_KM, WIRE_UNIT_NM,
-    wire_index_to_meters_for_unit,
+    SPOKE_ALIGNMENT_MASK, SPOKE_ANGLE_HIGH_MASK, SPOKE_LEN, SPOKES, TILE_MAGIC,
+    TILE_REPEAT_DEFAULT, TILE_SCALE, WIRE_UNIT_KM, WIRE_UNIT_NM, wire_index_to_meters_for_unit,
 };
 use super::settings;
 use crate::Cli;
@@ -214,6 +214,12 @@ impl FurunoReportReceiver {
                                     }
                                     first_report_received = true;
                                 }
+
+                                // NXT models support Tile echo format via ImoEchoSwitch (0xC8).
+                                // Not auto-switched: the radar may not respond to this command
+                                // on all firmware versions. The user can try switching manually
+                                // via the EchoFormat control. If the radar does switch, the
+                                // Tile frame detector and decoder in process_frame() handle it.
                             }
                             line.clear();
                         }
@@ -1028,8 +1034,22 @@ impl FurunoReportReceiver {
     }
 
     fn process_frame(&mut self, data: &[u8]) {
-        if data.len() < 16 || data[0] != FRAME_MAGIC {
-            log::debug!("Dropping invalid frame");
+        if data.len() < 16 {
+            log::debug!("Dropping short frame ({} bytes)", data.len());
+            return;
+        }
+
+        // Tile echo format: first uint32 bits 29-31 == TILE_MAGIC (2)
+        if data.len() >= 12 {
+            let header_word = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+            if (header_word >> 29) == TILE_MAGIC {
+                self.process_tile_frame(data);
+                return;
+            }
+        }
+
+        if data[0] != FRAME_MAGIC {
+            log::debug!("Dropping invalid frame (magic={:#04x})", data[0]);
             return;
         }
 
@@ -1136,6 +1156,137 @@ impl FurunoReportReceiver {
 
             self.prev_angle[range_idx] = angle;
             self.prev_spoke[range_idx] = generic_spoke;
+        }
+
+        if is_range_b {
+            self.common_b.as_mut().unwrap().send_spoke_message();
+        } else {
+            self.common.send_spoke_message();
+        }
+    }
+
+    /// Decode a Tile echo frame (NXT-only format).
+    ///
+    /// The Tile format uses bitstream-packed headers and a different RLE scheme
+    /// from IMO. Each frame contains one or more spoke strips (64 or 256 cells).
+    /// The literal pixel encoding uses a bit-twist:
+    /// `decoded = (byte & 0x7F) >> 1 | (byte & 1) << 7`.
+    ///
+    /// Reference: `DecodeTileEchoFormat` @ 0x5eda0 in libNAVNETDLL.so.
+    fn process_tile_frame(&mut self, data: &[u8]) {
+        if data.len() < 24 {
+            log::debug!("Tile frame too short ({} bytes)", data.len());
+            return;
+        }
+
+        // First header word at byte offset 8
+        let header_word = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+        let content_length = (header_word & 0x7FF) as usize; // bits 0-10
+
+        // Read range from the control state (updated by $N62 on the TCP stream).
+        // Tile format doesn't carry wire_index in its header the same way IMO does.
+        let range = self
+            .common
+            .info
+            .controls
+            .get(&ControlId::Range)
+            .and_then(|c| c.value)
+            .unwrap_or(0.0) as u32;
+
+        // Dual range ID: check byte 15 bit 6, same position as IMO format.
+        // If this turns out wrong for Tile, we fall back to Range A only.
+        let radar_no = (data[15] >> 6) & 0x01;
+        let is_range_b = radar_no == 1 && self.common_b.is_some();
+
+        if is_range_b {
+            self.common_b.as_mut().unwrap().new_spoke_message();
+        } else {
+            self.common.new_spoke_message();
+        }
+
+        // Per-spoke records start after the header words (byte offset 24)
+        let mut pos: usize = 24;
+        let frame_end = (content_length + 7).min(data.len());
+
+        while pos + 3 <= frame_end {
+            // Per-spoke sub-header: angle, heading/flags, first pixel + strip size
+            let angle = ((data[pos] as u16) | ((data[pos + 1] as u16 & 0x1F) << 8)) as u16;
+            let heading = ((data[pos + 2] as u16) | ((data[pos + 3] as u16 & 0x1F) << 8)) as u16;
+            pos += 4;
+
+            if pos >= frame_end {
+                break;
+            }
+
+            let flag = data[pos];
+            pos += 1;
+            let pixel_count = if flag & 0x80 != 0 { 256 } else { 64 };
+
+            // First pixel is a bit-twisted literal from `flag` bits 0-6
+            let first_pixel = (flag & 0x7F) >> 1 | (flag & 1) << 7;
+            let mut spoke = Vec::with_capacity(pixel_count);
+            spoke.push(first_pixel);
+
+            // Decode remaining pixels via Tile RLE
+            while spoke.len() < pixel_count && pos < frame_end {
+                let byte = data[pos];
+                pos += 1;
+
+                if byte & 0x80 == 0 {
+                    // Literal: bit-twist the 7-bit value
+                    let value = (byte & 0x7F) >> 1 | (byte & 1) << 7;
+                    spoke.push(value);
+                } else {
+                    // RLE: repeat previous value
+                    let mut count = (byte & 0x7F) as usize;
+                    if count == 0 {
+                        count = TILE_REPEAT_DEFAULT;
+                    }
+                    let prev = *spoke.last().unwrap_or(&0);
+                    for _ in 0..count {
+                        if spoke.len() >= pixel_count {
+                            break;
+                        }
+                        spoke.push(prev);
+                    }
+                }
+            }
+
+            // Pad to pixel_count if decoder ran short
+            spoke.resize(pixel_count, 0);
+
+            // Stretch to SPOKE_LEN using TILE_SCALE as the effective sample count
+            let send_spoke = Self::stretch_spoke(&spoke, TILE_SCALE as usize, SPOKE_LEN);
+
+            let metadata = FurunoSpokeMetadata {
+                sweep_count: 1,
+                sweep_len: pixel_count as u32,
+                encoding: 0,
+                have_heading: 1,
+                range,
+                radar_no,
+                scale: TILE_SCALE,
+            };
+
+            if is_range_b {
+                Self::add_spoke_to_common(
+                    self.common_b.as_mut().unwrap(),
+                    &metadata,
+                    angle,
+                    heading,
+                    &send_spoke,
+                );
+            } else {
+                Self::add_spoke_to_common(
+                    &mut self.common,
+                    &metadata,
+                    angle,
+                    heading,
+                    &send_spoke,
+                );
+            }
+
+            self.prev_angle[if is_range_b { 1 } else { 0 }] = angle;
         }
 
         if is_range_b {

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -370,6 +370,10 @@ pub fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, version:
         info.controls
             .add(new_numeric(ControlId::TimedRun, 10., 120.).wire_units(Units::Seconds));
     }
+    if model.is_nxt() {
+        info.controls
+            .add(new_list(ControlId::EchoFormat, &["IMO", "Tile"]));
+    }
     if cap.dual_range {
         info.dual_range = true;
     }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -303,7 +303,7 @@ pub struct RadarInfo {
     pub spoke_data_addr: SocketAddrV4,   // Where the radar will send data spokes
     pub report_addr: SocketAddrV4,       // Where the radar will send reports
     pub send_command_addr: SocketAddrV4, // Where displays will send commands to the radar
-    pub(crate) legend: Legend,            // What pixel values mean
+    legend: Legend,                      // What pixel values mean
     pub controls: SharedControls,        // Which controls there are, not complete in beginning
     pub ranges: Ranges,                  // Ranges for this radar, empty in beginning
     pub(crate) range_detection: Option<RangeDetection>, // if Some, then ranges are flexible, detected and persisted
@@ -537,6 +537,10 @@ impl RadarInfo {
 
     pub fn get_legend(&self) -> Legend {
         self.legend.clone()
+    }
+
+    pub fn pixel_colors(&self) -> u8 {
+        self.legend.pixel_colors
     }
 }
 

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -303,7 +303,7 @@ pub struct RadarInfo {
     pub spoke_data_addr: SocketAddrV4,   // Where the radar will send data spokes
     pub report_addr: SocketAddrV4,       // Where the radar will send reports
     pub send_command_addr: SocketAddrV4, // Where displays will send commands to the radar
-    legend: Legend,                      // What pixel values mean
+    pub(crate) legend: Legend,            // What pixel values mean
     pub controls: SharedControls,        // Which controls there are, not complete in beginning
     pub ranges: Ranges,                  // Ranges for this radar, empty in beginning
     pub(crate) range_detection: Option<RangeDetection>, // if Some, then ranges are flexible, detected and persisted

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -539,7 +539,7 @@ impl RadarInfo {
         self.legend.clone()
     }
 
-    pub fn pixel_colors(&self) -> u8 {
+    pub(crate) fn pixel_colors(&self) -> u8 {
         self.legend.pixel_colors
     }
 }

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -173,6 +173,7 @@ pub enum ControlId {
     FarStcCurve,
     StcRange,
     AntiJamming,
+    EchoFormat,
 }
 
 impl Display for ControlId {
@@ -283,7 +284,8 @@ impl ControlId {
             | ControlId::MiddleStcCurve
             | ControlId::FarStcCurve
             | ControlId::StcRange
-            | ControlId::AntiJamming => Category::Advanced,
+            | ControlId::AntiJamming
+            | ControlId::EchoFormat => Category::Advanced,
         }
     }
 
@@ -381,6 +383,7 @@ impl ControlId {
             ControlId::FarStcCurve => "Far-range STC suppression curve",
             ControlId::StcRange => "Distance boundary between STC range bands",
             ControlId::AntiJamming => "Anti-jamming filter reduces interference from other radars on the same frequency",
+            ControlId::EchoFormat => "Echo data encoding format (NXT only: IMO or Tile)",
         }
     }
 
@@ -474,6 +477,7 @@ impl ControlId {
             ControlId::FarStcCurve => "Far STC curve",
             ControlId::StcRange => "STC range",
             ControlId::AntiJamming => "Anti-jamming",
+            ControlId::EchoFormat => "Echo format",
         }
     }
 
@@ -559,6 +563,7 @@ impl ControlId {
             ControlId::FarStcCurve => ControlDestination::Command,
             ControlId::StcRange => ControlDestination::Command,
             ControlId::AntiJamming => ControlDestination::Command,
+            ControlId::EchoFormat => ControlDestination::Command,
         }
     }
 }

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -383,7 +383,7 @@ impl ControlId {
             ControlId::FarStcCurve => "Far-range STC suppression curve",
             ControlId::StcRange => "Distance boundary between STC range bands",
             ControlId::AntiJamming => "Anti-jamming filter reduces interference from other radars on the same frequency",
-            ControlId::EchoFormat => "Echo data encoding format (NXT only: IMO or Tile)",
+            ControlId::EchoFormat => "Experimental echo format request (NXT only: IMO or Tile)",
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove the `>>2` shift and per-model echo gain that crushed Furuno's 8-bit echo data to 64 palette levels. PIXEL_VALUES 64 → 252, raw echo bytes pass through directly. DRS4W weak-echo fix is automatic.
- Add Furuno-specific ECHO_FLOOR so weak returns skip the dimmest palette indices. No changes to `default_legend()` — other brands unaffected.
- Add Tile echo format decoder for NXT models (bitstream headers, bit-7 RLE, rotated 7-bit literals, hardcoded TILE_SCALE=496).
- Add `EchoFormat` advanced control (IMO/Tile) for NXT models via `ImoEchoSwitch` command (0xB8, confirmed from firmware `rmMakeComImoEchoSwitch`).

## Notes

The DRS4D-NXT (firmware v01.05) acknowledges `$SB8` but does not switch to Tile format. TimeZero also stays on IMO in captured sessions (`$RB8,0` → `$NB8,0`, no `$SB8` sent). The Tile decoder is ready for when the format switch can be triggered — the `EchoFormat` control allows manual experimentation.

## Tested

- 252-level palette verified on live DRS4D-NXT — full color range, no fading
- `pixelValues: 252`, `pixelColors: 219` confirmed via capabilities API
- Furuno ECHO_FLOOR produces visible weak returns without affecting other brands
- EchoFormat control appears for NXT models, sends correct `$SB8,{value}` on the wire
- All existing tests pass including Furuno pcap replay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR expands Furuno radar echo palette support from 64 to 252 intensity levels, implements a Tile echo-format decoder for NXT-family models, adds an experimental EchoFormat control (IMO/Tile) for NXT models, and applies Tile-decoder correctness fixes and Furuno-specific plumbing adjustments.

## Echo palette and mapping

- Raw Furuno 8-bit echo bytes pass through unchanged (no >>2 downshift and no per-model software gain).
- PIXEL_VALUES changes from 64 to 252. Non-zero raw bytes map into a Furuno-specific palette window that starts at ECHO_FLOOR so weak returns skip the dimmest indices; raw zero remains transparent.
- Mapped indices clamp to the legend’s effective palette size via RadarInfo::pixel_colors() to preserve reserved slots (ARPA/Doppler/history).
- Software echo-gain and gain-based amplification are removed from IMO-frame processing; add_spoke_to_common uses the legend’s pixel_colors and the new remapping.

## Tile echo format decoder (NXT models)

- Adds RadarModel::is_nxt() to identify NXT-family models (DRS4DNXT, DRS6ANXT, DRS12ANXT, DRS25ANXT).
- Detects Tile frames by reading a little-endian u32 at byte offset 8 and checking bits 29–31 against TILE_MAGIC; short frames early-return with debug logging.
- Implements process_tile_frame to decode Tile-format spokes:
  - Validates header and TILE_MAGIC.
  - Decodes bit-7 RLE and rotated 7-bit literal pixels via tile_literal().
  - Supports 64 vs 256 sample counts per strip, applies TILE_REPEAT_DEFAULT when repeat count is zero, pads/streches decoded samples to SPOKE_LEN using TILE_SCALE (496).
  - Constructs FurunoSpokeMetadata (encoding 0, have_heading = 1, scale = TILE_SCALE) and emits spokes via add_spoke_to_common.
  - Selects Range A vs Range B from the correct control/state byte and clears IMO delta/history state when switching to or processing Tile frames.

## EchoFormat control and command plumbing

- Adds ControlId::EchoFormat as an Advanced control with options ["IMO","Tile"], registered only when model.is_nxt() is true.
- Adds CommandId::ImoEchoSwitch = 0xB8 and updates CommandSender::set_control to map EchoFormat to ImoEchoSwitch, sending $SB8,{value} (0=IMO, 1=Tile). The control is experimental to allow manual experimentation; firmware acknowledgement behavior may vary.

## Structural/API changes

- Adds RadarInfo::pixel_colors() accessor used for palette mapping.
- Adds RadarModel::is_nxt() and extends CommandId enum.
- Removes ECHO_GAIN_* constants in favor of Tile-related constants and introduces named ECHO_FLOOR.

## Fixes and clarifications

- Corrects ImoEchoSwitch opcode comment to 0xB8.
- Adjusts Tile decoder bounds-check (pos+4) to avoid out-of-bounds on truncated frames.
- Documents tile_literal()’s 128-value ceiling as an inherent wire-format limitation and intentionally leaves Tile magic numbers inline per project guidance.

## Validation

- Live DRS4D-NXT verification reports pixelValues: 252 and pixelColors: 219.
- Furuno ECHO_FLOOR produces visible weak returns without affecting other brands.
- EchoFormat control appears for NXT models and sends correctly formatted $SB8,{value} on the wire; some firmware may acknowledge without switching in captured sessions.
- Existing tests, including Furuno pcap replay, continue to pass.

## Notes

- Author addresses reviewer findings (opcode comment, ECHO_FLOOR constant, Tile literal documentation); an automated reviewer bot records corresponding learnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->