### PR TITLE
fix(furuno): sqrt echo curve for DRS4W low-power radars

### DIFF
--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -121,9 +121,9 @@ impl FurunoLocator {
 
             info.start_forwarding_radar_messages_to_stdout(&subsys);
 
-            if self.args.is_replay() {
-                // Detect model from the original beacon model string, not from
-                // controls which persistence may have overwritten.
+            // In replay mode, detect model from the original beacon string
+            // (not from controls which persistence may have overwritten).
+            let replay_model = if self.args.is_replay() {
                 let model = RadarModel::from_model_name(beacon_model);
                 log::info!(
                     "{}: Radar model {} detected for replay mode (from beacon {:?})",
@@ -135,7 +135,10 @@ impl FurunoLocator {
                     settings::update_when_model_known(&mut info, model, REPLAY_FIRMWARE_VERSION);
                     radars.update(&mut info);
                 }
-            }
+                Some(model)
+            } else {
+                None
+            };
 
             // Register and configure Range B if this is a dual-range model
             let mut info_b = info_b.and_then(|ib| radars.add(ib));
@@ -143,8 +146,7 @@ impl FurunoLocator {
                 ib.send_command_addr.set_port(port);
                 ib.report_addr.set_port(port);
                 ib.start_forwarding_radar_messages_to_stdout(&subsys);
-                if self.args.is_replay() {
-                    let model = RadarModel::from_model_name(beacon_model);
+                if let Some(model) = replay_model {
                     if model != RadarModel::Unknown {
                         settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
                         radars.update(ib);

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -17,6 +17,8 @@ mod protocol;
 mod report;
 mod settings;
 
+const REPLAY_FIRMWARE_VERSION: &str = "00.00";
+
 use protocol::{
     ANNOUNCE_MAYARA_PACKET, BASE_PORT, BEACON_ADDRESS, BEACON_REPORT_HEADER,
     BEACON_REPORT_LENGTH_MIN, DATA_PORT, FurunoRadarModelReport, FurunoRadarReport,
@@ -129,7 +131,7 @@ impl FurunoLocator {
                     model,
                     beacon_model,
                 );
-                settings::update_when_model_known(&mut info, model, "00.00");
+                settings::update_when_model_known(&mut info, model, REPLAY_FIRMWARE_VERSION);
                 radars.update(&mut info);
             }
 
@@ -141,7 +143,7 @@ impl FurunoLocator {
                 ib.start_forwarding_radar_messages_to_stdout(&subsys);
                 if self.args.is_replay() {
                     let model = RadarModel::from_model_name(beacon_model);
-                    settings::update_when_model_known(ib, model, "00.00");
+                    settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
                     radars.update(ib);
                 }
             }

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -90,6 +90,7 @@ impl FurunoLocator {
         info_b: Option<RadarInfo>,
         radars: &SharedRadars,
         subsys: &SubsystemHandle,
+        beacon_model: &str,
     ) {
         if let Some(mut info) = radars.add(info) {
             // It's new, start the RadarProcessor thread
@@ -119,12 +120,14 @@ impl FurunoLocator {
             info.start_forwarding_radar_messages_to_stdout(&subsys);
 
             if self.args.is_replay() {
-                let model_name = info.controls.model_name().unwrap_or_default();
-                let model = RadarModel::from_model_name(&model_name);
+                // Detect model from the original beacon model string, not from
+                // controls which persistence may have overwritten.
+                let model = RadarModel::from_model_name(beacon_model);
                 log::info!(
-                    "{}: Radar model {} detected for replay mode",
+                    "{}: Radar model {} detected for replay mode (from beacon {:?})",
                     info.key(),
                     model,
+                    beacon_model,
                 );
                 settings::update_when_model_known(&mut info, model, "00.00");
                 radars.update(&mut info);
@@ -137,8 +140,7 @@ impl FurunoLocator {
                 ib.report_addr.set_port(port);
                 ib.start_forwarding_radar_messages_to_stdout(&subsys);
                 if self.args.is_replay() {
-                    let model_name = ib.controls.model_name().unwrap_or_default();
-                    let model = RadarModel::from_model_name(&model_name);
+                    let model = RadarModel::from_model_name(beacon_model);
                     settings::update_when_model_known(ib, model, "00.00");
                     radars.update(ib);
                 }
@@ -331,7 +333,7 @@ impl FurunoLocator {
                     None
                 };
 
-                self.found(radar_info, info_b, radars, subsys);
+                self.found(radar_info, info_b, radars, subsys, &model);
             }
             Err(e) => {
                 log::error!(

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -131,8 +131,10 @@ impl FurunoLocator {
                     model,
                     beacon_model,
                 );
-                settings::update_when_model_known(&mut info, model, REPLAY_FIRMWARE_VERSION);
-                radars.update(&mut info);
+                if model != RadarModel::Unknown {
+                    settings::update_when_model_known(&mut info, model, REPLAY_FIRMWARE_VERSION);
+                    radars.update(&mut info);
+                }
             }
 
             // Register and configure Range B if this is a dual-range model
@@ -143,8 +145,10 @@ impl FurunoLocator {
                 ib.start_forwarding_radar_messages_to_stdout(&subsys);
                 if self.args.is_replay() {
                     let model = RadarModel::from_model_name(beacon_model);
-                    settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
-                    radars.update(ib);
+                    if model != RadarModel::Unknown {
+                        settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
+                        radars.update(ib);
+                    }
                 }
             }
 

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -119,14 +119,14 @@ impl FurunoLocator {
             info.start_forwarding_radar_messages_to_stdout(&subsys);
 
             if self.args.is_replay() {
-                let model = RadarModel::DRS4DNXT; // Default model for replay
-                let version = "01.05";
+                let model_name = info.controls.model_name().unwrap_or_default();
+                let model = RadarModel::from_model_name(&model_name);
                 log::info!(
-                    "{}: Radar model {} assumed for replay mode",
+                    "{}: Radar model {} detected for replay mode",
                     info.key(),
                     model,
                 );
-                settings::update_when_model_known(&mut info, model, version);
+                settings::update_when_model_known(&mut info, model, "00.00");
                 radars.update(&mut info);
             }
 
@@ -137,9 +137,9 @@ impl FurunoLocator {
                 ib.report_addr.set_port(port);
                 ib.start_forwarding_radar_messages_to_stdout(&subsys);
                 if self.args.is_replay() {
-                    let model = RadarModel::DRS4DNXT;
-                    let version = "01.05";
-                    settings::update_when_model_known(ib, model, version);
+                    let model_name = ib.controls.model_name().unwrap_or_default();
+                    let model = RadarModel::from_model_name(&model_name);
+                    settings::update_when_model_known(ib, model, "00.00");
                     radars.update(ib);
                 }
             }

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -146,11 +146,9 @@ impl FurunoLocator {
                 ib.send_command_addr.set_port(port);
                 ib.report_addr.set_port(port);
                 ib.start_forwarding_radar_messages_to_stdout(&subsys);
-                if let Some(model) = replay_model {
-                    if model != RadarModel::Unknown {
-                        settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
-                        radars.update(ib);
-                    }
+                if let Some(model) = replay_model.filter(|m| *m != RadarModel::Unknown) {
+                    settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
+                    radars.update(ib);
                 }
             }
 

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -249,6 +249,41 @@ impl RadarModel {
         }
     }
 
+    /// Map a human-readable model name from the 170-byte beacon model report
+    /// to a [`RadarModel`]. Matches on substrings to handle variations like
+    /// "DRS4D-NXT" vs "DRS4DNXT".
+    pub(crate) fn from_model_name(name: &str) -> RadarModel {
+        if name.contains("DRS4D-NXT") || name.contains("DRS4DNXT") {
+            RadarModel::DRS4DNXT
+        } else if name.contains("DRS6A-NXT") || name.contains("DRS6ANXT") {
+            RadarModel::DRS6ANXT
+        } else if name.contains("DRS12A-NXT") || name.contains("DRS12ANXT") {
+            RadarModel::DRS12ANXT
+        } else if name.contains("DRS25A-NXT") || name.contains("DRS25ANXT") {
+            RadarModel::DRS25ANXT
+        } else if name.contains("DRS6A") && name.contains("CLASS") {
+            RadarModel::DRS6AXCLASS
+        } else if name.contains("DRS4W") {
+            RadarModel::DRS4W
+        } else if name.contains("DRS4DL") {
+            RadarModel::DRS4DL
+        } else if name.starts_with("DRS") {
+            RadarModel::DRS
+        } else if name.contains("FAR-21") || name.contains("FAR21") {
+            RadarModel::FAR21x7
+        } else if name.contains("FAR-14") && name.contains("7") {
+            RadarModel::FAR14x7
+        } else if name.contains("FAR-14") && name.contains("6") {
+            RadarModel::FAR14x6
+        } else if name.contains("FAR-15") || name.contains("FAR15") {
+            RadarModel::FAR15x3
+        } else if name.contains("FAR-3") || name.contains("FAR3") {
+            RadarModel::FAR3000
+        } else {
+            RadarModel::Unknown
+        }
+    }
+
     /// Whether this model belongs to the DRS-NXT family and supports the
     /// Tile echo format via `ImoEchoSwitch`.
     pub(crate) fn is_nxt(&self) -> bool {

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -284,6 +284,12 @@ impl RadarModel {
         }
     }
 
+    /// Whether this is a low-power radar (DRS4W 2.2 kW, DRS) that needs
+    /// an aggressive gamma curve for the echo palette mapping.
+    pub(crate) fn is_low_power(&self) -> bool {
+        matches!(self, RadarModel::DRS4W | RadarModel::DRS)
+    }
+
     /// Whether this model belongs to the DRS-NXT family and supports the
     /// Tile echo format via `ImoEchoSwitch`.
     pub(crate) fn is_nxt(&self) -> bool {

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -91,6 +91,16 @@ impl FurunoReportReceiver {
             Some(Command::new(&info, false))
         };
 
+        // In replay mode the model is already set on RadarInfo by mod.rs.
+        // In live mode, model_name may not be set yet (identified later via $N96).
+        let model_name = info.controls.model_name();
+        let model = model_name
+            .as_deref()
+            .map(RadarModel::from_model_name)
+            .unwrap_or(RadarModel::Unknown);
+        let low_power = matches!(model, RadarModel::DRS4W | RadarModel::DRS);
+        let echo_lut = Self::build_echo_lut(info.pixel_colors(), low_power);
+
         let control_update_rx = info.control_update_subscribe();
         let blob_tx = radars.get_blob_tx();
 
@@ -110,8 +120,8 @@ impl FurunoReportReceiver {
             stream: None,
             command_sender,
             report_request_interval: Duration::from_millis(5000),
-            model_known: false,
-            model: RadarModel::Unknown,
+            model_known: model != RadarModel::Unknown,
+            model,
             receive_type: ReceiveAddressType::Both,
             multicast_socket: None,
             broadcast_socket: None,
@@ -119,7 +129,7 @@ impl FurunoReportReceiver {
             prev_angle: [0, 0],
             guard_zone_alarm: [false, false],
             alarm_active: false,
-            echo_lut: Self::build_echo_lut(info.pixel_colors(), false),
+            echo_lut,
         }
     }
 
@@ -1474,9 +1484,10 @@ impl FurunoReportReceiver {
     /// Build the raw-byte → palette-index lookup table.
     ///
     /// Low-power radars (DRS4W, DRS) have a bottom-heavy echo distribution
-    /// where 95% of returns are below raw value 64. A sqrt curve spreads
-    /// those low values across more of the palette. Full-power models (NXT,
-    /// FAR) have a more even distribution and use a linear mapping.
+    /// where 95% of returns are below raw value 64. An 18th-root (gamma 0.056)
+    /// curve aggressively compresses the range so that even weak returns
+    /// reach red, matching the Furuno iOS app's vivid visual output.
+    /// Full-power models (NXT, FAR) use a linear mapping.
     fn build_echo_lut(pixel_colors: u8, low_power: bool) -> [u8; 256] {
         let pixel_max = pixel_colors.saturating_sub(1) as u16;
         let usable = pixel_max.saturating_sub(ECHO_FLOOR);
@@ -1484,7 +1495,7 @@ impl FurunoReportReceiver {
         for raw in 1u16..256 {
             let mapped = if low_power {
                 let normalized = raw as f64 / PIXEL_VALUES as f64;
-                ECHO_FLOOR + (normalized.sqrt() * usable as f64) as u16
+                ECHO_FLOOR + (normalized.powf(1.0 / 18.0) * usable as f64) as u16
             } else {
                 ECHO_FLOOR + raw * usable / PIXEL_VALUES as u16
             };

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -120,7 +120,7 @@ impl FurunoReportReceiver {
             stream: None,
             command_sender,
             report_request_interval: Duration::from_millis(5000),
-            model_known: model != RadarModel::Unknown,
+            model_known: args.is_replay() && model != RadarModel::Unknown,
             model,
             receive_type: ReceiveAddressType::Both,
             multicast_socket: None,
@@ -935,7 +935,7 @@ impl FurunoReportReceiver {
                 low_power,
             );
             if low_power {
-                log::info!("{}: using sqrt echo curve for low-power radar", self.common.key);
+                log::info!("{}: using gamma echo curve for low-power radar", self.common.key);
             }
             settings::update_when_model_known(&mut self.common.info, model, version);
             if let Some(cs) = &mut self.command_sender {

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -98,7 +98,7 @@ impl FurunoReportReceiver {
             .as_deref()
             .map(RadarModel::from_model_name)
             .unwrap_or(RadarModel::Unknown);
-        let low_power = matches!(model, RadarModel::DRS4W | RadarModel::DRS);
+        let low_power = model.is_low_power();
         let echo_lut = Self::build_echo_lut(info.pixel_colors(), low_power);
 
         let control_update_rx = info.control_update_subscribe();
@@ -929,7 +929,7 @@ impl FurunoReportReceiver {
                 version
             );
             self.model = model;
-            let low_power = matches!(model, RadarModel::DRS4W | RadarModel::DRS);
+            let low_power = model.is_low_power();
             self.echo_lut = Self::build_echo_lut(
                 self.common.info.pixel_colors(),
                 low_power,

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -77,8 +77,8 @@ pub struct FurunoReportReceiver {
     guard_zone_alarm: [bool; 2],
     alarm_active: bool,
     /// Precomputed raw-byte → palette-index lookup table. Built when the model
-    /// and legend are known. DRS4W/DRS use a sqrt curve to spread the
-    /// bottom-heavy echo distribution; other models use a linear mapping.
+    /// and legend are known. DRS4W/DRS use an 18th-root gamma curve to spread
+    /// the bottom-heavy echo distribution; other models use a linear mapping.
     echo_lut: [u8; 256],
 }
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -76,6 +76,10 @@ pub struct FurunoReportReceiver {
     prev_angle: [u16; 2],
     guard_zone_alarm: [bool; 2],
     alarm_active: bool,
+    /// Precomputed raw-byte → palette-index lookup table. Built when the model
+    /// and legend are known. DRS4W/DRS use a sqrt curve to spread the
+    /// bottom-heavy echo distribution; other models use a linear mapping.
+    echo_lut: [u8; 256],
 }
 
 impl FurunoReportReceiver {
@@ -115,6 +119,7 @@ impl FurunoReportReceiver {
             prev_angle: [0, 0],
             guard_zone_alarm: [false, false],
             alarm_active: false,
+            echo_lut: Self::build_echo_lut(info.pixel_colors(), false),
         }
     }
 
@@ -914,6 +919,14 @@ impl FurunoReportReceiver {
                 version
             );
             self.model = model;
+            let low_power = matches!(model, RadarModel::DRS4W | RadarModel::DRS);
+            self.echo_lut = Self::build_echo_lut(
+                self.common.info.pixel_colors(),
+                low_power,
+            );
+            if low_power {
+                log::info!("{}: using sqrt echo curve for low-power radar", self.common.key);
+            }
             settings::update_when_model_known(&mut self.common.info, model, version);
             if let Some(cs) = &mut self.command_sender {
                 cs.set_ranges(self.common.info.ranges.clone());
@@ -1135,6 +1148,7 @@ impl FurunoReportReceiver {
                 SPOKE_LEN,
             );
 
+            let echo_lut = &self.echo_lut;
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1142,6 +1156,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
+                    echo_lut,
                 );
             } else {
                 Self::add_spoke_to_common(
@@ -1150,6 +1165,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
+                    echo_lut,
                 );
             }
 
@@ -1275,6 +1291,7 @@ impl FurunoReportReceiver {
                 scale: TILE_SCALE,
             };
 
+            let echo_lut = &self.echo_lut;
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1282,6 +1299,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
+                    echo_lut,
                 );
             } else {
                 Self::add_spoke_to_common(
@@ -1290,6 +1308,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
+                    echo_lut,
                 );
             }
 
@@ -1452,12 +1471,35 @@ impl FurunoReportReceiver {
         out
     }
 
+    /// Build the raw-byte → palette-index lookup table.
+    ///
+    /// Low-power radars (DRS4W, DRS) have a bottom-heavy echo distribution
+    /// where 95% of returns are below raw value 64. A sqrt curve spreads
+    /// those low values across more of the palette. Full-power models (NXT,
+    /// FAR) have a more even distribution and use a linear mapping.
+    fn build_echo_lut(pixel_colors: u8, low_power: bool) -> [u8; 256] {
+        let pixel_max = pixel_colors.saturating_sub(1) as u16;
+        let usable = pixel_max.saturating_sub(ECHO_FLOOR);
+        let mut lut = [0u8; 256];
+        for raw in 1u16..256 {
+            let mapped = if low_power {
+                let normalized = raw as f64 / PIXEL_VALUES as f64;
+                ECHO_FLOOR + (normalized.sqrt() * usable as f64) as u16
+            } else {
+                ECHO_FLOOR + raw * usable / PIXEL_VALUES as u16
+            };
+            lut[raw as usize] = mapped.min(pixel_max) as u8;
+        }
+        lut
+    }
+
     fn add_spoke_to_common(
         common: &mut CommonRadar,
         metadata: &FurunoSpokeMetadata,
         angle: SpokeBearing,
         heading: SpokeBearing,
         sweep: &[u8],
+        echo_lut: &[u8; 256],
     ) {
         if common.replay {
             let _ = common
@@ -1478,23 +1520,10 @@ impl FurunoReportReceiver {
             heading.map(|h| (h * SPOKES as f64 / TAU) as u16)
         };
 
-        let pixel_max = common.info.pixel_colors().saturating_sub(1) as u16;
         let mut data = vec![0; sweep.len()];
 
-        // Furuno-specific: lift weak echoes so they are visually distinct from
-        // black. With 219 palette entries the linear blue ramp has ~72 levels,
-        // making raw values 1-20 near-invisible. Map the raw 0-252 range into
-        // a narrower palette window that skips the dimmest indices.
-        // Index 0 stays transparent; everything else starts at ECHO_FLOOR.
-        let usable = pixel_max.saturating_sub(ECHO_FLOOR);
-
         for (i, b) in sweep.iter().enumerate() {
-            let raw = *b as u16;
-            data[i] = if raw == 0 {
-                0
-            } else {
-                (ECHO_FLOOR + raw * usable / PIXEL_VALUES as u16).min(pixel_max) as u8
-            };
+            data[i] = echo_lut[*b as usize];
         }
 
         log::trace!(


### PR DESCRIPTION
## Summary

- Apply an 18th-root (gamma 0.056) echo curve for DRS4W and DRS models to fix washed-out display. Analysis of DRS4W pcap data shows 95% of echo values are below 64/252 — with a linear mapping these all land in dim blue. The aggressive curve pushes even weak returns into red, matching the Furuno iOS app's vivid output.
- Implemented as a precomputed 256-entry LUT, rebuilt when model is identified via `$N96` (live) or from the beacon model report name (replay).
- NXT and FAR models keep the linear mapping since their distribution covers the full 0-252 range.
- Add `RadarModel::from_model_name()` to detect model from the 170-byte beacon report string. Replaces the hardcoded `DRS4DNXT` default in pcap replay mode, so all Furuno models get correct settings during replay.

## Tested

- DRS4W pcap replay shows vivid red/green returns instead of dim blue
- Model correctly detected as DRS4W from beacon report during replay
- NXT pcap replay still uses linear mapping (unchanged)
- All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description

This PR fixes washed-out display on Furuno DRS4W and DRS low-power radars by applying a strong gamma echo curve instead of a linear mapping. The solution includes:

1. Echo curve mapping: Adds a precomputed 256-entry lookup table (`echo_lut`) that maps raw echo byte values to palette indices. DRS4W and DRS (low-power) models use an aggressive 18th-root gamma curve (gamma ≈ 0.056) to expand weak returns into vivid colors; NXT and FAR models retain a linear mapping.

2. Dynamic model detection: Adds `RadarModel::from_model_name()` to parse the model name from the 170‑byte beacon model report and derive the radar model instead of using a hardcoded replay default. Replay mode detects the model from the beacon name and updates settings accordingly; live mode avoids setting `model_known` prematurely so `parse_modules()` still runs and NXT controls register correctly.

3. Runtime LUT initialization: `FurunoReportReceiver` derives the model from initial control settings, computes `echo_lut` at construction, and rebuilds the LUT when the model is first identified during `parse_modules`. The code logs when the low-power gamma curve is selected and updates log text to reference "gamma" instead of "sqrt".

4. Replay firmware/version constant: Introduces `REPLAY_FIRMWARE_VERSION = "00.00"` and uses it when updating settings for replay-detected models.

## Changes

- src/lib/brand/furuno/protocol.rs
  - Adds `pub(crate) fn RadarModel::from_model_name(&str) -> RadarModel` to map beacon model name strings to radar model types with prioritized substring matching (handles variants like "DRS4D-NXT" vs "DRS4DNXT" and FAR variants).

- src/lib/brand/furuno/report.rs
  - Adds `echo_lut: [u8; 256]` to `FurunoReportReceiver`, computed from `info.pixel_colors()` and a `low_power` flag.
  - Introduces `build_echo_lut(pixel_colors, low_power) -> [u8; 256]` producing either the aggressive gamma curve for low-power models or a linear mapping for others.
  - Derives `model` from `info.controls.model_name()` at construction and sets `model_known` only when replay-mode supplies a non-`Unknown` model; recomputes `echo_lut` when `parse_modules` assigns the model during frame processing and logs selection of the gamma curve.
  - Replaces per-spoke inline echo-to-palette computation with direct LUT indexing in `add_spoke_to_common` and threads `echo_lut` through `process_frame`/`process_tile_frame` for both Range A and Range B.

- src/lib/brand/furuno/mod.rs
  - Removes hardcoded `RadarModel::DRS4DNXT`/firmware for replay and instead derives the replay model via `RadarModel::from_model_name(beacon_model)`, calling `settings::update_when_model_known(..., model, "00.00")`. Updates replay logging to indicate the model is detected from the beacon string. Applies same behavior for secondary Range B replay path.

- Misc
  - Prevents setting `model_known = true` from beacon name in live mode to ensure `parse_modules()` runs.
  - Adds `REPLAY_FIRMWARE_VERSION` constant used for replay-mode settings updates.
  - Tests and replay verification: DRS4W pcap replay shows vivid red/green returns; model detection from beacon report works in replay; NXT replay remains unchanged; existing tests pass.

## Impact

The gamma echo curve remaps the many low raw echo values (≈95% below 64/252 in DRS4W captures) into higher palette indices, dramatically improving visibility compared to linear mapping while preserving linear behavior for models whose echo distributions span the full range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->