### PR TITLE
fix(arpa): stop flooding broadcast channel with per-blob target updates

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1258,6 +1258,9 @@ async fn ws_signalk_delta(
                             send_message(socket, sk_delta).await?;
                         }
                     },
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        log::warn!("Control channel lagged by {n} messages, resuming");
+                    }
                     Err(e) => {
                         log::error!("Error on Control channel: {e}");
                         break Ok(());

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -563,6 +563,13 @@ impl Display for RadarInfo {
     }
 }
 
+/// Capacity of the Signal K client broadcast channel. Sized to absorb a
+/// full revolution's worth of target updates plus control value changes
+/// without dropping messages, even when multiple WebSocket clients are
+/// connected. A single lag event is now recoverable (see v2 stream
+/// handler), but larger headroom reduces the chance of visible gaps.
+const SK_CLIENT_CHANNEL_CAPACITY: usize = 128;
+
 #[derive(Clone)]
 pub struct SharedRadars {
     radars: Arc<RwLock<Radars>>,
@@ -570,7 +577,7 @@ pub struct SharedRadars {
 
 impl SharedRadars {
     pub fn new() -> Self {
-        let (sk_client_tx, _) = tokio::sync::broadcast::channel(32);
+        let (sk_client_tx, _) = tokio::sync::broadcast::channel(SK_CLIENT_CHANNEL_CAPACITY);
 
         SharedRadars {
             radars: Arc::new(RwLock::new(Radars {

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -215,10 +215,9 @@ impl TrackerManager {
         // Get tracker and process
         let tracker = self.get_or_create_tracker(&msg.radar_key, ctx.spokes_per_revolution);
 
-        // Check for revolution boundary
-        tracker.check_revolution(ctx.angle, ctx.time);
+        // Check for revolution boundary — batch-broadcast all targets once per revolution
+        let revolution_completed = tracker.check_revolution(ctx.angle, ctx.time);
 
-        // Process the candidate and broadcast if needed
         let result = tracker.process_candidate(candidate);
 
         log::debug!(
@@ -230,29 +229,23 @@ impl TrackerManager {
             msg.blob.size_meters,
             result
         );
-        // Broadcast target updates to GUI.
-        // Suppress until the target has been seen 3 times to avoid cluttering the display
-        // with blobs that will be deduplicated or discarded after the first few rotations.
-        match result {
-            ProcessResult::Updated(target_id)
-            | ProcessResult::Promoted(target_id)
-            | ProcessResult::NewAcquiring(target_id) => {
-                if let Some(target) = tracker.get_target(target_id) {
-                    if target.update_count >= 4 {
-                        let target_api = active_target_to_api(target, radar_position.as_ref());
 
-                        let mut delta = SignalKDelta::new();
-                        delta.add_target_update(&msg.radar_key, target_id, Some(target_api));
-
-                        if let Err(e) = self.sk_client_tx.send(delta) {
-                            log::trace!("Failed to broadcast target update: {}", e);
-                        }
-                    }
+        // Only broadcast immediately when a target is first promoted to tracking.
+        // All other updates are batched and sent once per revolution to avoid flooding.
+        if let ProcessResult::Promoted(target_id) = result {
+            if let Some(target) = tracker.get_target(target_id) {
+                let target_api = active_target_to_api(target, radar_position.as_ref());
+                let mut delta = SignalKDelta::new();
+                delta.add_target_update(&msg.radar_key, target_id, Some(target_api));
+                if let Err(e) = self.sk_client_tx.send(delta) {
+                    log::trace!("Failed to broadcast promoted target: {}", e);
                 }
             }
-            ProcessResult::Ignored => {
-                // No broadcast needed - candidate didn't match and wasn't in guard zone
-            }
+        }
+
+        // On revolution boundary, send a single batched delta with all tracking targets
+        if revolution_completed {
+            self.broadcast_all_targets(&msg.radar_key, radar_position.as_ref());
         }
     }
 
@@ -506,6 +499,50 @@ impl TrackerManager {
 
         for (target_id, radar_key) in deletions {
             self.broadcast_deletion(target_id, &radar_key);
+        }
+    }
+
+    /// Broadcast all tracking targets in a single batched delta (once per revolution)
+    fn broadcast_all_targets(&self, radar_key: &str, radar_position: Option<&GeoPosition>) {
+        let targets: Vec<(u64, ArpaTargetApi)> = if self.merge_mode {
+            self.shared_tracker
+                .as_ref()
+                .map(|t| {
+                    t.get_active_targets()
+                        .filter(|t| t.update_count >= 4)
+                        .map(|t| (t.id, active_target_to_api(t, radar_position)))
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            self.per_radar_trackers
+                .get(radar_key)
+                .map(|t| {
+                    t.get_active_targets()
+                        .filter(|t| t.update_count >= 4)
+                        .map(|t| (t.id, active_target_to_api(t, radar_position)))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+
+        if targets.is_empty() {
+            return;
+        }
+
+        log::debug!(
+            "Broadcasting {} targets for radar {radar_key} to {} receivers",
+            targets.len(),
+            self.sk_client_tx.receiver_count()
+        );
+
+        let mut delta = SignalKDelta::new();
+        for (id, api) in targets {
+            delta.add_target_update(radar_key, id, Some(api));
+        }
+
+        if let Err(e) = self.sk_client_tx.send(delta) {
+            log::trace!("Failed to broadcast batched target update: {}", e);
         }
     }
 

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -368,13 +368,17 @@ impl TargetTracker {
         id
     }
 
-    /// Check for revolution boundary and perform cleanup
-    pub fn check_revolution(&mut self, angle: u16, time: u64) {
+    /// Check for revolution boundary and perform cleanup.
+    /// Returns `true` if a revolution just completed.
+    pub fn check_revolution(&mut self, angle: u16, time: u64) -> bool {
         // Detect revolution boundary (angle wraps from high to low)
-        if angle < self.last_angle && (self.last_angle - angle) > (self.spokes_per_revolution / 2) {
+        let is_boundary = angle < self.last_angle
+            && (self.last_angle - angle) > (self.spokes_per_revolution / 2);
+        if is_boundary {
             self.on_revolution_complete(time);
         }
         self.last_angle = angle;
+        is_boundary
     }
 
     /// Handle revolution complete event


### PR DESCRIPTION
## Scope

**This is an intermediate fix, not a full ARPA overhaul.** It targets the specific crash/flood symptom observed when guard zones are enabled on a Furuno radar with many tracked targets. More ARPA work (target stability, merge behaviour, UI updates) will follow in separate PRs.

Independent of #119: useful on its own — without #119 the GUI may still have heading from another Signal K source.

## Problem

With guard zones enabled, the software ARPA tracker produced 17+ targets per revolution. Every blob match on an existing target sent a separate `SignalKDelta` through the 32-slot broadcast channel. With ~1300 blob candidates per ~1s revolution, the channel overflowed constantly:

```
Error on Control channel: channel lagged by 224
```

The SignalK v2 WebSocket handler treated `Lagged` as a fatal error and disconnected the subscriber (`break Ok(())`). The browser reconnected, got flooded again, disconnected — a 10–20 second crash/reconnect cycle. Targets never stayed on screen long enough to see.

## Change

Three small, related fixes:

1. **Batch target updates per revolution** (`radar/target/manager.rs`, `radar/target/tracker.rs`)
   - `check_revolution` now returns `bool` to signal a revolution boundary
   - Only `Promoted` (target first confirmed as tracking) broadcasts immediately
   - All other active-target state is collected and sent in a single delta once per revolution
2. **Recover from broadcast lag instead of disconnecting** (`web/signalk/v2.rs`)
   - `RecvError::Lagged` is now warn + continue; the spoke stream already handled it this way
3. **Raise channel capacity 32 → 128** (`radar/mod.rs`) as headroom

## Not in this PR

- No tracker/motion model tuning
- No deduplication or lifecycle changes
- No UI changes
- No change to how `Lost`/deletion deltas are sent

## Tested

- Furuno DRS4D-NXT + guard zone enabled, 60+ tracked targets
- WebSocket no longer disconnects; no `Error on Control channel` lines in log
- Target circles + velocity arrows render stably
- `cargo test` passes