### PR TITLE
feat(navdata): seed --static-position for real radars

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -395,6 +395,33 @@ pub async fn start_session(
     // Initialize navigation broadcast sender so navdata can push updates to GUI clients
     navdata::init_nav_broadcast(radars.get_sk_client_tx());
 
+    // Seed navigation data from --static-position (for shore-based installations
+    // without a connected Signal K/NMEA navigation source). Mirrors the emulator
+    // pattern: set atomics once, then periodically re-broadcast so late-joining
+    // GUI clients receive the current heading/position.
+    if let Some(static_pos) = args.get_static_position() {
+        navdata::set_position(Some(static_pos.lat), Some(static_pos.lon));
+        navdata::set_heading_true(Some(static_pos.heading.to_radians()), "static");
+        navdata::set_sog(Some(0.0));
+        navdata::set_cog(Some(static_pos.heading.to_radians()));
+
+        subsystem.start(SubsystemBuilder::new(
+            "Static Navigation",
+            |subsys| async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+                loop {
+                    tokio::select! { biased;
+                        _ = subsys.on_shutdown_requested() => break,
+                        _ = interval.tick() => {
+                            navdata::broadcast_heading("static");
+                        }
+                    }
+                }
+                Ok::<(), miette::Report>(())
+            },
+        ));
+    }
+
     // Initialize AIS vessel store if pass_ais is enabled
     if args.pass_ais {
         navdata::init_ais_store(radars.get_sk_client_tx());

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -32,6 +32,10 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const PACKAGE: &str = env!("CARGO_PKG_NAME");
 pub const SIGNALK_RADAR_API_VERSION: &str = env!("SIGNALK_RADAR_API_VERSION");
 
+/// How often the static-position task re-broadcasts the current heading
+/// so late-joining GUI clients can receive it.
+const STATIC_NAV_REBROADCAST_INTERVAL_SECS: u64 = 2;
+
 #[derive(clap::ValueEnum, Clone, Default, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TargetMode {
@@ -400,26 +404,45 @@ pub async fn start_session(
     // pattern: set atomics once, then periodically re-broadcast so late-joining
     // GUI clients receive the current heading/position.
     if let Some(static_pos) = args.get_static_position() {
-        navdata::set_position(Some(static_pos.lat), Some(static_pos.lon));
-        navdata::set_heading_true(Some(static_pos.heading.to_radians()), "static");
-        navdata::set_sog(Some(0.0));
-        navdata::set_cog(Some(static_pos.heading.to_radians()));
+        if static_pos.lat.is_finite()
+            && static_pos.lon.is_finite()
+            && static_pos.heading.is_finite()
+            && (-90.0..=90.0).contains(&static_pos.lat)
+            && (-180.0..=180.0).contains(&static_pos.lon)
+        {
+            let heading_rad = static_pos.heading.to_radians();
+            navdata::set_position(Some(static_pos.lat), Some(static_pos.lon));
+            navdata::set_heading_true(Some(heading_rad), "static");
+            navdata::set_sog(Some(0.0));
+            navdata::set_cog(Some(heading_rad));
 
-        subsystem.start(SubsystemBuilder::new(
-            "Static Navigation",
-            |subsys| async move {
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
-                loop {
-                    tokio::select! { biased;
-                        _ = subsys.on_shutdown_requested() => break,
-                        _ = interval.tick() => {
-                            navdata::broadcast_heading("static");
+            subsystem.start(SubsystemBuilder::new(
+                "Static Navigation",
+                |subsys| async move {
+                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(
+                        STATIC_NAV_REBROADCAST_INTERVAL_SECS,
+                    ));
+                    loop {
+                        tokio::select! { biased;
+                            _ = subsys.on_shutdown_requested() => break,
+                            _ = interval.tick() => {
+                                navdata::broadcast_heading("static");
+                            }
                         }
                     }
-                }
-                Ok::<(), miette::Report>(())
-            },
-        ));
+                    Ok::<(), miette::Report>(())
+                },
+            ));
+        } else {
+            log::warn!(
+                "--static-position ignored: values out of range \
+                 (lat={}, lon={}, heading={}). \
+                 Expected lat ∈ [-90,90], lon ∈ [-180,180], finite heading.",
+                static_pos.lat,
+                static_pos.lon,
+                static_pos.heading
+            );
+        }
     }
 
     // Initialize AIS vessel store if pass_ais is enabled


### PR DESCRIPTION
## Motivation

`--static-position` was only read by the emulator. A real shore-based radar installation (the intended use of `--stationary`) with no connected Signal K / NMEA navigation source had no way to supply its known fixed position and heading, leaving ARPA target geographic positions and the GUI target overlay (which gates rendering on `navigation.headingTrue`) broken.

## Solution

Seed the navdata atomics (position, heading, SOG, COG) from `--static-position` at the start of `start_session`, then spawn a small task that re-broadcasts the heading every 2s so late-joining GUI clients receive it. Mirrors the emulator's existing `broadcast_heading` pattern.

The emulator already calls `get_static_position()` for its own initial position and is unaffected.

## Tested

- Furuno DRS4D-NXT + `--stationary --static-position=52.367 4.904 0.0`
- GUI now shows position (52°22'03.4" N / 4°54'14.8" E) and `Hdg: 0.0°`
- ARPA targets compute geographic positions correctly
- `cargo test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for using the `--static-position` flag with real shore-based (stationary) radar installations that lack a connected navigation data source (Signal K / NMEA). Previously, this flag was only utilized by the emulator.

## Changes
The PR modifies `start_session` to initialize navigation state from `--static-position` when provided:
- Seeds `navdata` atomic values with latitude, longitude, heading (converted to radians), SOG (0.0), and COG (heading in radians)
- Spawns a new periodic subsystem ("Static Navigation") that re-broadcasts heading every 2 seconds until shutdown, ensuring late-joining GUI clients receive the heading information
- This mirrors the existing emulator behavior without affecting its operation, as the emulator already calls `get_static_position()` for its initial position

## Impact
- Enables correct ARPA target geographic computations for stationary radars
- Ensures GUI target overlay displays correctly by providing the required navigation data
- Provides consistent heading broadcast to all clients connecting to the radar session

## Testing
Verified with a Furuno DRS4D-NXT radar using `--stationary --static-position=52.367 4.904 0.0`:
- GUI displays the supplied position (52°22'03.4" N / 4°54'14.8" E)
- Heading displays correctly (0.0°)
- ARPA targets compute geographic positions correctly
- All unit tests pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->