### PR TITLE
fix(network): remove overly strict broadcast address assertion

### DIFF
--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -235,16 +235,15 @@ pub fn create_udp_listen(
 
     let socket: socket2::Socket = new_socket()?;
 
+    // Multicast is detectable from the address. Broadcast is not, because
+    // `Ipv4Addr::is_broadcast` only matches 255.255.255.255, while many
+    // radars (e.g. Furuno) use subnet-directed broadcasts like
+    // 172.31.255.255 that look like unicast to the stdlib. Trust the
+    // caller-supplied SocketType for broadcast vs unicast.
     debug_assert!(
         matches!(socket_type, SocketType::Any)
             || matches!(socket_type, SocketType::Multicast) == addr.ip().is_multicast(),
         "SocketType::Multicast mismatch for address {}",
-        addr,
-    );
-    debug_assert!(
-        matches!(socket_type, SocketType::Any | SocketType::Multicast)
-            || matches!(socket_type, SocketType::Broadcast) == addr.ip().is_broadcast(),
-        "SocketType::Broadcast mismatch for address {}",
         addr,
     );
 


### PR DESCRIPTION
## Motivation

`Ipv4Addr::is_broadcast()` in the Rust stdlib only returns `true` for the limited broadcast `255.255.255.255`. Subnet-directed broadcasts like Furuno's `172.31.255.255` look like unicast to stdlib, so the `debug_assert!` in `create_udp_listen` panics on valid setups when running a debug build:

```
thread 'tokio-runtime-worker' panicked at src/lib/network/mod.rs:244:5:
SocketType::Broadcast mismatch for address 172.31.255.255:10024
```

## Solution

Drop the broadcast-specific assertion. Broadcast vs unicast cannot be reliably distinguished from the address alone without netmask context, so trust the caller-supplied `SocketType`. The multicast assertion is kept because multicast addresses are detectable from the address.

The runtime `match` on `effective` already handles routing correctly — the assertion was the only thing rejecting legitimate subnet-directed broadcasts.

## Tested

- Debug build (`cargo build`) no longer panics when Furuno radar binds `172.31.255.255:10024`
- `cargo test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR removes an overly strict `debug_assert!` validation in the `create_udp_listen` function that enforces `Ipv4Addr::is_broadcast()` checks for broadcast socket addresses.

## Problem

The Rust standard library's `is_broadcast()` method only returns `true` for the limited broadcast address 255.255.255.255, not for subnet-directed broadcasts (e.g., 172.31.255.255 used by Furuno). This causes debug builds to panic when binding to subnet-directed broadcast addresses, even though they are valid broadcast addresses within their network context.

## Solution

The PR removes the broadcast-specific assertion from the debug assertion logic. The assertion now only validates:
- When `SocketType` is `Any`, it correctly matches whether the address is multicast
- When `SocketType` is `Multicast`, it matches `addr.ip().is_multicast()`

The multicast assertion remains since multicast addresses are reliably detectable. A new comment documents that broadcast detection via `Ipv4Addr::is_broadcast` is unreliable for subnet-directed broadcasts, and the function now relies on the caller-provided `SocketType` for broadcast vs unicast classification. The existing runtime `match` on `effective` already handles routing appropriately.

## Changes

- **File**: `src/lib/network/mod.rs`
- **Lines changed**: +5/-6

## Testing

The fix resolves the panic in debug builds when binding to subnet-directed broadcast addresses (e.g., 172.31.255.255:10024), and all tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->