### PR TITLE
chore(lib): reduce pub visibility to pub(crate) and fix warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Do not add error handling, fallbacks, or validation for scenarios that cannot ha
 - Handle errors explicitly at system boundaries
 - No magic numbers; use named constants
 - Documentation describes current state, not development history - avoid changelog-style language that will become stale
+- Prefer minimal visibility: use `pub(crate)` or private over `pub` unless the item is part of the public API
 
 ### Type Safety
 

--- a/src/lib/brand/emulator/command.rs
+++ b/src/lib/brand/emulator/command.rs
@@ -6,12 +6,12 @@ use crate::radar::{RadarError, RadarInfo};
 
 /// Command sender for the emulator radar.
 /// Since this is a simulated radar, most commands are just logged.
-pub struct Command {
+pub(crate) struct Command {
     key: String,
 }
 
 impl Command {
-    pub fn new(info: RadarInfo) -> Self {
+    pub(crate) fn new(info: RadarInfo) -> Self {
         Command { key: info.key() }
     }
 }

--- a/src/lib/brand/emulator/mod.rs
+++ b/src/lib/brand/emulator/mod.rs
@@ -66,7 +66,7 @@ pub(super) fn new(_args: &Cli, _addresses: &mut Vec<LocatorAddress>) {
 }
 
 /// Create the emulator radar directly (called from locator when --emulator is set)
-pub fn create_emulator_radar(args: &Cli, radars: &SharedRadars, subsys: &SubsystemHandle) {
+pub(crate) fn create_emulator_radar(args: &Cli, radars: &SharedRadars, subsys: &SubsystemHandle) {
     log::info!("create_emulator_radar called");
 
     // Check if we already have an emulator radar

--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -22,7 +22,7 @@ const SPOKES_PER_BATCH: usize = 32; // Like Navico
 const KNOTS_TO_MS: f64 = 1852.0 / 3600.0;
 const DEG_TO_RAD: f64 = PI / 180.0;
 
-pub struct EmulatorReportReceiver {
+pub(crate) struct EmulatorReportReceiver {
     common: CommonRadar,
     command_sender: Option<Command>,
 
@@ -45,7 +45,7 @@ pub struct EmulatorReportReceiver {
 }
 
 impl EmulatorReportReceiver {
-    pub fn new(args: &Cli, info: RadarInfo, radars: SharedRadars) -> Self {
+    pub(crate) fn new(args: &Cli, info: RadarInfo, radars: SharedRadars) -> Self {
         let key = info.key();
 
         log::debug!("{}: Creating EmulatorReportReceiver", key);

--- a/src/lib/brand/emulator/settings.rs
+++ b/src/lib/brand/emulator/settings.rs
@@ -8,7 +8,7 @@ use crate::radar::settings::{
 use crate::radar::units::Units;
 use crate::stream::SignalKDelta;
 
-pub fn new(
+pub(crate) fn new(
     radar_id: String,
     sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
     args: &Cli,

--- a/src/lib/brand/emulator/world.rs
+++ b/src/lib/brand/emulator/world.rs
@@ -36,11 +36,11 @@ const KNOTS_TO_MS: f64 = 1852.0 / 3600.0; // 1 knot = 1852m/h = 0.5144 m/s
 const DEG_TO_RAD: f64 = PI / 180.0;
 
 /// Radius of the half-circle turn when reversing course (meters)
-pub const TURN_RADIUS: f64 = 100.0;
+pub(crate) const TURN_RADIUS: f64 = 100.0;
 
 /// Progress state for a half-circle turn maneuver
 #[derive(Clone, Debug)]
-pub struct TurnProgress {
+pub(crate) struct TurnProgress {
     /// Center of the turning circle
     pub center: GeoPosition,
     /// Turn radius in meters
@@ -57,7 +57,7 @@ pub struct TurnProgress {
 
 /// A moving target (boat)
 #[derive(Clone, Debug)]
-pub struct Target {
+pub(crate) struct Target {
     /// Current position
     pub position: GeoPosition,
     /// Heading in degrees (0 = North, 90 = East)
@@ -115,7 +115,7 @@ impl Target {
     }
 
     /// Start a port (counterclockwise) half-circle turn
-    pub fn start_port_turn(&mut self, radius: f64) {
+    pub(crate) fn start_port_turn(&mut self, radius: f64) {
         let heading_rad = self.heading * DEG_TO_RAD;
         // Port (left) direction is heading - π/2
         let center_bearing = heading_rad - PI / 2.0;
@@ -136,7 +136,7 @@ impl Target {
 
 /// A static buoy (small radar target)
 #[derive(Clone, Debug)]
-pub struct Buoy {
+pub(crate) struct Buoy {
     /// Position of the buoy
     pub position: GeoPosition,
     /// Radar return radius in meters (typically small, ~5m)
@@ -151,7 +151,7 @@ impl Buoy {
 
 /// A target moving in a circle
 #[derive(Clone, Debug)]
-pub struct CirclingTarget {
+pub(crate) struct CirclingTarget {
     /// Center of the circular path
     pub center: GeoPosition,
     /// Radius of the circular path in meters
@@ -218,7 +218,7 @@ impl CirclingTarget {
 
 /// Land area (stationary oblong)
 #[derive(Clone, Debug)]
-pub struct LandArea {
+pub(crate) struct LandArea {
     /// Center position
     pub center: GeoPosition,
     /// Half-width (perpendicular to orientation)
@@ -258,7 +258,7 @@ impl LandArea {
 }
 
 /// Cached local coordinates for efficient per-spoke lookups
-pub struct LocalCache {
+pub(crate) struct LocalCache {
     /// Land center in local coords
     land_center: (f64, f64),
     /// Target positions in local coords
@@ -274,7 +274,7 @@ pub struct LocalCache {
 }
 
 /// The simulated world
-pub struct EmulatorWorld {
+pub(crate) struct EmulatorWorld {
     /// Land area (fixed position)
     pub land: LandArea,
     /// Moving targets (east-moving boats)
@@ -292,7 +292,7 @@ pub struct EmulatorWorld {
 }
 
 impl EmulatorWorld {
-    pub fn new(initial_boat_pos: GeoPosition) -> Self {
+    pub(crate) fn new(initial_boat_pos: GeoPosition) -> Self {
         // Create land area 700m south, directly south of initial position
         let south_bearing = 180.0 * DEG_TO_RAD;
         let west_bearing = 270.0 * DEG_TO_RAD;
@@ -393,7 +393,7 @@ impl EmulatorWorld {
     }
 
     /// Update all moving objects based on elapsed time
-    pub fn update(&mut self, elapsed_secs: f64) {
+    pub(crate) fn update(&mut self, elapsed_secs: f64) {
         for target in &mut self.targets {
             target.update(elapsed_secs);
         }
@@ -409,7 +409,7 @@ impl EmulatorWorld {
     }
 
     /// Initiate port (counterclockwise) half-circle turns for all linear targets
-    pub fn reverse_all_targets(&mut self, radius: f64) {
+    pub(crate) fn reverse_all_targets(&mut self, radius: f64) {
         for target in &mut self.targets {
             target.start_port_turn(radius);
         }
@@ -423,7 +423,7 @@ impl EmulatorWorld {
     }
 
     /// Count how many targets are within the given range of the boat
-    pub fn count_visible_targets(&self, boat_pos: &GeoPosition, max_range: f64) -> usize {
+    pub(crate) fn count_visible_targets(&self, boat_pos: &GeoPosition, max_range: f64) -> usize {
         let max_range_sq = max_range * max_range;
         let meters_per_degree_lat: f64 = 111_320.0;
         let lat_rad = boat_pos.lat().to_radians();
@@ -459,7 +459,7 @@ impl EmulatorWorld {
 
     /// Update the local coordinate cache for the current boat position
     /// Call once per spoke batch before generating spokes
-    pub fn update_cache(&mut self, boat_pos: &GeoPosition) {
+    pub(crate) fn update_cache(&mut self, boat_pos: &GeoPosition) {
         const METERS_PER_DEGREE_LAT: f64 = 111_320.0;
 
         let lat_rad = boat_pos.lat().to_radians();
@@ -504,7 +504,7 @@ impl EmulatorWorld {
     /// sin_b, cos_b are precomputed sin/cos of bearing
     /// Returns 0-15 intensity value (0 = no return, 15 = strongest)
     #[inline]
-    pub fn get_intensity_fast(&self, sin_b: f64, cos_b: f64, distance: f64) -> u8 {
+    pub(crate) fn get_intensity_fast(&self, sin_b: f64, cos_b: f64, distance: f64) -> u8 {
         let cache = match &self.cache {
             Some(c) => c,
             None => return 0,
@@ -585,7 +585,7 @@ impl EmulatorWorld {
 
     /// Get the radar return intensity at a given position (legacy method)
     #[allow(dead_code)]
-    pub fn get_intensity(&self, _boat_pos: &GeoPosition, bearing_rad: f64, distance: f64) -> u8 {
+    pub(crate) fn get_intensity(&self, _boat_pos: &GeoPosition, bearing_rad: f64, distance: f64) -> u8 {
         self.get_intensity_fast(bearing_rad.sin(), bearing_rad.cos(), distance)
     }
 }

--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -27,7 +27,7 @@ pub(crate) struct Command {
 }
 
 impl Command {
-    pub fn new(info: &RadarInfo, has_dual_range: bool) -> Self {
+    pub(crate) fn new(info: &RadarInfo, has_dual_range: bool) -> Self {
         Command {
             key: info.key(),
             write: None,
@@ -38,11 +38,11 @@ impl Command {
         }
     }
 
-    pub fn set_writer(&mut self, write: WriteHalf<TcpStream>) {
+    pub(crate) fn set_writer(&mut self, write: WriteHalf<TcpStream>) {
         self.write = Some(write);
     }
 
-    pub fn set_ranges(&mut self, ranges: Ranges) {
+    pub(crate) fn set_ranges(&mut self, ranges: Ranges) {
         self.ranges = ranges;
     }
 

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 // =============================================================================
 
 /// Total number of spokes per revolution (13-bit angle, 0–8191).
-pub const SPOKES: usize = 8192;
+pub(crate) const SPOKES: usize = 8192;
 
 /// Maximum spoke length in pixels delivered to the GUI.
 ///
@@ -42,7 +42,7 @@ pub const SPOKES: usize = 8192;
 /// reports 884). Shorter native spokes are stretched to this size by
 /// `stretch_spoke` so the inner/outer scale stays consistent. 1024 is a
 /// round upper bound that accommodates all known Furuno models.
-pub const SPOKE_LEN: usize = 1024;
+pub(crate) const SPOKE_LEN: usize = 1024;
 
 /// Number of echo intensity levels in the palette.
 ///
@@ -51,33 +51,33 @@ pub const SPOKE_LEN: usize = 1024;
 /// to the palette — no shift, no gain. The `default_legend()` function may
 /// cap the effective palette size if reserved slots (ARPA, Doppler, history)
 /// would push the total beyond 255.
-pub const PIXEL_VALUES: u8 = 252;
+pub(crate) const PIXEL_VALUES: u8 = 252;
 
 // =============================================================================
 // Network — ports and addresses
 // =============================================================================
 
 /// Base port for all Furuno NavNet services.
-pub const BASE_PORT: u16 = 10000;
+pub(crate) const BASE_PORT: u16 = 10000;
 
 /// UDP beacon discovery port (`BASE_PORT + 10`).
-pub const BEACON_PORT: u16 = BASE_PORT + 10;
+pub(crate) const BEACON_PORT: u16 = BASE_PORT + 10;
 
 /// UDP spoke echo data port (`BASE_PORT + 24`).
-pub const DATA_PORT: u16 = BASE_PORT + 24;
+pub(crate) const DATA_PORT: u16 = BASE_PORT + 24;
 
 /// Broadcast address for beacon discovery.
-pub const BEACON_ADDRESS: SocketAddr = SocketAddr::new(
+pub(crate) const BEACON_ADDRESS: SocketAddr = SocketAddr::new(
     IpAddr::V4(Ipv4Addr::new(172, 31, 255, 255)),
     BEACON_PORT,
 );
 
 /// Broadcast address for spoke echo data (used by DRS4W WiFi radar).
-pub const DATA_BROADCAST_ADDRESS: SocketAddrV4 =
+pub(crate) const DATA_BROADCAST_ADDRESS: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::new(172, 31, 255, 255), DATA_PORT);
 
 /// Multicast address for spoke echo data (used by wired DRS/NXT/FAR models).
-pub const SPOKE_DATA_MULTICAST_ADDRESS: SocketAddrV4 =
+pub(crate) const SPOKE_DATA_MULTICAST_ADDRESS: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::new(239, 255, 0, 2), DATA_PORT);
 
 // =============================================================================
@@ -86,46 +86,46 @@ pub const SPOKE_DATA_MULTICAST_ADDRESS: SocketAddrV4 =
 
 /// 32-byte packet announcing this software to the radar.
 /// Contains embedded ASCII `"MAYARA"` at bytes 16–21.
-pub const ANNOUNCE_MAYARA_PACKET: [u8; 32] = [
+pub(crate) const ANNOUNCE_MAYARA_PACKET: [u8; 32] = [
     0x1, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x18, 0x1, 0x0, 0x0, 0x0, b'M', b'A',
     b'Y', b'A', b'R', b'A', 0x0, 0x0, 0x1, 0x1, 0x0, 0x2, 0x0, 0x1, 0x0, 0x12,
 ];
 
 /// 16-byte beacon request packet. Byte 8 = `0x01` (beacon request type).
-pub const REQUEST_BEACON_PACKET: [u8; 16] = [
+pub(crate) const REQUEST_BEACON_PACKET: [u8; 16] = [
     0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x08, 0x01, 0x00, 0x00,
     0x00,
 ];
 
 /// 16-byte model request packet. Byte 8 = `0x14` (model request type).
-pub const REQUEST_MODEL_PACKET: [u8; 16] = [
+pub(crate) const REQUEST_MODEL_PACKET: [u8; 16] = [
     0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x14, 0x01, 0x00, 0x08, 0x01, 0x00, 0x00,
     0x00,
 ];
 
 /// Expected header bytes in the 32-byte beacon report (bytes 0–10).
-pub const BEACON_REPORT_HEADER: [u8; 11] =
+pub(crate) const BEACON_REPORT_HEADER: [u8; 11] =
     [0x1, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0];
 
 /// Minimum beacon report size (= `size_of::<FurunoRadarReport>()`).
-pub const BEACON_REPORT_LENGTH_MIN: usize = std::mem::size_of::<FurunoRadarReport>();
+pub(crate) const BEACON_REPORT_LENGTH_MIN: usize = std::mem::size_of::<FurunoRadarReport>();
 
 /// Fixed length of the 170-byte model report.
-pub const MODEL_REPORT_LENGTH: usize = 170;
+pub(crate) const MODEL_REPORT_LENGTH: usize = 170;
 
 // =============================================================================
 // Login protocol
 // =============================================================================
 
 /// TCP connect / read / write timeout for the COPYRIGHT login handshake.
-pub const LOGIN_TIMEOUT: Duration = Duration::from_millis(500);
+pub(crate) const LOGIN_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// 56-byte login message sent via TCP to port 10010.
 ///
 /// From `fnet.dll` function `login_via_copyright`. Byte 9 selects the service
 /// (1 = Radar). The embedded ASCII payload starting at byte 12 reads:
 /// `"COPYRIGHT (C) 2001 FURUNO ELECTRIC CO.,LTD. "`.
-pub const LOGIN_MESSAGE: [u8; 56] = [
+pub(crate) const LOGIN_MESSAGE: [u8; 56] = [
     //                                              v- byte 9: service ID (1=Radar)
     0x8, 0x1, 0x0, 0x38, 0x1, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x43, 0x4f, 0x50, 0x59, 0x52,
     0x49, 0x47, 0x48, 0x54, 0x20, 0x28, 0x43, 0x29, 0x20, 0x32, 0x30, 0x30, 0x31, 0x20, 0x46,
@@ -135,7 +135,7 @@ pub const LOGIN_MESSAGE: [u8; 56] = [
 
 /// Expected 8-byte reply header from the radar after sending [`LOGIN_MESSAGE`].
 /// The 4 bytes following this header contain the big-endian port offset.
-pub const LOGIN_EXPECTED_HEADER: [u8; 8] = [0x9, 0x1, 0x0, 0xc, 0x1, 0x0, 0x0, 0x0];
+pub(crate) const LOGIN_EXPECTED_HEADER: [u8; 8] = [0x9, 0x1, 0x0, 0xc, 0x1, 0x0, 0x0, 0x0];
 
 // =============================================================================
 // Wire-format report structures
@@ -156,7 +156,7 @@ pub const LOGIN_EXPECTED_HEADER: [u8; 8] = [0x9, 0x1, 0x0, 0xc, 0x1, 0x0, 0x0, 0
 /// 32-byte beacon report — radar serial/name identification.
 #[derive(Deserialize, Debug, Copy, Clone)]
 #[repr(packed)]
-pub struct FurunoRadarReport {
+pub(crate) struct FurunoRadarReport {
     pub _header: [u8; 11],
     pub length: u8,
     pub _filler2: [u8; 4],
@@ -166,7 +166,7 @@ pub struct FurunoRadarReport {
 /// 170-byte model report — radar model name, firmware versions, serial number.
 #[derive(Deserialize, Debug, Copy, Clone)]
 #[repr(packed)]
-pub struct FurunoRadarModelReport {
+pub(crate) struct FurunoRadarModelReport {
     pub _filler1: [u8; 24],
     pub model: [u8; 32],
     pub _firmware_versions: [u8; 32],
@@ -181,7 +181,7 @@ pub struct FurunoRadarModelReport {
 
 /// All known Furuno radar models.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub enum RadarModel {
+pub(crate) enum RadarModel {
     Unknown,
     FAR21x7,
     DRS,
@@ -226,7 +226,7 @@ impl RadarModel {
     /// [`RadarModel`]. Returns [`RadarModel::Unknown`] for unrecognized codes.
     ///
     /// Source: `Fec.Wrapper.SensorProperty.GetRadarSensorType` (TimeZero).
-    pub fn from_part_number(part: &str) -> RadarModel {
+    pub(crate) fn from_part_number(part: &str) -> RadarModel {
         match part {
             "0359235" => RadarModel::DRS,
             "0359255" => RadarModel::FAR14x7,
@@ -307,7 +307,7 @@ impl RadarModel {
 // =============================================================================
 
 /// ASCII mode character prefixing every NavNet command.
-pub enum CommandMode {
+pub(crate) enum CommandMode {
     /// `'S'` — Set (write a control value).
     Set,
     /// `'R'` — Request (read a control value).
@@ -323,7 +323,7 @@ pub enum CommandMode {
 }
 
 impl CommandMode {
-    pub fn to_char(&self) -> char {
+    pub(crate) fn to_char(&self) -> char {
         match self {
             CommandMode::Set => 'S',
             CommandMode::Request => 'R',
@@ -355,7 +355,7 @@ impl From<u8> for CommandMode {
 
 /// Two-digit hex opcode following the mode character in `$<mode><hex>,...`.
 #[derive(Primitive, PartialEq, Eq, Debug, Clone)]
-pub enum CommandId {
+pub(crate) enum CommandId {
     /// `0x60` — Connection control.
     Connect = 0x60,
     /// `0x61` — Display mode.
@@ -479,10 +479,10 @@ pub enum CommandId {
 // =============================================================================
 
 /// Wire unit value for nautical miles.
-pub const WIRE_UNIT_NM: i32 = 0;
+pub(crate) const WIRE_UNIT_NM: i32 = 0;
 
 /// Wire unit value for kilometres.
-pub const WIRE_UNIT_KM: i32 = 1;
+pub(crate) const WIRE_UNIT_KM: i32 = 1;
 // Wire unit 2 = SM (statute miles), 3 = Kyd (kilo-yards) — not yet implemented
 
 /// Wire index → meters mapping (NM mode, wire unit 0).
@@ -490,7 +490,7 @@ pub const WIRE_UNIT_KM: i32 = 1;
 /// Wire indices are **non-sequential**. The radar uses specific slot numbers
 /// that do not correspond to a sorted range order. Verified via Wireshark
 /// captures from TimeZero ↔ DRS4D-NXT.
-pub const WIRE_INDEX_TABLE: [(i32, i32); 22] = [
+pub(crate) const WIRE_INDEX_TABLE: [(i32, i32); 22] = [
     (21, 116),    // 1/16 nm = 116m - wire index 21!
     (0, 231),     // 1/8 nm = 231m
     (1, 463),     // 1/4 nm = 463m
@@ -517,7 +517,7 @@ pub const WIRE_INDEX_TABLE: [(i32, i32); 22] = [
 
 /// Wire index → meters mapping (km mode, wire unit 1).
 /// Wire index 21 (0.0625 km) is **not** available in km mode.
-pub const WIRE_INDEX_TABLE_KM: [(i32, i32); 21] = [
+pub(crate) const WIRE_INDEX_TABLE_KM: [(i32, i32); 21] = [
     (0, 125),     // 0.125 km
     (1, 250),     // 0.25 km
     (2, 500),     // 0.5 km
@@ -542,17 +542,17 @@ pub const WIRE_INDEX_TABLE_KM: [(i32, i32); 21] = [
 ];
 
 /// Convert meters to the nearest wire index (NM table).
-pub fn meters_to_wire_index(meters: i32) -> i32 {
+pub(crate) fn meters_to_wire_index(meters: i32) -> i32 {
     lookup_wire_index(&WIRE_INDEX_TABLE, meters)
 }
 
 /// Convert meters to the nearest wire index (km table).
-pub fn meters_to_wire_index_km(meters: i32) -> i32 {
+pub(crate) fn meters_to_wire_index_km(meters: i32) -> i32 {
     lookup_wire_index(&WIRE_INDEX_TABLE_KM, meters)
 }
 
 /// Convert meters to the nearest wire index for the given wire unit.
-pub fn meters_to_wire_index_for_unit(meters: i32, wire_unit: i32) -> i32 {
+pub(crate) fn meters_to_wire_index_for_unit(meters: i32, wire_unit: i32) -> i32 {
     match wire_unit {
         WIRE_UNIT_KM => meters_to_wire_index_km(meters),
         _ => meters_to_wire_index(meters),
@@ -568,7 +568,7 @@ fn lookup_wire_index(table: &[(i32, i32)], meters: i32) -> i32 {
 }
 
 /// Convert a wire index to meters (NM table).
-pub fn wire_index_to_meters(wire_index: i32) -> Option<i32> {
+pub(crate) fn wire_index_to_meters(wire_index: i32) -> Option<i32> {
     WIRE_INDEX_TABLE
         .iter()
         .find(|(idx, _)| *idx == wire_index)
@@ -576,7 +576,7 @@ pub fn wire_index_to_meters(wire_index: i32) -> Option<i32> {
 }
 
 /// Convert a wire index to meters (km table).
-pub fn wire_index_to_meters_km(wire_index: i32) -> Option<i32> {
+pub(crate) fn wire_index_to_meters_km(wire_index: i32) -> Option<i32> {
     WIRE_INDEX_TABLE_KM
         .iter()
         .find(|(idx, _)| *idx == wire_index)
@@ -584,7 +584,7 @@ pub fn wire_index_to_meters_km(wire_index: i32) -> Option<i32> {
 }
 
 /// Convert a wire index to meters for the given wire unit.
-pub fn wire_index_to_meters_for_unit(wire_index: i32, wire_unit: i32) -> Option<i32> {
+pub(crate) fn wire_index_to_meters_for_unit(wire_index: i32, wire_unit: i32) -> Option<i32> {
     match wire_unit {
         WIRE_UNIT_KM => wire_index_to_meters_km(wire_index),
         _ => wire_index_to_meters(wire_index),
@@ -593,7 +593,7 @@ pub fn wire_index_to_meters_for_unit(wire_index: i32, wire_unit: i32) -> Option<
 
 /// Determine the wire unit for a range value in meters.
 /// Metric distances (km-based) use wire unit 1, nautical use wire unit 0.
-pub fn wire_unit_for_meters(meters: i32) -> i32 {
+pub(crate) fn wire_unit_for_meters(meters: i32) -> i32 {
     if WIRE_INDEX_TABLE_KM.iter().any(|(_, m)| *m == meters) {
         if crate::radar::range::Range::is_metric_distance(meters) {
             return WIRE_UNIT_KM;
@@ -623,73 +623,73 @@ pub fn wire_unit_for_meters(meters: i32) -> i32 {
 //          bits 4-5: echo_type; bit 6: dual_range_id; bit 7: unknown
 
 /// Byte 0 of every IMO echo frame must be this value.
-pub const FRAME_MAGIC: u8 = 0x02;
+pub(crate) const FRAME_MAGIC: u8 = 0x02;
 
 /// Byte 9 bit 0: high bit of `spoke_data_len`.
-pub const FRAME_SPOKE_DATA_LEN_HIGH_BIT: u8 = 0x01;
+pub(crate) const FRAME_SPOKE_DATA_LEN_HIGH_BIT: u8 = 0x01;
 
 /// Byte 11 bits 0–2: high bits of `sweep_len` (sample_count).
-pub const FRAME_SWEEP_LEN_HIGH_MASK: u8 = 0x07;
+pub(crate) const FRAME_SWEEP_LEN_HIGH_MASK: u8 = 0x07;
 
 /// Byte 11 bits 3–4: encoding mode (0–3).
-pub const FRAME_ENCODING_MASK: u8 = 0x18;
+pub(crate) const FRAME_ENCODING_MASK: u8 = 0x18;
 
 /// Right-shift for encoding mode extraction from byte 11.
-pub const FRAME_ENCODING_SHIFT: u8 = 3;
+pub(crate) const FRAME_ENCODING_SHIFT: u8 = 3;
 
 /// Byte 11 bit 5: heading data present in per-spoke sub-header.
-pub const FRAME_HEADING_VALID_BIT: u8 = 0x20;
+pub(crate) const FRAME_HEADING_VALID_BIT: u8 = 0x20;
 
 /// Byte 12 bits 0–5: range wire index.
-pub const FRAME_WIRE_INDEX_MASK: u8 = 0x3F;
+pub(crate) const FRAME_WIRE_INDEX_MASK: u8 = 0x3F;
 
 /// Byte 15 bits 0–2: high bits of `scale`.
-pub const FRAME_SCALE_HIGH_MASK: u8 = 0x07;
+pub(crate) const FRAME_SCALE_HIGH_MASK: u8 = 0x07;
 
 /// Byte 15 bit 6: dual range identifier (0 = Range A, 1 = Range B).
-pub const FRAME_DUAL_RANGE_BIT: u8 = 0x40;
+pub(crate) const FRAME_DUAL_RANGE_BIT: u8 = 0x40;
 
 /// Per-spoke sub-header: bits 0–4 of angle/heading byte 1 or 3.
-pub const SPOKE_ANGLE_HIGH_MASK: u8 = 0x1F;
+pub(crate) const SPOKE_ANGLE_HIGH_MASK: u8 = 0x1F;
 
 // =============================================================================
 // Spoke encoding constants
 // =============================================================================
 
 /// Encoding modes 1/2: a zero repeat count means 128.
-pub const ENCODING_1_REPEAT_DEFAULT: usize = 0x80;
+pub(crate) const ENCODING_1_REPEAT_DEFAULT: usize = 0x80;
 
 /// Encoding mode 3: a zero repeat count means 64.
-pub const ENCODING_3_REPEAT_DEFAULT: usize = 0x40;
+pub(crate) const ENCODING_3_REPEAT_DEFAULT: usize = 0x40;
 
 /// Bitmask for rounding consumed bytes up to 4-byte alignment:
 /// `used = (used + 3) & SPOKE_ALIGNMENT_MASK`.
-pub const SPOKE_ALIGNMENT_MASK: usize = !3;
+pub(crate) const SPOKE_ALIGNMENT_MASK: usize = !3;
 
 /// Minimum palette index for non-zero echo values. Skips the dimmest
 /// indices so weak returns are visually distinct from transparent black.
-pub const ECHO_FLOOR: u16 = 10;
+pub(crate) const ECHO_FLOOR: u16 = 10;
 
 // =============================================================================
 // Tile echo format (NXT only)
 // =============================================================================
 
 /// Bits 29-31 of the first header word must equal this value for a Tile frame.
-pub const TILE_MAGIC: u32 = 2;
+pub(crate) const TILE_MAGIC: u32 = 2;
 
 /// Tile echo format uses a hardcoded scale of 496 at all ranges.
 /// From `DecodeTileEchoFormat` in libNAVNETDLL.so (Ghidra decompilation).
-pub const TILE_SCALE: u32 = 496;
+pub(crate) const TILE_SCALE: u32 = 496;
 
 /// Tile RLE: a zero repeat count (low 7 bits) means 128 repeats.
-pub const TILE_REPEAT_DEFAULT: usize = 128;
+pub(crate) const TILE_REPEAT_DEFAULT: usize = 128;
 
 // =============================================================================
 // Guard zone constants
 // =============================================================================
 
 /// Guard mode value: zone disabled.
-pub const GUARD_MODE_OFF: i32 = 0;
+pub(crate) const GUARD_MODE_OFF: i32 = 0;
 
 /// Guard mode value: fan (sector) zone.
-pub const GUARD_MODE_FAN: i32 = 1;
+pub(crate) const GUARD_MODE_FAN: i32 = 1;

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -54,7 +54,7 @@ struct FurunoSpokeMetadata {
     scale: u32,
 }
 
-pub struct FurunoReportReceiver {
+pub(crate) struct FurunoReportReceiver {
     common: CommonRadar,
     /// Second CommonRadar for Range B in dual range mode.
     common_b: Option<CommonRadar>,
@@ -83,7 +83,7 @@ pub struct FurunoReportReceiver {
 }
 
 impl FurunoReportReceiver {
-    pub fn new(args: &Cli, radars: SharedRadars, info: RadarInfo) -> FurunoReportReceiver {
+    pub(crate) fn new(args: &Cli, radars: SharedRadars, info: RadarInfo) -> FurunoReportReceiver {
         let key = info.key();
         let command_sender = if args.is_replay() {
             None
@@ -134,7 +134,7 @@ impl FurunoReportReceiver {
     }
 
     /// Set the Range B RadarInfo for dual range mode.
-    pub fn set_range_b(&mut self, args: &Cli, radars: &SharedRadars, info_b: RadarInfo) {
+    pub(crate) fn set_range_b(&mut self, args: &Cli, radars: &SharedRadars, info_b: RadarInfo) {
         let key_b = info_b.key();
         let control_update_rx_b = info_b.control_update_subscribe();
         let blob_tx_b = radars.get_blob_tx();

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::protocol::RadarModel;
 
-pub fn new(
+pub(crate) fn new(
     radar_id: String,
     sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
     args: &Cli,
@@ -216,7 +216,7 @@ fn capabilities(model: &RadarModel) -> Capabilities {
     }
 }
 
-pub fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, version: &str) {
+pub(crate) fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, version: &str) {
     let model_name = model.to_string();
     log::debug!("update_when_model_known: {}", model_name);
     info.controls.set_model_name(model_name.to_string());

--- a/src/lib/brand/garmin/capabilities.rs
+++ b/src/lib/brand/garmin/capabilities.rs
@@ -31,101 +31,101 @@ const CAP_BODY_TOTAL_LEN: usize = CAP_BODY_FIRST_WORD_OFFSET + CAP_WORDS * 8;
 /// used by the Garmin MFD; the multi-byte u64 layout is hidden inside
 /// [`GarminCapabilities::has`].
 #[allow(non_camel_case_types)]
-pub mod cap {
+pub(crate) mod cap {
     // ---- Operational ----
-    pub const RANGE_MODE: u32 = 0x02;
-    pub const RANGE_MODE_TOGGLE: u32 = 0x09;
-    pub const RPM_MODE: u32 = 0x0c;
-    pub const TRANSMIT_MODE: u32 = 0x13;
-    pub const FRONT_OF_BOAT: u32 = 0x1c;
-    pub const PARK_POSITION: u32 = 0x1d;
-    pub const RESTORE_DEFAULTS: u32 = 0x20;
-    pub const NO_TX_ZONE_1_MODE: u32 = 0x21;
-    pub const NO_TX_ZONE_1_START: u32 = 0x22;
-    pub const NO_TX_ZONE_1_STOP: u32 = 0x23;
-    pub const SENTRY_MODE: u32 = 0x24;
-    pub const SENTRY_TRANSMIT_TIME: u32 = 0x28;
-    pub const SENTRY_STANDBY_TIME: u32 = 0x29;
-    pub const DITHER_MODE: u32 = 0x37;
-    pub const NOISE_BLANKER_MODE: u32 = 0x38;
+    pub(crate) const RANGE_MODE: u32 = 0x02;
+    pub(crate) const RANGE_MODE_TOGGLE: u32 = 0x09;
+    pub(crate) const RPM_MODE: u32 = 0x0c;
+    pub(crate) const TRANSMIT_MODE: u32 = 0x13;
+    pub(crate) const FRONT_OF_BOAT: u32 = 0x1c;
+    pub(crate) const PARK_POSITION: u32 = 0x1d;
+    pub(crate) const RESTORE_DEFAULTS: u32 = 0x20;
+    pub(crate) const NO_TX_ZONE_1_MODE: u32 = 0x21;
+    pub(crate) const NO_TX_ZONE_1_START: u32 = 0x22;
+    pub(crate) const NO_TX_ZONE_1_STOP: u32 = 0x23;
+    pub(crate) const SENTRY_MODE: u32 = 0x24;
+    pub(crate) const SENTRY_TRANSMIT_TIME: u32 = 0x28;
+    pub(crate) const SENTRY_STANDBY_TIME: u32 = 0x29;
+    pub(crate) const DITHER_MODE: u32 = 0x37;
+    pub(crate) const NOISE_BLANKER_MODE: u32 = 0x38;
 
     // ---- Range A ----
-    pub const RANGE_A: u32 = 0x4a;
-    pub const RANGE_A_GAIN_MODE: u32 = 0x4b;
-    pub const RANGE_A_GAIN: u32 = 0x4c;
-    pub const RANGE_A_RAIN_CONTROL: u32 = 0x4e;
-    pub const RANGE_A_RAIN_MODE: u32 = 0x4f;
-    pub const RANGE_A_RAIN_GAIN: u32 = 0x50;
-    pub const RANGE_A_SEA_MODE: u32 = 0x51;
-    pub const RANGE_A_SEA_STATE: u32 = 0x52;
-    pub const RANGE_A_SEA_GAIN: u32 = 0x53;
+    pub(crate) const RANGE_A: u32 = 0x4a;
+    pub(crate) const RANGE_A_GAIN_MODE: u32 = 0x4b;
+    pub(crate) const RANGE_A_GAIN: u32 = 0x4c;
+    pub(crate) const RANGE_A_RAIN_CONTROL: u32 = 0x4e;
+    pub(crate) const RANGE_A_RAIN_MODE: u32 = 0x4f;
+    pub(crate) const RANGE_A_RAIN_GAIN: u32 = 0x50;
+    pub(crate) const RANGE_A_SEA_MODE: u32 = 0x51;
+    pub(crate) const RANGE_A_SEA_STATE: u32 = 0x52;
+    pub(crate) const RANGE_A_SEA_GAIN: u32 = 0x53;
 
     // ---- Range B (dual range) ----
-    pub const RANGE_B: u32 = 0x56;
-    pub const RANGE_B_GAIN_MODE: u32 = 0x57;
-    pub const RANGE_B_GAIN: u32 = 0x58;
-    pub const RANGE_B_RAIN_CONTROL: u32 = 0x5a;
-    pub const RANGE_B_RAIN_MODE: u32 = 0x5b;
-    pub const RANGE_B_RAIN_GAIN: u32 = 0x5c;
-    pub const RANGE_B_SEA_MODE: u32 = 0x5d;
-    pub const RANGE_B_SEA_STATE: u32 = 0x5e;
-    pub const RANGE_B_SEA_GAIN: u32 = 0x5f;
+    pub(crate) const RANGE_B: u32 = 0x56;
+    pub(crate) const RANGE_B_GAIN_MODE: u32 = 0x57;
+    pub(crate) const RANGE_B_GAIN: u32 = 0x58;
+    pub(crate) const RANGE_B_RAIN_CONTROL: u32 = 0x5a;
+    pub(crate) const RANGE_B_RAIN_MODE: u32 = 0x5b;
+    pub(crate) const RANGE_B_RAIN_GAIN: u32 = 0x5c;
+    pub(crate) const RANGE_B_SEA_MODE: u32 = 0x5d;
+    pub(crate) const RANGE_B_SEA_STATE: u32 = 0x5e;
+    pub(crate) const RANGE_B_SEA_GAIN: u32 = 0x5f;
 
     // ---- AFC ----
-    pub const AFC_MODE: u32 = 0x61;
-    pub const AFC_SETTING: u32 = 0x62;
-    pub const AFC_COARSE: u32 = 0x65;
+    pub(crate) const AFC_MODE: u32 = 0x61;
+    pub(crate) const AFC_SETTING: u32 = 0x62;
+    pub(crate) const AFC_COARSE: u32 = 0x65;
 
     // ---- Hardware ----
-    pub const ANTENNA_SIZE: u32 = 0x9c;
+    pub(crate) const ANTENNA_SIZE: u32 = 0x9c;
 
     // ---- Doppler / MotionScope (Fantom) ----
-    pub const DOPPLER_RANGE_A: u32 = 0xa3;
-    pub const DOPPLER_RANGE_B: u32 = 0xa4;
-    pub const DOPPLER_SENSITIVITY_A: u32 = 0xc3;
-    pub const DOPPLER_SENSITIVITY_B: u32 = 0xc4;
+    pub(crate) const DOPPLER_RANGE_A: u32 = 0xa3;
+    pub(crate) const DOPPLER_RANGE_B: u32 = 0xa4;
+    pub(crate) const DOPPLER_SENSITIVITY_A: u32 = 0xc3;
+    pub(crate) const DOPPLER_SENSITIVITY_B: u32 = 0xc4;
 
     // ---- Echo trails (xHD2+ / Fantom) ----
-    pub const ECHO_TRAIL_MODE_A: u32 = 0xa6;
-    pub const ECHO_TRAIL_TIME_A: u32 = 0xa7;
-    pub const ECHO_TRAIL_MODE_B: u32 = 0xa8;
-    pub const ECHO_TRAIL_TIME_B: u32 = 0xa9;
+    pub(crate) const ECHO_TRAIL_MODE_A: u32 = 0xa6;
+    pub(crate) const ECHO_TRAIL_TIME_A: u32 = 0xa7;
+    pub(crate) const ECHO_TRAIL_MODE_B: u32 = 0xa8;
+    pub(crate) const ECHO_TRAIL_TIME_B: u32 = 0xa9;
 
     // ---- Pulse expansion (xHD2+) ----
-    pub const PULSE_EXPANSION_A: u32 = 0xab;
-    pub const PULSE_EXPANSION_B: u32 = 0xac;
+    pub(crate) const PULSE_EXPANSION_A: u32 = 0xab;
+    pub(crate) const PULSE_EXPANSION_B: u32 = 0xac;
 
     // ---- Transmit channel (Fantom Pro / Solid State) ----
-    pub const TRANSMIT_CHANNEL_MODE: u32 = 0xb2;
-    pub const TRANSMIT_CHANNEL_SELECT: u32 = 0xb5;
+    pub(crate) const TRANSMIT_CHANNEL_MODE: u32 = 0xb2;
+    pub(crate) const TRANSMIT_CHANNEL_SELECT: u32 = 0xb5;
 
     // ---- Target size (xHD2 / Fantom) ----
-    pub const TARGET_SIZE_MODE_A: u32 = 0xbd;
-    pub const TARGET_SIZE_MODE_B: u32 = 0xbe;
+    pub(crate) const TARGET_SIZE_MODE_A: u32 = 0xbd;
+    pub(crate) const TARGET_SIZE_MODE_B: u32 = 0xbe;
 
     // ---- Second no-transmit zone (Fantom Pro) ----
-    pub const NO_TX_ZONE_2_MODE: u32 = 0xbf;
-    pub const NO_TX_ZONE_2_START: u32 = 0xc0;
-    pub const NO_TX_ZONE_2_STOP: u32 = 0xc1;
+    pub(crate) const NO_TX_ZONE_2_MODE: u32 = 0xbf;
+    pub(crate) const NO_TX_ZONE_2_START: u32 = 0xc0;
+    pub(crate) const NO_TX_ZONE_2_STOP: u32 = 0xc1;
 
     // ---- Misc ----
-    pub const CROSSTALK_LEVEL: u32 = 0xc5;
-    pub const SCAN_AVERAGE_MODE_A: u32 = 0xca;
-    pub const SCAN_AVERAGE_MODE_B: u32 = 0xcb;
-    pub const SCAN_AVERAGE_SENSITIVITY_A: u32 = 0xcc;
-    pub const SCAN_AVERAGE_SENSITIVITY_B: u32 = 0xcd;
-    pub const POWER_SAVE_MODE: u32 = 0xd2;
+    pub(crate) const CROSSTALK_LEVEL: u32 = 0xc5;
+    pub(crate) const SCAN_AVERAGE_MODE_A: u32 = 0xca;
+    pub(crate) const SCAN_AVERAGE_MODE_B: u32 = 0xcb;
+    pub(crate) const SCAN_AVERAGE_SENSITIVITY_A: u32 = 0xcc;
+    pub(crate) const SCAN_AVERAGE_SENSITIVITY_B: u32 = 0xcd;
+    pub(crate) const POWER_SAVE_MODE: u32 = 0xd2;
 }
 
 /// 320-bit capability vector reported by Garmin xHD and newer radars.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct GarminCapabilities {
+pub(crate) struct GarminCapabilities {
     bits: [u64; CAP_WORDS],
 }
 
 impl GarminCapabilities {
     /// Construct an empty (no-features) capability vector.
-    pub const fn empty() -> Self {
+    pub(crate) const fn empty() -> Self {
         Self {
             bits: [0; CAP_WORDS],
         }
@@ -138,7 +138,7 @@ impl GarminCapabilities {
     /// matching the legacy feature footprint
     /// (single range, manual/auto gain, sea/rain clutter, no-TX zone 1,
     /// sentry mode, RPM mode toggle).
-    pub fn for_legacy_hd() -> Self {
+    pub(crate) fn for_legacy_hd() -> Self {
         let mut caps = Self::empty();
         for &bit in LEGACY_HD_BITS {
             caps.set(bit);
@@ -149,7 +149,7 @@ impl GarminCapabilities {
     /// Parse a `0x09B1` payload (the message body **as received from the
     /// network**, including the 8-byte capability-message header that
     /// precedes the five u64 words).
-    pub fn parse(payload: &[u8]) -> Option<Self> {
+    pub(crate) fn parse(payload: &[u8]) -> Option<Self> {
         if payload.len() < CAP_BODY_TOTAL_LEN {
             return None;
         }
@@ -163,7 +163,7 @@ impl GarminCapabilities {
 
     /// Look up a single capability bit. Returns `false` for unknown / out
     /// of range bits.
-    pub fn has(&self, bit: u32) -> bool {
+    pub(crate) fn has(&self, bit: u32) -> bool {
         let word = (bit / 64) as usize;
         let shift = bit % 64;
         if word >= CAP_WORDS {
@@ -190,64 +190,64 @@ impl GarminCapabilities {
     // group. These are the gates the settings module needs to decide which
     // controls to register.
 
-    pub fn has_dual_range(&self) -> bool {
+    pub(crate) fn has_dual_range(&self) -> bool {
         self.has(cap::RANGE_B)
     }
 
-    pub fn has_motionscope(&self) -> bool {
+    pub(crate) fn has_motionscope(&self) -> bool {
         self.has(cap::DOPPLER_RANGE_A) || self.has(cap::DOPPLER_RANGE_B)
     }
 
-    pub fn has_doppler_sensitivity(&self) -> bool {
+    pub(crate) fn has_doppler_sensitivity(&self) -> bool {
         self.has(cap::DOPPLER_SENSITIVITY_A) || self.has(cap::DOPPLER_SENSITIVITY_B)
     }
 
-    pub fn has_echo_trails(&self) -> bool {
+    pub(crate) fn has_echo_trails(&self) -> bool {
         self.has(cap::ECHO_TRAIL_MODE_A)
     }
 
-    pub fn has_pulse_expansion(&self) -> bool {
+    pub(crate) fn has_pulse_expansion(&self) -> bool {
         self.has(cap::PULSE_EXPANSION_A)
     }
 
-    pub fn has_target_size_mode(&self) -> bool {
+    pub(crate) fn has_target_size_mode(&self) -> bool {
         self.has(cap::TARGET_SIZE_MODE_A)
     }
 
-    pub fn has_no_tx_zone_1(&self) -> bool {
+    pub(crate) fn has_no_tx_zone_1(&self) -> bool {
         self.has(cap::NO_TX_ZONE_1_MODE)
     }
 
-    pub fn has_no_tx_zone_2(&self) -> bool {
+    pub(crate) fn has_no_tx_zone_2(&self) -> bool {
         self.has(cap::NO_TX_ZONE_2_MODE)
     }
 
-    pub fn has_sentry_mode(&self) -> bool {
+    pub(crate) fn has_sentry_mode(&self) -> bool {
         self.has(cap::SENTRY_MODE)
     }
 
-    pub fn has_afc(&self) -> bool {
+    pub(crate) fn has_afc(&self) -> bool {
         self.has(cap::AFC_MODE)
     }
 
-    pub fn has_open_array_antenna(&self) -> bool {
+    pub(crate) fn has_open_array_antenna(&self) -> bool {
         self.has(cap::ANTENNA_SIZE)
     }
 
-    pub fn has_scan_average(&self) -> bool {
+    pub(crate) fn has_scan_average(&self) -> bool {
         self.has(cap::SCAN_AVERAGE_MODE_A)
     }
 
-    pub fn has_power_save(&self) -> bool {
+    pub(crate) fn has_power_save(&self) -> bool {
         self.has(cap::POWER_SAVE_MODE)
     }
 
-    pub fn has_transmit_channel_select(&self) -> bool {
+    pub(crate) fn has_transmit_channel_select(&self) -> bool {
         self.has(cap::TRANSMIT_CHANNEL_MODE)
     }
 
     /// True if the radar reports any Fantom-class feature.
-    pub fn is_fantom(&self) -> bool {
+    pub(crate) fn is_fantom(&self) -> bool {
         self.has_motionscope() || self.has_doppler_sensitivity()
     }
 }

--- a/src/lib/brand/garmin/command.rs
+++ b/src/lib/brand/garmin/command.rs
@@ -13,7 +13,7 @@ use crate::radar::{DopplerMode, Power, RadarError};
 /// Garmin command sender. In dual-range mode each range gets its own
 /// `Command` instance — Range B's instance has `range_b = true` and
 /// sends Range B opcodes instead of Range A ones.
-pub struct Command {
+pub(crate) struct Command {
     radar_type: GarminRadarType,
     send_addr: SocketAddrV4,
     socket: Option<UdpSocket>,
@@ -21,7 +21,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn new(radar_type: GarminRadarType, send_addr: SocketAddrV4) -> Self {
+    pub(crate) fn new(radar_type: GarminRadarType, send_addr: SocketAddrV4) -> Self {
         Command {
             radar_type,
             send_addr,
@@ -30,7 +30,7 @@ impl Command {
         }
     }
 
-    pub fn new_range_b(radar_type: GarminRadarType, send_addr: SocketAddrV4) -> Self {
+    pub(crate) fn new_range_b(radar_type: GarminRadarType, send_addr: SocketAddrV4) -> Self {
         Command {
             radar_type,
             send_addr,

--- a/src/lib/brand/garmin/discovery.rs
+++ b/src/lib/brand/garmin/discovery.rs
@@ -46,7 +46,7 @@ const MIN_CDM_BODY_LEN: usize = 12;
 
 /// Decoded fields from a `0x038e` CDM heartbeat.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CdmHeartbeat {
+pub(crate) struct CdmHeartbeat {
     /// `version_marker` byte. Should always be `2` for V2 heartbeats.
     pub version: u8,
     /// 16-bit product identifier. Maps to a model via [`product_name`].
@@ -61,7 +61,7 @@ pub struct CdmHeartbeat {
 /// Parse the body of a `0x038e` heartbeat. `payload` must be the slice
 /// **after** the 8-byte GMN header. Returns `None` if the body is too
 /// short or has the wrong version marker.
-pub fn parse(payload: &[u8]) -> Option<CdmHeartbeat> {
+pub(crate) fn parse(payload: &[u8]) -> Option<CdmHeartbeat> {
     if payload.len() < MIN_CDM_BODY_LEN {
         return None;
     }
@@ -90,16 +90,16 @@ pub fn parse(payload: &[u8]) -> Option<CdmHeartbeat> {
 const MIN_PRODUCT_DATA_LEN: usize = 0x42;
 
 /// `0x0392` — CDM product data response.
-pub const MSG_CDM_PRODUCT_DATA: u32 = 0x0392;
+pub(crate) const MSG_CDM_PRODUCT_DATA: u32 = 0x0392;
 
 /// `0x0391` — CDM product data request. Sent as a GMN packet to the
 /// radar's IP on port 50050 to solicit a `0x0392` response containing
 /// the factory model name and user-customizable alias.
-pub const MSG_CDM_PRODUCT_DATA_REQUEST: u32 = 0x0391;
+pub(crate) const MSG_CDM_PRODUCT_DATA_REQUEST: u32 = 0x0391;
 
 /// Decoded fields from a `0x0392` product data response.
 #[derive(Debug, Clone)]
-pub struct CdmProductData {
+pub(crate) struct CdmProductData {
     /// Factory model name (e.g. "GMR Fantom 24"), up to 30 chars.
     pub device_name: String,
     /// User-customizable alias (e.g. "Bow Radar"), up to 31 chars.
@@ -108,7 +108,7 @@ pub struct CdmProductData {
 
 /// Parse the body of a `0x0392` product data response. `payload` is the
 /// slice after the 8-byte GMN header.
-pub fn parse_product_data(payload: &[u8]) -> Option<CdmProductData> {
+pub(crate) fn parse_product_data(payload: &[u8]) -> Option<CdmProductData> {
     if payload.len() < MIN_PRODUCT_DATA_LEN {
         return None;
     }
@@ -122,7 +122,7 @@ pub fn parse_product_data(payload: &[u8]) -> Option<CdmProductData> {
 
 /// Build a minimal `0x0391` request packet (just the 8-byte GMN header,
 /// no payload). The radar responds with a `0x0392` on the same port.
-pub fn build_product_data_request() -> [u8; 8] {
+pub(crate) fn build_product_data_request() -> [u8; 8] {
     let mut buf = [0u8; 8];
     buf[0..4].copy_from_slice(&MSG_CDM_PRODUCT_DATA_REQUEST.to_le_bytes());
     // payload_len = 0
@@ -132,14 +132,14 @@ pub fn build_product_data_request() -> [u8; 8] {
 /// `0x0393` — Set device alias. The MFD sends this to rename a device
 /// on the Garmin Marine Network. Payload: 30-byte alias string, NUL-padded.
 /// Sent to the device's IP on the CDM control port (50051).
-pub const MSG_CDM_SET_ALIAS: u32 = 0x0393;
+pub(crate) const MSG_CDM_SET_ALIAS: u32 = 0x0393;
 
 /// CDM control port used for alias-set and other CDM write operations.
-pub const CDM_CONTROL_PORT: u16 = 50051;
+pub(crate) const CDM_CONTROL_PORT: u16 = 50051;
 
 /// Build a `0x0393` set-alias packet. `alias` is truncated to 30 bytes
 /// and NUL-padded.
-pub fn build_set_alias(alias: &str) -> Vec<u8> {
+pub(crate) fn build_set_alias(alias: &str) -> Vec<u8> {
     let alias_bytes = alias.as_bytes();
     let copy_len = alias_bytes.len().min(30);
     let payload_len: u32 = 32; // 30 chars + 2 padding/null bytes
@@ -155,7 +155,7 @@ pub fn build_set_alias(alias: &str) -> Vec<u8> {
 /// Sourced from `research/garmin/radar-detection.md`. Returns `None`
 /// for unknown IDs (the caller should
 /// fall back to a generic "Garmin xHD" / "Garmin HD" label).
-pub fn product_name(product_id: u16) -> Option<&'static str> {
+pub(crate) fn product_name(product_id: u16) -> Option<&'static str> {
     Some(match product_id {
         0x010f => "GMR 18",
         0x0195 => "GMR 24 HD",

--- a/src/lib/brand/garmin/mod.rs
+++ b/src/lib/brand/garmin/mod.rs
@@ -54,7 +54,7 @@ const GARMIN_HD_RANGES_NAUTICAL: &[i32] = &[
 /// Supported Garmin radar types
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(dead_code)]
-pub enum GarminRadarType {
+pub(crate) enum GarminRadarType {
     /// Original HD radar: 720 spokes, 1-bit samples
     HD,
     /// xHD radar: 1440 spokes, 8-bit samples
@@ -82,7 +82,7 @@ impl Display for GarminRadarType {
 
 impl GarminRadarType {
     /// Returns the number of spokes per revolution for this radar type
-    pub fn spokes_per_revolution(&self) -> usize {
+    pub(crate) fn spokes_per_revolution(&self) -> usize {
         match self {
             GarminRadarType::HD => HD_SPOKES_PER_REVOLUTION,
             // Unsupported types default to enhanced protocol specs
@@ -91,7 +91,7 @@ impl GarminRadarType {
     }
 
     /// Returns the maximum spoke length for this radar type
-    pub fn max_spoke_len(&self) -> usize {
+    pub(crate) fn max_spoke_len(&self) -> usize {
         match self {
             GarminRadarType::HD => HD_MAX_SPOKE_LEN,
             _ => MAX_SPOKE_LEN,
@@ -99,7 +99,7 @@ impl GarminRadarType {
     }
 
     /// Returns the number of pixel values for this radar type
-    pub fn pixel_values(&self) -> u8 {
+    pub(crate) fn pixel_values(&self) -> u8 {
         match self {
             GarminRadarType::HD => HD_PIXEL_VALUES,
             _ => PIXEL_VALUES,
@@ -107,7 +107,7 @@ impl GarminRadarType {
     }
 
     /// Returns true if this radar type is currently supported
-    pub fn is_supported(&self) -> bool {
+    pub(crate) fn is_supported(&self) -> bool {
         matches!(self, GarminRadarType::HD | GarminRadarType::XHD)
     }
 }

--- a/src/lib/brand/garmin/protocol.rs
+++ b/src/lib/brand/garmin/protocol.rs
@@ -30,36 +30,36 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 /// Garmin radars live on the `172.16.0.0/12` subnet (netmask `255.240.0.0`).
 /// The radar in `garmin_xhd.pcap` advertises itself as `172.16.2.0` (yes, .0
 /// is a valid host address — Garmin uses /16 subnets).
-pub const GARMIN_NETMASK: Ipv4Addr = Ipv4Addr::new(255, 240, 0, 0);
+pub(crate) const GARMIN_NETMASK: Ipv4Addr = Ipv4Addr::new(255, 240, 0, 0);
 
 /// CDM (Common Device Model) heartbeat multicast group. The radar — and every
 /// other Garmin marine device — broadcasts a 34-byte `0x038e` "V2 heartbeat"
 /// here every 5 seconds, advertising its product ID and service IDs.
-pub const CDM_HEARTBEAT_ADDRESS: SocketAddr =
+pub(crate) const CDM_HEARTBEAT_ADDRESS: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(239, 254, 2, 2)), 50050);
 
 /// Settings/status report multicast group. The radar broadcasts ~80
 /// individual report messages per second here, one setting per packet.
-pub const REPORT_ADDRESS: SocketAddr =
+pub(crate) const REPORT_ADDRESS: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(239, 254, 2, 0)), REPORT_PORT);
 
 /// Spoke (sweep) data multicast group used by enhanced-protocol radars. Legacy
 /// HD radars send spoke data on `REPORT_ADDRESS` (port 50100) instead.
-pub const DATA_ADDRESS: SocketAddr =
+pub(crate) const DATA_ADDRESS: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(239, 254, 2, 0)), DATA_PORT);
 
 /// UDP port for the CDM heartbeat group (`0xC382`).
-pub const CDM_HEARTBEAT_PORT: u16 = 50050;
+pub(crate) const CDM_HEARTBEAT_PORT: u16 = 50050;
 
 /// UDP port for the radar settings/status report stream (`0xC3B4`).
-pub const REPORT_PORT: u16 = 50100;
+pub(crate) const REPORT_PORT: u16 = 50100;
 
 /// UDP port for unicast control commands sent from the MFD to the radar
 /// (`0xC3B5`). Commands are sent as UDP datagrams to `<radar_ip>:50101`.
-pub const COMMAND_PORT: u16 = 50101;
+pub(crate) const COMMAND_PORT: u16 = 50101;
 
 /// UDP port for the spoke (sweep) data stream (`0xC3B6`).
-pub const DATA_PORT: u16 = 50102;
+pub(crate) const DATA_PORT: u16 = 50102;
 
 // =============================================================================
 // Packet header
@@ -67,70 +67,70 @@ pub const DATA_PORT: u16 = 50102;
 
 /// Length of the GMN packet header in bytes. Every Garmin radar packet starts
 /// with: `[u32 LE packet_type][u32 LE payload_len]`.
-pub const GMN_HEADER_LEN: usize = 8;
+pub(crate) const GMN_HEADER_LEN: usize = 8;
 
 // =============================================================================
 // Spoke geometry — HD (legacy)
 // =============================================================================
 
 /// HD radars use 720 spokes per revolution (0.5° resolution).
-pub const HD_SPOKES_PER_REVOLUTION: usize = 720;
+pub(crate) const HD_SPOKES_PER_REVOLUTION: usize = 720;
 
 /// HD radars pack 1-bit binary samples, up to 2016 samples per spoke
 /// (252 bytes × 8 bits).
-pub const HD_MAX_SPOKE_LEN: usize = 2016;
+pub(crate) const HD_MAX_SPOKE_LEN: usize = 2016;
 
 /// HD spoke packet header is 52 bytes; samples follow at offset +52.
-pub const HD_SPOKE_HEADER_SIZE: usize = 52;
+pub(crate) const HD_SPOKE_HEADER_SIZE: usize = 52;
 
 /// HD packs **4 spokes per UDP packet** (the spoke index is `angle*2 + i`
 /// for `i ∈ 0..4`).
-pub const HD_SPOKES_PER_PACKET: usize = 4;
+pub(crate) const HD_SPOKES_PER_PACKET: usize = 4;
 
 /// HD has 1-bit binary data, expanded to 0 or 255 by the unpacker.
 /// `pixel_values` is the number of distinct intensity levels in the rendered
 /// spoke data — for HD that's just on/off.
-pub const HD_PIXEL_VALUES: u8 = 2;
+pub(crate) const HD_PIXEL_VALUES: u8 = 2;
 
 // =============================================================================
 // Spoke geometry — enhanced protocol
 // =============================================================================
 
 /// enhanced-protocol radars use 1440 spokes per revolution (0.25° resolution).
-pub const SPOKES_PER_REVOLUTION: usize = 1440;
+pub(crate) const SPOKES_PER_REVOLUTION: usize = 1440;
 
 /// enhanced-protocol radars use 8-bit grayscale samples, up to ~705 samples per spoke
 /// (from `radar_pi`'s `GARMIN_MAX_SPOKE_LEN`).
-pub const MAX_SPOKE_LEN: usize = 705;
+pub(crate) const MAX_SPOKE_LEN: usize = 705;
 
 /// Enhanced spoke packet header is 36 bytes; samples follow at offset +36.
 /// See `enhanced-radar-protocol.md` for the per-field layout.
-pub const SPOKE_HEADER_SIZE: usize = 36;
+pub(crate) const SPOKE_HEADER_SIZE: usize = 36;
 
 /// Wire offset of the range indicator byte in the spoke header.
 /// `0` = Range A, `1` = Range B. Corresponds to `payload[0x10]`
 /// = `wire_data[24]`.
-pub const SPOKE_RANGE_INDICATOR_OFFSET: usize = 24;
+pub(crate) const SPOKE_RANGE_INDICATOR_OFFSET: usize = 24;
 
 /// Enhanced protocol encodes spoke angles in **1/8 degree units**, so the wire angle ranges
 /// `0..11520` (= 1440 × 8). Divide by 8 to get the spoke index in `0..1440`.
-pub const ANGLE_UNITS_PER_SPOKE: u16 = 8;
+pub(crate) const ANGLE_UNITS_PER_SPOKE: u16 = 8;
 
 /// Enhanced protocol has 8-bit samples; mayara halves them to make room for legend / marker
 /// pixels in the rendered output (matching the Raymarine convention).
-pub const PIXEL_VALUES: u8 = 128;
+pub(crate) const PIXEL_VALUES: u8 = 128;
 
 /// First sample byte value in the Fantom MotionScope "approaching" band.
 /// Wire values 0xF0–0xF7 (240–247) encode approaching targets with 8
 /// intensity sub-levels.
-pub const DOPPLER_APPROACHING_START: u8 = 0xF0;
+pub(crate) const DOPPLER_APPROACHING_START: u8 = 0xF0;
 
 /// First sample byte value in the "receding" band (0xF8–0xFF, 248–255).
-pub const DOPPLER_RECEDING_START: u8 = 0xF8;
+pub(crate) const DOPPLER_RECEDING_START: u8 = 0xF8;
 
 /// Number of intensity sub-levels per Doppler direction on the wire (8),
 /// and per direction in the legend after the ÷2 halving (4).
-pub const DOPPLER_LEVELS_PER_DIRECTION: u8 = 4;
+pub(crate) const DOPPLER_LEVELS_PER_DIRECTION: u8 = 4;
 
 // =============================================================================
 // Encoding conventions
@@ -138,11 +138,11 @@ pub const DOPPLER_LEVELS_PER_DIRECTION: u8 = 4;
 
 /// Most enhanced-protocol angle fields (bearing alignment, no-TX zone start/stop, park
 /// position) are encoded as `int32 LE` in **degrees × 32**.
-pub const DEGREE_SCALE: i32 = 32;
+pub(crate) const DEGREE_SCALE: i32 = 32;
 
 /// Enhanced-protocol gain, sea, and rain levels are reported and accepted as `uint16 LE`
 /// in `0..=10000`, i.e. percent × 100.
-pub const GAIN_SCALE: u16 = 100;
+pub(crate) const GAIN_SCALE: u16 = 100;
 
 // =============================================================================
 // CDM discovery (`0x038e` heartbeat)
@@ -151,20 +151,20 @@ pub const GAIN_SCALE: u16 = 100;
 /// `0x038e` — CDM "V2 heartbeat" announcement. 26-byte payload sent to
 /// `239.254.2.2:50050` every 5 seconds. Carries `product_id`, service IDs,
 /// and an uptime/sequence counter.
-pub const MSG_CDM_HEARTBEAT: u32 = 0x038e;
+pub(crate) const MSG_CDM_HEARTBEAT: u32 = 0x038e;
 
 /// Offset (within the heartbeat payload, after the 8-byte GMN header) of the
 /// `version_marker` byte. Value `2` means "V2 heartbeat".
-pub const CDM_OFFSET_VERSION_MARKER: usize = 0;
+pub(crate) const CDM_OFFSET_VERSION_MARKER: usize = 0;
 
 /// Offset of the `product_id` u16 within the heartbeat payload.
-pub const CDM_OFFSET_PRODUCT_ID: usize = 2;
+pub(crate) const CDM_OFFSET_PRODUCT_ID: usize = 2;
 
 /// Offset of the `simulator_mode` byte within the heartbeat payload.
-pub const CDM_OFFSET_SIMULATOR_MODE: usize = 4;
+pub(crate) const CDM_OFFSET_SIMULATOR_MODE: usize = 4;
 
 /// Offset of the `product_subtype` byte within the heartbeat payload.
-pub const CDM_OFFSET_PRODUCT_SUBTYPE: usize = 5;
+pub(crate) const CDM_OFFSET_PRODUCT_SUBTYPE: usize = 5;
 
 // =============================================================================
 // Legacy HD message IDs (0x02xx)
@@ -173,72 +173,72 @@ pub const CDM_OFFSET_PRODUCT_SUBTYPE: usize = 5;
 // --- Status / report messages (radar → MFD) -------------------------------------
 
 /// `0x02A3` — HD spoke data (short form), 4 spokes packed per packet.
-pub const MSG_HD_SPOKE: u32 = 0x02a3;
+pub(crate) const MSG_HD_SPOKE: u32 = 0x02a3;
 
 /// `0x02A4` — HD AFC status update.
-pub const MSG_HD_AFC_STATUS: u32 = 0x02a4;
+pub(crate) const MSG_HD_AFC_STATUS: u32 = 0x02a4;
 
 /// `0x02A5` — HD radar state (state code, warmup countdown, range, gain,
 /// sea/rain clutter, bearing, crosstalk, scan speed). Sent periodically.
-pub const MSG_HD_STATE: u32 = 0x02a5;
+pub(crate) const MSG_HD_STATE: u32 = 0x02a5;
 
 /// `0x02A6` — HD scanner identification / version packet.
-pub const MSG_HD_SCANNER_ID: u32 = 0x02a6;
+pub(crate) const MSG_HD_SCANNER_ID: u32 = 0x02a6;
 
 /// `0x02A7` — HD composite settings report (~88 bytes). Triggered by
 /// sending `MSG_HD_REQUEST_SETTINGS` (`0x02EE`).
-pub const MSG_HD_SETTINGS: u32 = 0x02a7;
+pub(crate) const MSG_HD_SETTINGS: u32 = 0x02a7;
 
 /// `0x02AA` — HD cumulative transmit time (seconds).
-pub const MSG_HD_TRANSMIT_TIME: u32 = 0x02aa;
+pub(crate) const MSG_HD_TRANSMIT_TIME: u32 = 0x02aa;
 
 /// `0x02AB` — HD rotation speed (RPM × 100).
-pub const MSG_HD_ROTATION_SPEED: u32 = 0x02ab;
+pub(crate) const MSG_HD_ROTATION_SPEED: u32 = 0x02ab;
 
 /// `0x02AC` — HD system temperature (raw × 25).
-pub const MSG_HD_SYSTEM_TEMP: u32 = 0x02ac;
+pub(crate) const MSG_HD_SYSTEM_TEMP: u32 = 0x02ac;
 
 /// `0x02AD` — HD antenna size report.
-pub const MSG_HD_ANTENNA_SIZE: u32 = 0x02ad;
+pub(crate) const MSG_HD_ANTENNA_SIZE: u32 = 0x02ad;
 
 /// `0x02AE` — HD capability report (determines whether the radar uses 720/1‑bit
 /// or 1440/8‑bit spoke data).
-pub const MSG_HD_CAPABILITY: u32 = 0x02ae;
+pub(crate) const MSG_HD_CAPABILITY: u32 = 0x02ae;
 
 // --- Command messages (MFD → radar) --------------------------------------------
 
 /// `0x02B2` — Set transmit mode. Payload: `[u16 LE]` `1=standby, 2=transmit`.
-pub const CMD_HD_SET_TRANSMIT: u32 = 0x02b2;
+pub(crate) const CMD_HD_SET_TRANSMIT: u32 = 0x02b2;
 
 /// `0x02B3` — Set range A (single-range mode). Payload: `[i32 LE meters - 1]`.
 /// **Note the off-by-one**: HD wire encodes `meters - 1`, Enhanced protocol encodes `meters`
 /// directly.
-pub const CMD_HD_SET_RANGE_A: u32 = 0x02b3;
+pub(crate) const CMD_HD_SET_RANGE_A: u32 = 0x02b3;
 
 /// `0x02B4` — Set range A gain. Payload: `[u8 gain][u8 auto_flag]`.
-pub const CMD_HD_SET_GAIN: u32 = 0x02b4;
+pub(crate) const CMD_HD_SET_GAIN: u32 = 0x02b4;
 
 /// `0x02B5` — Set range A sea clutter. Payload:
 /// `[u32 LE gain][u32 LE auto_flag]` (8-byte body).
-pub const CMD_HD_SET_SEA: u32 = 0x02b5;
+pub(crate) const CMD_HD_SET_SEA: u32 = 0x02b5;
 
 /// `0x02B6` — Set range A rain clutter gain. Payload: `[u32 LE gain]`.
-pub const CMD_HD_SET_RAIN: u32 = 0x02b6;
+pub(crate) const CMD_HD_SET_RAIN: u32 = 0x02b6;
 
 /// `0x02B7` — Set front-of-boat / bearing alignment. Payload: `[i16 LE degrees]`.
-pub const CMD_HD_SET_BEARING_ALIGNMENT: u32 = 0x02b7;
+pub(crate) const CMD_HD_SET_BEARING_ALIGNMENT: u32 = 0x02b7;
 
 /// `0x02B9` — Set rotation speed mode (0=normal, 1=slow).
-pub const CMD_HD_SET_RPM_MODE: u32 = 0x02b9;
+pub(crate) const CMD_HD_SET_RPM_MODE: u32 = 0x02b9;
 
 /// `0x02BE` — Set dither mode (interference rejection).
-pub const CMD_HD_SET_DITHER: u32 = 0x02be;
+pub(crate) const CMD_HD_SET_DITHER: u32 = 0x02be;
 
 /// `0x02EE` — Request settings report (triggers a `MSG_HD_SETTINGS` reply).
-pub const CMD_HD_REQUEST_SETTINGS: u32 = 0x02ee;
+pub(crate) const CMD_HD_REQUEST_SETTINGS: u32 = 0x02ee;
 
 /// `0x02FC` — Set FTC gain (single-range). Payload: `[u8 gain][u8 ftc_mode]`.
-pub const CMD_HD_SET_FTC: u32 = 0x02fc;
+pub(crate) const CMD_HD_SET_FTC: u32 = 0x02fc;
 
 // =============================================================================
 // Enhanced message IDs (0x09xx)
@@ -252,286 +252,286 @@ pub const CMD_HD_SET_FTC: u32 = 0x02fc;
 // --- Operational settings ------------------------------------------------------
 
 /// `0x0911` — Scan type (1 = single range).
-pub const MSG_SCAN_TYPE: u32 = 0x0911;
+pub(crate) const MSG_SCAN_TYPE: u32 = 0x0911;
 
 /// `0x0916` — RPM mode (0=normal, 1=slow). Payload: `[u8]`.
 /// On the wire mayara sends this as `value × 2` per radar_pi.
-pub const MSG_RPM_MODE: u32 = 0x0916;
+pub(crate) const MSG_RPM_MODE: u32 = 0x0916;
 
 /// `0x0917` — Total spoke count (typically 2400).
-pub const MSG_SPOKE_TOTAL: u32 = 0x0917;
+pub(crate) const MSG_SPOKE_TOTAL: u32 = 0x0917;
 
 /// `0x0918` — Current transmit mode (companion to `0x0919`).
-pub const MSG_TRANSMIT_MODE_CURRENT: u32 = 0x0918;
+pub(crate) const MSG_TRANSMIT_MODE_CURRENT: u32 = 0x0918;
 
 /// `0x0919` — Set transmit mode (0=standby, 1=transmit). Payload: `[u8]`.
-pub const MSG_TRANSMIT_MODE: u32 = 0x0919;
+pub(crate) const MSG_TRANSMIT_MODE: u32 = 0x0919;
 
 /// `0x091B` — Dither / interference rejection mode. Payload: `[u8]`.
-pub const MSG_DITHER_MODE: u32 = 0x091b;
+pub(crate) const MSG_DITHER_MODE: u32 = 0x091b;
 
 /// `0x091C` — Range mode (0=single, 1=dual).
-pub const MSG_RANGE_MODE: u32 = 0x091c;
+pub(crate) const MSG_RANGE_MODE: u32 = 0x091c;
 
 /// `0x091D` — Range A radar mode / auto-gain level (0=auto low, 1=auto high).
-pub const MSG_RANGE_A_AUTO_LEVEL: u32 = 0x091d;
+pub(crate) const MSG_RANGE_A_AUTO_LEVEL: u32 = 0x091d;
 
 /// `0x091E` — Set range A in **meters** (uint32 LE). Unlike legacy HD this is a
 /// direct value, no -1 offset.
-pub const MSG_RANGE_A: u32 = 0x091e;
+pub(crate) const MSG_RANGE_A: u32 = 0x091e;
 
 /// `0x091F` — Range B in meters (dual-range mode).
-pub const MSG_RANGE_B: u32 = 0x091f;
+pub(crate) const MSG_RANGE_B: u32 = 0x091f;
 
 /// `0x0920` — AFC mode (0=manual, 1=auto).
-pub const MSG_AFC_MODE: u32 = 0x0920;
+pub(crate) const MSG_AFC_MODE: u32 = 0x0920;
 
 /// `0x0921` — AFC setting (uint16 LE).
-pub const MSG_AFC_SETTING: u32 = 0x0921;
+pub(crate) const MSG_AFC_SETTING: u32 = 0x0921;
 
 /// `0x0922` — AFC coarse value (uint16 LE).
-pub const MSG_AFC_COARSE: u32 = 0x0922;
+pub(crate) const MSG_AFC_COARSE: u32 = 0x0922;
 
 /// `0x0924` — Range A gain mode (0=manual, 2=auto).
-pub const MSG_RANGE_A_GAIN_MODE: u32 = 0x0924;
+pub(crate) const MSG_RANGE_A_GAIN_MODE: u32 = 0x0924;
 
 /// `0x0925` — Range A gain level (uint16 LE, 0..10000 = 0..100% × 100).
-pub const MSG_RANGE_A_GAIN: u32 = 0x0925;
+pub(crate) const MSG_RANGE_A_GAIN: u32 = 0x0925;
 
 /// `0x0926` — Range B gain mode (dual-range).
-pub const MSG_RANGE_B_GAIN_MODE: u32 = 0x0926;
+pub(crate) const MSG_RANGE_B_GAIN_MODE: u32 = 0x0926;
 
 /// `0x0927` — Range B gain level (dual-range).
-pub const MSG_RANGE_B_GAIN: u32 = 0x0927;
+pub(crate) const MSG_RANGE_B_GAIN: u32 = 0x0927;
 
 /// `0x092F` — AFC tuning mode / trigger.
-pub const MSG_AFC_TUNING_MODE: u32 = 0x092f;
+pub(crate) const MSG_AFC_TUNING_MODE: u32 = 0x092f;
 
 /// `0x0930` — Front-of-boat / bearing alignment. Payload: `[i32 LE deg × 32]`.
-pub const MSG_BEARING_ALIGNMENT: u32 = 0x0930;
+pub(crate) const MSG_BEARING_ALIGNMENT: u32 = 0x0930;
 
 /// `0x0931` — Park position. Payload: `[i32 LE deg × 32]`.
-pub const MSG_PARK_POSITION: u32 = 0x0931;
+pub(crate) const MSG_PARK_POSITION: u32 = 0x0931;
 
 /// `0x0932` — Noise blanker / crosstalk rejection mode.
-pub const MSG_NOISE_BLANKER: u32 = 0x0932;
+pub(crate) const MSG_NOISE_BLANKER: u32 = 0x0932;
 
 /// `0x0933` — Range A rain filter control mode (0=off, 1=on).
-pub const MSG_RANGE_A_RAIN_MODE: u32 = 0x0933;
+pub(crate) const MSG_RANGE_A_RAIN_MODE: u32 = 0x0933;
 
 /// `0x0934` — Range A rain filter gain (uint16 LE, gain × 100).
-pub const MSG_RANGE_A_RAIN_GAIN: u32 = 0x0934;
+pub(crate) const MSG_RANGE_A_RAIN_GAIN: u32 = 0x0934;
 
 /// `0x0936` — Range B rain filter control mode (dual-range).
-pub const MSG_RANGE_B_RAIN_MODE: u32 = 0x0936;
+pub(crate) const MSG_RANGE_B_RAIN_MODE: u32 = 0x0936;
 
 /// `0x0937` — Range B rain filter gain (dual-range).
-pub const MSG_RANGE_B_RAIN_GAIN: u32 = 0x0937;
+pub(crate) const MSG_RANGE_B_RAIN_GAIN: u32 = 0x0937;
 
 /// `0x0939` — Range A sea clutter mode (0=off, 1=manual, 2=auto).
-pub const MSG_RANGE_A_SEA_MODE: u32 = 0x0939;
+pub(crate) const MSG_RANGE_A_SEA_MODE: u32 = 0x0939;
 
 /// `0x093A` — Range A sea clutter gain (uint16 LE, gain × 100).
-pub const MSG_RANGE_A_SEA_GAIN: u32 = 0x093a;
+pub(crate) const MSG_RANGE_A_SEA_GAIN: u32 = 0x093a;
 
 /// `0x093B` — Range A sea state (0=calm, 1=moderate, 2=rough).
-pub const MSG_RANGE_A_SEA_STATE: u32 = 0x093b;
+pub(crate) const MSG_RANGE_A_SEA_STATE: u32 = 0x093b;
 
 /// `0x093C` — Range B sea clutter mode (dual-range).
-pub const MSG_RANGE_B_SEA_MODE: u32 = 0x093c;
+pub(crate) const MSG_RANGE_B_SEA_MODE: u32 = 0x093c;
 
 /// `0x093D` — Range B sea clutter gain (dual-range).
-pub const MSG_RANGE_B_SEA_GAIN: u32 = 0x093d;
+pub(crate) const MSG_RANGE_B_SEA_GAIN: u32 = 0x093d;
 
 /// `0x093E` — Range B sea state (dual-range).
-pub const MSG_RANGE_B_SEA_STATE: u32 = 0x093e;
+pub(crate) const MSG_RANGE_B_SEA_STATE: u32 = 0x093e;
 
 /// `0x093F` — No-transmit zone 1 mode (0=off, 1=on).
-pub const MSG_NO_TX_ZONE_1_MODE: u32 = 0x093f;
+pub(crate) const MSG_NO_TX_ZONE_1_MODE: u32 = 0x093f;
 
 /// `0x0940` — No-transmit zone 1 start angle. Payload: `[i32 LE deg × 32]`.
-pub const MSG_NO_TX_ZONE_1_START: u32 = 0x0940;
+pub(crate) const MSG_NO_TX_ZONE_1_START: u32 = 0x0940;
 
 /// `0x0941` — No-transmit zone 1 stop angle. Payload: `[i32 LE deg × 32]`.
-pub const MSG_NO_TX_ZONE_1_STOP: u32 = 0x0941;
+pub(crate) const MSG_NO_TX_ZONE_1_STOP: u32 = 0x0941;
 
 /// `0x0942` — Sentry / timed transmit mode (0=off, 1=on).
-pub const MSG_SENTRY_MODE: u32 = 0x0942;
+pub(crate) const MSG_SENTRY_MODE: u32 = 0x0942;
 
 /// `0x0943` — Sentry standby time in seconds (uint16 LE).
-pub const MSG_SENTRY_STANDBY_TIME: u32 = 0x0943;
+pub(crate) const MSG_SENTRY_STANDBY_TIME: u32 = 0x0943;
 
 /// `0x0944` — Sentry transmit time in seconds (uint16 LE).
-pub const MSG_SENTRY_TRANSMIT_TIME: u32 = 0x0944;
+pub(crate) const MSG_SENTRY_TRANSMIT_TIME: u32 = 0x0944;
 
 /// `0x0950` — Antenna size (uint16 LE).
-pub const MSG_ANTENNA_SIZE: u32 = 0x0950;
+pub(crate) const MSG_ANTENNA_SIZE: u32 = 0x0950;
 
 /// `0x0956` — Range B radar mode / auto-gain level (dual-range).
-pub const MSG_RANGE_B_RADAR_MODE: u32 = 0x0956;
+pub(crate) const MSG_RANGE_B_RADAR_MODE: u32 = 0x0956;
 
 /// `0x0966` — Transmit channel mode. Payload: `[u8]`.
 /// `0` = manual, `1` = auto. Fantom Pro / solid-state only.
 /// Gated on capability bit `0xb2`.
-pub const MSG_TRANSMIT_CHANNEL_MODE: u32 = 0x0966;
+pub(crate) const MSG_TRANSMIT_CHANNEL_MODE: u32 = 0x0966;
 
 /// `0x0967` — Transmit channel select (uint16 LE, 1-based channel number).
-pub const MSG_TRANSMIT_CHANNEL_SELECT: u32 = 0x0967;
+pub(crate) const MSG_TRANSMIT_CHANNEL_SELECT: u32 = 0x0967;
 
 /// `0x09B6` — Transmit channel max (uint16 LE). Broadcast once at init.
-pub const MSG_TRANSMIT_CHANNEL_MAX: u32 = 0x09b6;
+pub(crate) const MSG_TRANSMIT_CHANNEL_MAX: u32 = 0x09b6;
 
 /// `0x096A` — No-transmit zone 2 mode (0=off, 1=on). Fantom Pro and
 /// later — only present on radars that report capability bit
 /// `cap::NO_TX_ZONE_2_MODE` (0xbf) in `0x09B1`.
-pub const MSG_NO_TX_ZONE_2_MODE: u32 = 0x096a;
+pub(crate) const MSG_NO_TX_ZONE_2_MODE: u32 = 0x096a;
 
 /// `0x096B` — No-transmit zone 2 start angle. Payload: `[i32 LE deg × 32]`.
-pub const MSG_NO_TX_ZONE_2_START: u32 = 0x096b;
+pub(crate) const MSG_NO_TX_ZONE_2_START: u32 = 0x096b;
 
 /// `0x096C` — No-transmit zone 2 stop angle. Payload: `[i32 LE deg × 32]`.
-pub const MSG_NO_TX_ZONE_2_STOP: u32 = 0x096c;
+pub(crate) const MSG_NO_TX_ZONE_2_STOP: u32 = 0x096c;
 
 /// `0x0960` — Range A scan mode / MotionScope (Doppler). Payload: `[u8]`.
 /// `0` = off, `1` = approaching only, `2` = approaching + receding.
 /// Gated on capability bit `0xa3`.
-pub const MSG_RANGE_A_DOPPLER_MODE: u32 = 0x0960;
+pub(crate) const MSG_RANGE_A_DOPPLER_MODE: u32 = 0x0960;
 
 /// `0x0961` — Range B scan mode (dual-range Doppler).
-pub const MSG_RANGE_B_DOPPLER_MODE: u32 = 0x0961;
+pub(crate) const MSG_RANGE_B_DOPPLER_MODE: u32 = 0x0961;
 
 /// `0x0962` — Range A pulse expansion mode (0=off, 1=on). xHD2+.
 /// Gated on capability bit `0xab`.
-pub const MSG_RANGE_A_PULSE_EXPANSION: u32 = 0x0962;
+pub(crate) const MSG_RANGE_A_PULSE_EXPANSION: u32 = 0x0962;
 
 /// `0x0963` — Range B pulse expansion mode (dual-range).
-pub const MSG_RANGE_B_PULSE_EXPANSION: u32 = 0x0963;
+pub(crate) const MSG_RANGE_B_PULSE_EXPANSION: u32 = 0x0963;
 
 /// `0x0968` — Range A target size mode. xHD2/Fantom.
 /// Gated on capability bit `0xbd`.
-pub const MSG_RANGE_A_TARGET_SIZE: u32 = 0x0968;
+pub(crate) const MSG_RANGE_A_TARGET_SIZE: u32 = 0x0968;
 
 /// `0x0969` — Range B target size mode (dual-range).
-pub const MSG_RANGE_B_TARGET_SIZE: u32 = 0x0969;
+pub(crate) const MSG_RANGE_B_TARGET_SIZE: u32 = 0x0969;
 
 /// `0x096D` — Range A Doppler sensitivity (uint16 LE).
 /// Gated on capability bit `0xc3`. Units uncertain (likely percent).
-pub const MSG_RANGE_A_DOPPLER_SENSITIVITY: u32 = 0x096d;
+pub(crate) const MSG_RANGE_A_DOPPLER_SENSITIVITY: u32 = 0x096d;
 
 /// `0x096E` — Range B Doppler sensitivity (uint16 LE).
-pub const MSG_RANGE_B_DOPPLER_SENSITIVITY: u32 = 0x096e;
+pub(crate) const MSG_RANGE_B_DOPPLER_SENSITIVITY: u32 = 0x096e;
 
 /// `0x0970` — Range A scan average mode (0=off, 1=on). xHD3/Fantom Pro.
 /// Gated on capability bit `0xca`.
-pub const MSG_RANGE_A_SCAN_AVERAGE_MODE: u32 = 0x0970;
+pub(crate) const MSG_RANGE_A_SCAN_AVERAGE_MODE: u32 = 0x0970;
 
 /// `0x0971` — Range B scan average mode (dual-range).
-pub const MSG_RANGE_B_SCAN_AVERAGE_MODE: u32 = 0x0971;
+pub(crate) const MSG_RANGE_B_SCAN_AVERAGE_MODE: u32 = 0x0971;
 
 /// `0x0972` — Range A scan average sensitivity (uint16 LE).
-pub const MSG_RANGE_A_SCAN_AVERAGE_SENSITIVITY: u32 = 0x0972;
+pub(crate) const MSG_RANGE_A_SCAN_AVERAGE_SENSITIVITY: u32 = 0x0972;
 
 /// `0x0973` — Range B scan average sensitivity (uint16 LE).
-pub const MSG_RANGE_B_SCAN_AVERAGE_SENSITIVITY: u32 = 0x0973;
+pub(crate) const MSG_RANGE_B_SCAN_AVERAGE_SENSITIVITY: u32 = 0x0973;
 
 // --- State / runtime / hardware health ----------------------------------------
 
 /// `0x0992` — Scanner state. Payload: `[u8]`. See `STATE_*` constants.
-pub const MSG_SCANNER_STATE: u32 = 0x0992;
+pub(crate) const MSG_SCANNER_STATE: u32 = 0x0992;
 
 /// `0x0993` — Milliseconds until the next state change.
-pub const MSG_STATE_CHANGE: u32 = 0x0993;
+pub(crate) const MSG_STATE_CHANGE: u32 = 0x0993;
 
 /// `0x0998` — Spoke (sweep) data. One spoke per packet on port 50102.
-pub const MSG_SPOKE: u32 = 0x0998;
+pub(crate) const MSG_SPOKE: u32 = 0x0998;
 
 /// `0x099A` — AFC tuning progress (0..100%).
-pub const MSG_AFC_PROGRESS: u32 = 0x099a;
+pub(crate) const MSG_AFC_PROGRESS: u32 = 0x099a;
 
 /// `0x099B` — Error message. Body has a 64-byte ASCII info string at +16.
-pub const MSG_ERROR_MESSAGE: u32 = 0x099b;
+pub(crate) const MSG_ERROR_MESSAGE: u32 = 0x099b;
 
 /// `0x099F` — Maximum range in meters.
-pub const MSG_MAX_RANGE: u32 = 0x099f;
+pub(crate) const MSG_MAX_RANGE: u32 = 0x099f;
 
 /// `0x09A2` — Transmit power.
-pub const MSG_TRANSMIT_POWER: u32 = 0x09a2;
+pub(crate) const MSG_TRANSMIT_POWER: u32 = 0x09a2;
 
 /// `0x09A3` — Input voltage (uint16 LE).
-pub const MSG_INPUT_VOLTAGE: u32 = 0x09a3;
+pub(crate) const MSG_INPUT_VOLTAGE: u32 = 0x09a3;
 
 /// `0x09A4` — Heater voltage (uint16 LE).
-pub const MSG_HEATER_VOLTAGE: u32 = 0x09a4;
+pub(crate) const MSG_HEATER_VOLTAGE: u32 = 0x09a4;
 
 /// `0x09A6` — High voltage (uint16 LE).
-pub const MSG_HIGH_VOLTAGE: u32 = 0x09a6;
+pub(crate) const MSG_HIGH_VOLTAGE: u32 = 0x09a6;
 
 /// `0x09A7` — Transmit current (uint16 LE).
-pub const MSG_TRANSMIT_CURRENT: u32 = 0x09a7;
+pub(crate) const MSG_TRANSMIT_CURRENT: u32 = 0x09a7;
 
 /// `0x09A8` — System temperature (uint16 LE).
-pub const MSG_SYSTEM_TEMPERATURE: u32 = 0x09a8;
+pub(crate) const MSG_SYSTEM_TEMPERATURE: u32 = 0x09a8;
 
 /// `0x09AA` — Cumulative operation time in seconds.
-pub const MSG_OPERATION_TIME: u32 = 0x09aa;
+pub(crate) const MSG_OPERATION_TIME: u32 = 0x09aa;
 
 /// `0x09AB` — Cumulative modulator time in seconds.
-pub const MSG_MODULATOR_TIME: u32 = 0x09ab;
+pub(crate) const MSG_MODULATOR_TIME: u32 = 0x09ab;
 
 /// `0x09AC` — Cumulative transmit time in seconds.
-pub const MSG_TRANSMIT_TIME: u32 = 0x09ac;
+pub(crate) const MSG_TRANSMIT_TIME: u32 = 0x09ac;
 
 /// `0x09B1` — Capability bitmap. 48-byte payload containing 5 × u64 capability
 /// words at offsets +0x08..+0x28. See `feature-detection.md` for the bit map.
-pub const MSG_CAPABILITY: u32 = 0x09b1;
+pub(crate) const MSG_CAPABILITY: u32 = 0x09b1;
 
 /// `0x09B2` — Range table. 72-byte payload listing the supported ranges in
 /// meters. Layout: 4-byte `[version=1, length=72]`, then `[u32 count]`,
 /// then `count` × `u32 LE meters`.
-pub const MSG_RANGE_TABLE: u32 = 0x09b2;
+pub(crate) const MSG_RANGE_TABLE: u32 = 0x09b2;
 
 /// `0x09B7` — Default Doppler sensitivity (uint16 LE). Broadcast once at
 /// init as part of the capability stream. Used by the "Restore Defaults"
 /// code path; no `Radar_Manager_Command_*` wrapper.
-pub const MSG_DEFAULT_DOPPLER_SENSITIVITY: u32 = 0x09b7;
+pub(crate) const MSG_DEFAULT_DOPPLER_SENSITIVITY: u32 = 0x09b7;
 
 // =============================================================================
 // Scanner state values (msg `0x0992`)
 // =============================================================================
 
 /// Warmup — transmitter is heating up.
-pub const STATE_WARMING_UP: u32 = 2;
+pub(crate) const STATE_WARMING_UP: u32 = 2;
 
 /// Standby — radar ready but not transmitting.
-pub const STATE_STANDBY: u32 = 3;
+pub(crate) const STATE_STANDBY: u32 = 3;
 
 /// Spinning up — antenna accelerating before transmit.
-pub const STATE_SPINNING_UP: u32 = 4;
+pub(crate) const STATE_SPINNING_UP: u32 = 4;
 
 /// Transmitting — actively scanning.
-pub const STATE_TRANSMIT: u32 = 5;
+pub(crate) const STATE_TRANSMIT: u32 = 5;
 
 /// Stopping — shutdown requested.
-pub const STATE_STOPPING: u32 = 6;
+pub(crate) const STATE_STOPPING: u32 = 6;
 
 /// Spinning down — antenna decelerating.
-pub const STATE_SPINNING_DOWN: u32 = 7;
+pub(crate) const STATE_SPINNING_DOWN: u32 = 7;
 
 /// Starting — initial startup.
-pub const STATE_STARTING: u32 = 10;
+pub(crate) const STATE_STARTING: u32 = 10;
 
 // =============================================================================
 // HD scanner state values (msg `0x02A5`)
 // =============================================================================
 
 /// HD warming up.
-pub const HD_STATE_WARMING_UP: u16 = 1;
+pub(crate) const HD_STATE_WARMING_UP: u16 = 1;
 
 /// HD standby.
-pub const HD_STATE_STANDBY: u16 = 3;
+pub(crate) const HD_STATE_STANDBY: u16 = 3;
 
 /// HD transmitting.
-pub const HD_STATE_TRANSMIT: u16 = 4;
+pub(crate) const HD_STATE_TRANSMIT: u16 = 4;
 
 /// HD spinning up.
-pub const HD_STATE_SPINNING_UP: u16 = 5;
+pub(crate) const HD_STATE_SPINNING_UP: u16 = 5;

--- a/src/lib/brand/garmin/range_table.rs
+++ b/src/lib/brand/garmin/range_table.rs
@@ -43,7 +43,7 @@ const RANGES_OFFSET: usize = 8;
 /// has been stripped. Returns the list of supported ranges in meters,
 /// or `None` if the body is malformed (truncated, count too large, or
 /// the declared length doesn't match the data we got).
-pub fn parse(payload: &[u8]) -> Option<Ranges> {
+pub(crate) fn parse(payload: &[u8]) -> Option<Ranges> {
     if payload.len() < RANGES_OFFSET {
         return None;
     }

--- a/src/lib/brand/garmin/settings.rs
+++ b/src/lib/brand/garmin/settings.rs
@@ -28,7 +28,7 @@ use crate::{
 /// range, doppler) are registered — antenna-level controls (bearing
 /// alignment, scan speed, interference rejection, no-TX zones, sentry,
 /// target expansion, telemetry) are omitted because they live on Range A.
-pub fn new(
+pub(crate) fn new(
     radar_id: String,
     sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
     args: &Cli,

--- a/src/lib/brand/navico/capabilities.rs
+++ b/src/lib/brand/navico/capabilities.rs
@@ -15,7 +15,7 @@ use super::protocol::tlv;
 
 /// Capabilities parsed from the 0xC409 TLV data block.
 #[derive(Debug, Clone)]
-pub struct NavicoCapabilities {
+pub(crate) struct NavicoCapabilities {
     /// Bitmask of supported operating modes (from TLV type 2).
     pub supported_modes_mask: u32,
     /// Bitmask of supported interference rejection levels (TLV type 3).
@@ -44,7 +44,7 @@ pub struct NavicoCapabilities {
 
 impl NavicoCapabilities {
     /// Parse a 0xC409 StateDataBlock payload (after the 2-byte opcode header).
-    pub fn parse(data: &[u8]) -> Self {
+    pub(crate) fn parse(data: &[u8]) -> Self {
         let mut caps = NavicoCapabilities {
             supported_modes_mask: 0,
             interference_reject_mask: 0,
@@ -168,23 +168,23 @@ impl NavicoCapabilities {
     }
 
     /// Whether Doppler mode is supported.
-    pub fn has_doppler(&self) -> bool {
+    pub(crate) fn has_doppler(&self) -> bool {
         self.supported_modes_mask & tlv::MODE_DOPPLER != 0
     }
 
     /// Whether bird mode is supported.
     #[allow(dead_code)]
-    pub fn has_bird_mode(&self) -> bool {
+    pub(crate) fn has_bird_mode(&self) -> bool {
         self.supported_modes_mask & tlv::MODE_BIRD != 0
     }
 
     /// Instrumented range minimum in meters.
-    pub fn range_min_m(&self) -> i32 {
+    pub(crate) fn range_min_m(&self) -> i32 {
         (self.instrumented_range_min_dm / 10) as i32
     }
 
     /// Instrumented range maximum in meters.
-    pub fn range_max_m(&self) -> i32 {
+    pub(crate) fn range_max_m(&self) -> i32 {
         (self.instrumented_range_max_dm / 10) as i32
     }
 }

--- a/src/lib/brand/navico/command.rs
+++ b/src/lib/brand/navico/command.rs
@@ -18,7 +18,7 @@ use super::protocol::{
     INSTALL_TAG_ANTENNA_OFFSET, REQUEST_STATE_BATCH, REQUEST_STATE_PROPERTIES,
 };
 
-pub struct Command {
+pub(crate) struct Command {
     key: String,
     info: RadarInfo,
     model: Model,
@@ -27,7 +27,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn new(fake_errors: bool, info: RadarInfo) -> Self {
+    pub(crate) fn new(fake_errors: bool, info: RadarInfo) -> Self {
         Command {
             key: info.key(),
             info,
@@ -37,7 +37,7 @@ impl Command {
         }
     }
 
-    pub fn set_model(&mut self, model: Model) {
+    pub(crate) fn set_model(&mut self, model: Model) {
         self.model = model;
     }
 

--- a/src/lib/brand/navico/info.rs
+++ b/src/lib/brand/navico/info.rs
@@ -41,7 +41,7 @@ pub(crate) struct HaloHeadingPacket {
 }
 
 impl HaloHeadingPacket {
-    pub fn transmute(bytes: &[u8]) -> Result<Self, anyhow::Error> {
+    pub(crate) fn transmute(bytes: &[u8]) -> Result<Self, anyhow::Error> {
         Ok(unsafe {
             let report: [u8; 72] = bytes.try_into()?;
             transmute(report)
@@ -70,7 +70,7 @@ pub(crate) struct HaloNavigationPacket {
 }
 
 impl HaloNavigationPacket {
-    pub fn transmute(bytes: &[u8]) -> Result<Self, anyhow::Error> {
+    pub(crate) fn transmute(bytes: &[u8]) -> Result<Self, anyhow::Error> {
         Ok(unsafe {
             let report: [u8; 72] = bytes.try_into()?;
             transmute(report)
@@ -125,7 +125,7 @@ fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
 }
 
 impl Information {
-    pub fn new(key: String, info: &RadarInfo) -> Self {
+    pub(crate) fn new(key: String, info: &RadarInfo) -> Self {
         Information {
             key,
             nic_addr: info.nic_addr.clone(),

--- a/src/lib/brand/navico/mod.rs
+++ b/src/lib/brand/navico/mod.rs
@@ -32,7 +32,7 @@ pub(super) use protocol::{
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(u32)]
-pub enum Model {
+pub(crate) enum Model {
     Unknown = 9,
     BR24 = 10,       // Broadband Radar 24 (FMCW dome)
     Gen3 = 12,       // Broadband 3G (FMCW dome)
@@ -72,7 +72,7 @@ impl fmt::Display for Model {
 impl Model {
     /// Parse from a persisted model name string.
     #[allow(dead_code)]
-    pub fn new(s: &str) -> Self {
+    pub(crate) fn new(s: &str) -> Self {
         match s {
             "BR24" => Model::BR24,
             "3G" => Model::Gen3,
@@ -91,7 +91,7 @@ impl Model {
     }
 
     /// Map from the eScannerType u32 in the 0xC403 StateProperties packet.
-    pub fn from_scanner_type(scanner_type: u32) -> Self {
+    pub(crate) fn from_scanner_type(scanner_type: u32) -> Self {
         match scanner_type {
             10 => Model::BR24,
             12 => Model::Gen3,
@@ -110,7 +110,7 @@ impl Model {
     }
 
     /// Returns true for all HALO variants (dome and open array).
-    pub fn is_halo(&self) -> bool {
+    pub(crate) fn is_halo(&self) -> bool {
         let v = *self as u32;
         v >= 14 && v <= 23
     }

--- a/src/lib/brand/navico/protocol.rs
+++ b/src/lib/brand/navico/protocol.rs
@@ -33,48 +33,48 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 // =============================================================================
 
 /// Number of spokes per full antenna revolution (display space).
-pub const SPOKES_PER_REVOLUTION: usize = 2048;
+pub(crate) const SPOKES_PER_REVOLUTION: usize = 2048;
 
 /// Raw spoke counter range: `[0..4096)`. The radar reports angles in this
 /// double-resolution space but only every other value is populated, so after
 /// dividing by 2 the result fits in `SPOKES_PER_REVOLUTION`.
-pub const SPOKES_RAW: u16 = 4096;
+pub(crate) const SPOKES_RAW: u16 = 4096;
 
 /// Number of pixels in a single spoke (samples per radar line).
-pub const SPOKE_PIXEL_LEN: usize = 1024;
+pub(crate) const SPOKE_PIXEL_LEN: usize = 1024;
 
 /// Each pixel is a 4-bit nibble (values `0..16`).
-pub const BITS_PER_PIXEL: usize = 4;
+pub(crate) const BITS_PER_PIXEL: usize = 4;
 
 /// Number of pixels packed into a single wire byte.
-pub const PIXELS_PER_BYTE: usize = 8 / BITS_PER_PIXEL;
+pub(crate) const PIXELS_PER_BYTE: usize = 8 / BITS_PER_PIXEL;
 
 /// Number of bytes in one spoke's pixel data on the wire.
-pub const SPOKE_DATA_LENGTH: usize = SPOKE_PIXEL_LEN / PIXELS_PER_BYTE;
+pub(crate) const SPOKE_DATA_LENGTH: usize = SPOKE_PIXEL_LEN / PIXELS_PER_BYTE;
 
 /// Number of spokes batched into a single radar data frame UDP packet.
-pub const SPOKES_PER_FRAME: usize = 32;
+pub(crate) const SPOKES_PER_FRAME: usize = 32;
 
 // =============================================================================
 // Discovery — Multi-device service
 // =============================================================================
 
 /// Multicast group used by Gen3+ radars (3G, 4G, HALO) for discovery.
-pub const GEN3PLUS_DISCOVERY_ADDRESS: SocketAddr =
+pub(crate) const GEN3PLUS_DISCOVERY_ADDRESS: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(236, 6, 7, 5)), 6878);
 
 /// Multicast group used by BR24 radars for discovery queries. BR24 radars
 /// still respond on the Gen3+ discovery address (`236.6.7.5:6878`), but the
 /// MFD must also probe this older group to find them.
-pub const BR24_DISCOVERY_ADDRESS: SocketAddr =
+pub(crate) const BR24_DISCOVERY_ADDRESS: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(236, 6, 7, 4)), 6768);
 
 /// Discovery query packet sent by the MFD (multi-device service, opcode
 /// `0xB101`, little-endian on the wire).
-pub const DISCOVERY_QUERY_PACKET: [u8; 2] = [0x01, 0xB1];
+pub(crate) const DISCOVERY_QUERY_PACKET: [u8; 2] = [0x01, 0xB1];
 
 /// Beacon response header bytes (opcode `0xB201`).
-pub const BEACON_RESPONSE_HEADER: [u8; 2] = [0x01, 0xB2];
+pub(crate) const BEACON_RESPONSE_HEADER: [u8; 2] = [0x01, 0xB2];
 
 // =============================================================================
 // Beacon service/subtype identifiers
@@ -85,16 +85,16 @@ pub const BEACON_RESPONSE_HEADER: [u8; 2] = [0x01, 0xB2];
 // individual data/command/report channels.
 
 /// Service type for the primary radar services device group.
-pub const RADAR_SERVICE_TYPE: u16 = 0x0010;
+pub(crate) const RADAR_SERVICE_TYPE: u16 = 0x0010;
 
 /// Service entry subtype: spoke data stream (multicast RX).
-pub const SPOKE_DATA_SUBTYPE: u16 = 0x0010;
+pub(crate) const SPOKE_DATA_SUBTYPE: u16 = 0x0010;
 
 /// Service entry subtype: control commands (multicast TX to radar).
-pub const COMMAND_SUBTYPE: u16 = 0x0011;
+pub(crate) const COMMAND_SUBTYPE: u16 = 0x0011;
 
 /// Service entry subtype: state/report channel (multicast RX from radar).
-pub const REPORT_SUBTYPE: u16 = 0x0012;
+pub(crate) const REPORT_SUBTYPE: u16 = 0x0012;
 
 // =============================================================================
 // HALO heading / navigation / speed multicast addresses
@@ -104,17 +104,17 @@ pub const REPORT_SUBTYPE: u16 = 0x0012;
 /// HALO radars (NKOE format, 72-byte payload). The MFD must keep sending
 /// these packets while the radar is transmitting so the radar can map
 /// Doppler returns and tracked targets to ground-relative coordinates.
-pub const HALO_HEADING_INFO_ADDRESS: SocketAddrV4 =
+pub(crate) const HALO_HEADING_INFO_ADDRESS: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::new(239, 238, 55, 73), 7527);
 
 /// Primary multicast address where the MFD sends a 23-byte speed packet
 /// (`01 d3 01 00 00 00`-prefixed) to HALO radars.
-pub const HALO_SPEED_ADDRESS_A: SocketAddrV4 =
+pub(crate) const HALO_SPEED_ADDRESS_A: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::new(236, 6, 7, 20), 6690);
 
 /// Alternate multicast address where the MFD also sends the speed packet.
 /// radar_pi sends an identical copy to both addresses.
-pub const HALO_SPEED_ADDRESS_B: SocketAddrV4 =
+pub(crate) const HALO_SPEED_ADDRESS_B: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::new(236, 6, 7, 15), 6005);
 
 // =============================================================================
@@ -122,47 +122,47 @@ pub const HALO_SPEED_ADDRESS_B: SocketAddrV4 =
 // =============================================================================
 
 /// Category byte for MFD → radar control commands (`0xC1xx`).
-pub const CATEGORY_CONTROL: u8 = 0xC1;
+pub(crate) const CATEGORY_CONTROL: u8 = 0xC1;
 
 /// Category byte for MFD → radar query commands (`0xC2xx`).
-pub const CATEGORY_QUERY: u8 = 0xC2;
+pub(crate) const CATEGORY_QUERY: u8 = 0xC2;
 
 /// Category byte for radar → MFD state reports (`0xC4xx`).
-pub const CATEGORY_STATE: u8 = 0xC4;
+pub(crate) const CATEGORY_STATE: u8 = 0xC4;
 
 // =============================================================================
 // State report sub-opcodes (radar → MFD, category 0xC4)
 // =============================================================================
 
 /// `0xC401` — Power/transmit state. 18 bytes. All models.
-pub const STATE_MODE: u8 = 0x01;
+pub(crate) const STATE_MODE: u8 = 0x01;
 
 /// `0xC402` — Range, gain, sea clutter, rain clutter, mode. 99 bytes. All models.
-pub const STATE_SETUP: u8 = 0x02;
+pub(crate) const STATE_SETUP: u8 = 0x02;
 
 /// `0xC403` — Scanner type, operating hours, firmware version. 129 bytes. All models.
-pub const STATE_PROPERTIES: u8 = 0x03;
+pub(crate) const STATE_PROPERTIES: u8 = 0x03;
 
 /// `0xC404` — Bearing alignment, antenna height, accent light. 66 bytes. All models.
-pub const STATE_CONFIG: u8 = 0x04;
+pub(crate) const STATE_CONFIG: u8 = 0x04;
 
 /// `0xC405` — BR24-only extended status block. 564 bytes.
-pub const STATE_BR24_EXTENDED: u8 = 0x05;
+pub(crate) const STATE_BR24_EXTENDED: u8 = 0x05;
 
 /// `0xC406` — Sector blanking, antenna offsets, transceiver name. 68 or 74 bytes. HALO only.
-pub const STATE_INSTALLATION: u8 = 0x06;
+pub(crate) const STATE_INSTALLATION: u8 = 0x06;
 
 /// `0xC407` — Extended properties. Variable length (BR24: 780, 4G: 188, HALO: varies).
-pub const STATE_PROPERTIES_EXTENDED: u8 = 0x07;
+pub(crate) const STATE_PROPERTIES_EXTENDED: u8 = 0x07;
 
 /// `0xC408` — Sea state, scan speed, sidelobe, doppler. 18/21/22/32 bytes.
-pub const STATE_SETUP_EXTENDED: u8 = 0x08;
+pub(crate) const STATE_SETUP_EXTENDED: u8 = 0x08;
 
 /// `0xC409` — TLV-encoded feature/capability advertisement. Variable length. HALO only.
-pub const STATE_FEATURES: u8 = 0x09;
+pub(crate) const STATE_FEATURES: u8 = 0x09;
 
 /// `0xC40A` — Additional HALO state. Variable length.
-pub const STATE_ADDITIONAL: u8 = 0x0A;
+pub(crate) const STATE_ADDITIONAL: u8 = 0x0A;
 
 // =============================================================================
 // 0xC409 TLV feature type IDs
@@ -170,40 +170,44 @@ pub const STATE_ADDITIONAL: u8 = 0x0A;
 // Each TLV entry in the StateDataBlock is: [type:u8][reserved:u8][length:u8][payload...]
 // =============================================================================
 
-/// TLV type IDs for the 0xC409 StateDataBlock.
-pub mod tlv {
-    /// Bitmask of supported operating modes.
-    /// 4 bytes LE: bit0=custom, 1=harbor, 2=offshore, 3=weather, 4=bird, 5=doppler, 6=buoy.
-    pub const SUPPORTED_USE_MODES: u8 = 2;
-    /// Interference rejection level count. 5 bytes: `[count:u8][_:3B][flags:u8]`.
-    pub const INTERFERENCE_REJECT: u8 = 3;
-    /// Noise rejection level count. 5 bytes.
-    pub const NOISE_REJECT: u8 = 4;
-    /// Target boost (expansion) level count. 5 bytes.
-    pub const TARGET_BOOST: u8 = 5;
-    /// STC curve level count. 5 bytes.
-    pub const STC_CURVE: u8 = 6;
-    /// Beam sharpening (target separation) level count. 5 bytes.
-    pub const BEAM_SHARPENING: u8 = 7;
-    /// Fast scan (scan speed) level count. 5 bytes.
-    pub const FAST_SCAN: u8 = 8;
-    /// Sidelobe gain min/max range. 4 bytes: `[min:u8][_:u8][max:u8][_:u8]`.
-    pub const SIDELOBE_GAIN_RANGE: u8 = 9;
-    /// Supported antenna types. Variable: dome=`00`, array=`[count:u8][size_mm:u16 LE]...`.
-    pub const SUPPORTED_ANTENNAS: u8 = 10;
-    /// Instrumented range min/max in decimeters. 8 bytes: `[min:u32 LE][max:u32 LE]`.
-    pub const INSTRUMENTED_RANGE: u8 = 11;
-    /// Local interference rejection level count. 5 bytes.
-    pub const LOCAL_INTERFERENCE_REJECT: u8 = 12;
+/// TLV type IDs for the 0xC409 capability advertisement (HALO only).
+///
+/// Each entry: `[type:u8][reserved:u8][length:u8][payload...]`.
+/// Capability types 3-8 and 12 carry a 5-byte payload where byte 0 is a
+/// bitmask of supported values (set bits = valid wire values for that control).
+pub(crate) mod tlv {
+    /// Supported operating modes. 4 bytes LE bitmask.
+    /// bit0=custom, 1=harbor, 2=offshore, 3=weather, 4=bird, 5=doppler, 6=buoy.
+    pub(crate) const SUPPORTED_USE_MODES: u8 = 2;
+    /// Interference rejection capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const INTERFERENCE_REJECT: u8 = 3;
+    /// Noise rejection capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const NOISE_REJECT: u8 = 4;
+    /// Target boost (expansion) capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const TARGET_BOOST: u8 = 5;
+    /// STC curve capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const STC_CURVE: u8 = 6;
+    /// Beam sharpening (target separation) capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const BEAM_SHARPENING: u8 = 7;
+    /// Fast scan (scan speed) capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const FAST_SCAN: u8 = 8;
+    /// Sidelobe gain min/max. 4 bytes: `[min:u8][_:u8][max:u8][_:u8]`.
+    pub(crate) const SIDELOBE_GAIN_RANGE: u8 = 9;
+    /// Supported antennas. Variable: dome=`[0x00]`, array=`[count:u8][size_mm:u16 LE]...`.
+    pub(crate) const SUPPORTED_ANTENNAS: u8 = 10;
+    /// Instrumented range limits in decimeters. 8 bytes: `[min:u32 LE][max:u32 LE]`.
+    pub(crate) const INSTRUMENTED_RANGE: u8 = 11;
+    /// Local interference rejection capability. 5 bytes: `[mask:u8][_:3B][flags:u8]`.
+    pub(crate) const LOCAL_INTERFERENCE_REJECT: u8 = 12;
 
-    /// Mode bitmask bit positions.
-    pub const MODE_CUSTOM: u32 = 1 << 0;
-    pub const MODE_HARBOR: u32 = 1 << 1;
-    pub const MODE_OFFSHORE: u32 = 1 << 2;
-    pub const MODE_WEATHER: u32 = 1 << 3;
-    pub const MODE_BIRD: u32 = 1 << 4;
-    pub const MODE_DOPPLER: u32 = 1 << 5;
-    pub const MODE_BUOY: u32 = 1 << 6;
+    // Mode bitmask bit positions (for SUPPORTED_USE_MODES payload).
+    pub(crate) const MODE_CUSTOM: u32 = 1 << 0;
+    pub(crate) const MODE_HARBOR: u32 = 1 << 1;
+    pub(crate) const MODE_OFFSHORE: u32 = 1 << 2;
+    pub(crate) const MODE_WEATHER: u32 = 1 << 3;
+    pub(crate) const MODE_BIRD: u32 = 1 << 4;
+    pub(crate) const MODE_DOPPLER: u32 = 1 << 5;
+    pub(crate) const MODE_BUOY: u32 = 1 << 6;
 }
 
 // =============================================================================
@@ -211,115 +215,115 @@ pub mod tlv {
 // =============================================================================
 
 /// `0xC100` — Radar power. Payload: `01` byte.
-pub const CMD_POWER_ON: u8 = 0x00;
+pub(crate) const CMD_POWER_ON: u8 = 0x00;
 
 /// `0xC101` — Transmit enable. Payload: `0` (standby) or `1` (transmit).
-pub const CMD_TRANSMIT: u8 = 0x01;
+pub(crate) const CMD_TRANSMIT: u8 = 0x01;
 
 /// `0xC103` — Range in decimeters, i32 LE.
-pub const CMD_RANGE: u8 = 0x03;
+pub(crate) const CMD_RANGE: u8 = 0x03;
 
 /// `0xC105` — Bearing alignment, i16 LE, tenths of a degree.
-pub const CMD_BEARING_ALIGNMENT: u8 = 0x05;
+pub(crate) const CMD_BEARING_ALIGNMENT: u8 = 0x05;
 
 /// `0xC106` — Generic gain-style multi-variant command (gain, sea, rain,
 /// sidelobe suppression). Payload starts with a variant byte.
-pub const CMD_GAIN_VARIANT: u8 = 0x06;
+pub(crate) const CMD_GAIN_VARIANT: u8 = 0x06;
 
 /// `0xC108` — Interference rejection level.
-pub const CMD_INTERFERENCE_REJECTION: u8 = 0x08;
+pub(crate) const CMD_INTERFERENCE_REJECTION: u8 = 0x08;
 
 /// `0xC109` — Target expansion level (non-HALO).
-pub const CMD_TARGET_EXPANSION: u8 = 0x09;
+pub(crate) const CMD_TARGET_EXPANSION: u8 = 0x09;
 
 /// `0xC10A` — Target boost level.
-pub const CMD_TARGET_BOOST: u8 = 0x0A;
+pub(crate) const CMD_TARGET_BOOST: u8 = 0x0A;
 
 /// `0xC10B` — Sea state level.
-pub const CMD_SEA_STATE: u8 = 0x0B;
+pub(crate) const CMD_SEA_STATE: u8 = 0x0B;
 
 /// `0xC10D` — No-transmit sector enable (step 1 of a 2-part command).
-pub const CMD_NOTRANSMIT_ENABLE: u8 = 0x0D;
+pub(crate) const CMD_NOTRANSMIT_ENABLE: u8 = 0x0D;
 
 /// `0xC10E` — Local interference rejection level.
-pub const CMD_LOCAL_INTERFERENCE_REJECTION: u8 = 0x0E;
+pub(crate) const CMD_LOCAL_INTERFERENCE_REJECTION: u8 = 0x0E;
 
 /// `0xC10F` — Scan speed level.
-pub const CMD_SCAN_SPEED: u8 = 0x0F;
+pub(crate) const CMD_SCAN_SPEED: u8 = 0x0F;
 
 /// `0xC110` — Use mode. Payload: 2-byte `tUseMode` (mode + variant).
-pub const CMD_USE_MODE: u8 = 0x10;
+pub(crate) const CMD_USE_MODE: u8 = 0x10;
 
 /// `0xC111` — HALO-specific sea clutter with auto offset.
-pub const CMD_HALO_SEA: u8 = 0x11;
+pub(crate) const CMD_HALO_SEA: u8 = 0x11;
 
 /// `0xC112` — HALO-specific target expansion.
-pub const CMD_HALO_TARGET_EXPANSION: u8 = 0x12;
+pub(crate) const CMD_HALO_TARGET_EXPANSION: u8 = 0x12;
 
 /// `0xC121` — Noise rejection level.
-pub const CMD_NOISE_REJECTION: u8 = 0x21;
+pub(crate) const CMD_NOISE_REJECTION: u8 = 0x21;
 
 /// `0xC122` — Target separation level.
-pub const CMD_TARGET_SEPARATION: u8 = 0x22;
+pub(crate) const CMD_TARGET_SEPARATION: u8 = 0x22;
 
 /// `0xC123` — Doppler mode.
-pub const CMD_DOPPLER: u8 = 0x23;
+pub(crate) const CMD_DOPPLER: u8 = 0x23;
 
 /// `0xC124` — Doppler speed threshold, u16 LE in cm/s (range 0..=1594).
-pub const CMD_DOPPLER_SPEED_THRESHOLD: u8 = 0x24;
+pub(crate) const CMD_DOPPLER_SPEED_THRESHOLD: u8 = 0x24;
 
 /// `0xC130` — Installation setting (antenna height, antenna offsets, etc).
 /// Payload: 4-byte tag followed by setting-specific data.
-pub const CMD_INSTALLATION: u8 = 0x30;
+pub(crate) const CMD_INSTALLATION: u8 = 0x30;
 
 /// `0xC131` — Accent light level.
-pub const CMD_ACCENT_LIGHT: u8 = 0x31;
+pub(crate) const CMD_ACCENT_LIGHT: u8 = 0x31;
 
 /// `0xC1A0` — "Stay on scanner A" ping (keeps the MFD as the active client).
-pub const CMD_STAY_ON_A: u8 = 0xA0;
+pub(crate) const CMD_STAY_ON_A: u8 = 0xA0;
 
 /// `0xC1C0` — No-transmit sector range (step 2 of a 2-part command).
-pub const CMD_NOTRANSMIT_SECTOR: u8 = 0xC0;
+pub(crate) const CMD_NOTRANSMIT_SECTOR: u8 = 0xC0;
 
 // =============================================================================
 // Installation command (0xC130) tags
 // =============================================================================
 
 /// Set antenna height. Payload: i32 LE millimetres.
-pub const INSTALL_TAG_ANTENNA_HEIGHT: u8 = 0x01;
+pub(crate) const INSTALL_TAG_ANTENNA_HEIGHT: u8 = 0x01;
 
 /// Set antenna offset from GPS position. Payload: i32 LE ahead mm + i32 LE starboard mm.
-pub const INSTALL_TAG_ANTENNA_OFFSET: u8 = 0x04;
+pub(crate) const INSTALL_TAG_ANTENNA_OFFSET: u8 = 0x04;
 
 // =============================================================================
 // Query sub-opcodes (MFD → radar, category 0xC2)
 // =============================================================================
 
-/// `0xC201` — Request a batch of state reports (StateSetup, StateConfig,
-/// StateFeatures, StatePropertiesExtended, StateInstallation).
-pub const QUERY_REPORTS_BATCH: u8 = 0x01;
+/// `0xC201` — Request a batch of state reports (StateSetup, StateProperties,
+/// StateConfig, StateInstallation, StatePropertiesExtended).
+pub(crate) const QUERY_REPORTS_BATCH: u8 = 0x01;
 
-/// `0xC202` — Request StateFeatures.
-pub const QUERY_STATE_CONFIG: u8 = 0x02;
+/// `0xC202` — Request StateConfig (0xC404).
+pub(crate) const QUERY_STATE_CONFIG: u8 = 0x02;
 
-/// `0xC203` — Request StateSetup and StateInstallation.
-pub const QUERY_SETUP_AND_INSTALLATION: u8 = 0x03;
+/// `0xC203` — Request StateSetup (0xC402) and StateInstallation (0xC406).
+pub(crate) const QUERY_SETUP_AND_INSTALLATION: u8 = 0x03;
 
-/// `0xC204` — Request StateConfig (model info and firmware).
-pub const QUERY_STATE_PROPERTIES: u8 = 0x04;
+/// `0xC204` — Request StateProperties (0xC403).
+pub(crate) const QUERY_STATE_PROPERTIES: u8 = 0x04;
 
 // =============================================================================
 // Packet constructors — common discovery / query byte sequences
 // =============================================================================
 
-/// Request a StateConfig report (`0xC204`).
-pub const REQUEST_STATE_PROPERTIES: [u8; 2] = [QUERY_STATE_PROPERTIES, CATEGORY_QUERY];
+/// Request a StateProperties report (`0xC204` → radar replies with `0xC403`).
+pub(crate) const REQUEST_STATE_PROPERTIES: [u8; 2] = [QUERY_STATE_PROPERTIES, CATEGORY_QUERY];
 
 /// Request a batch of state reports (`0xC201`).
-pub const REQUEST_STATE_BATCH: [u8; 2] = [QUERY_REPORTS_BATCH, CATEGORY_QUERY];
+pub(crate) const REQUEST_STATE_BATCH: [u8; 2] = [QUERY_REPORTS_BATCH, CATEGORY_QUERY];
 
 /// "Stay on scanner A" ping (`0xC1A0`).
-pub const COMMAND_STAY_ON_A: [u8; 2] = [CMD_STAY_ON_A, CATEGORY_CONTROL];
+pub(crate) const COMMAND_STAY_ON_A: [u8; 2] = [CMD_STAY_ON_A, CATEGORY_CONTROL];
 
 /// Spoke/radar line status bytes that indicate a valid spoke payload.
 /// Different HALO firmware revisions use different upper bits, so we accept
@@ -328,4 +332,4 @@ pub const COMMAND_STAY_ON_A: [u8; 2] = [CMD_STAY_ON_A, CATEGORY_CONTROL];
 /// - `0x02` — BR24 valid spoke (from the 2011 Dabrowski paper)
 /// - `0x12` — observed on 4G and newer
 /// - `0xC2` — observed on HALO 20+
-pub const VALID_SPOKE_STATUSES: [u8; 3] = [0x02, 0x12, 0xC2];
+pub(crate) const VALID_SPOKE_STATUSES: [u8; 3] = [0x02, 0x12, 0xC2];

--- a/src/lib/brand/navico/settings.rs
+++ b/src/lib/brand/navico/settings.rs
@@ -14,7 +14,7 @@ use crate::{
     stream::SignalKDelta,
 };
 
-pub fn new(
+pub(crate) fn new(
     radar_id: String,
     sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
     args: &Cli,
@@ -87,7 +87,7 @@ pub fn new(
     SharedControls::new(radar_id, sk_client_tx, args, controls)
 }
 
-pub fn update_when_model_known(
+pub(crate) fn update_when_model_known(
     controls: &mut SharedControls,
     model: Model,
     radar_info: &RadarInfo,
@@ -220,7 +220,7 @@ pub fn update_when_model_known(
 /// Refine controls based on 0xC409 TLV capabilities. Called after
 /// `update_when_model_known` for HALO models when the capability
 /// advertisement arrives from the radar.
-pub fn update_from_capabilities(
+pub(crate) fn update_from_capabilities(
     controls: &mut SharedControls,
     caps: &super::capabilities::NavicoCapabilities,
 ) {

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -11,7 +11,7 @@ use crate::radar::{RadarError, RadarInfo};
 mod quantum;
 mod rd;
 
-pub struct Command {
+pub(crate) struct Command {
     key: String,
     info: RadarInfo,
     model: BaseModel,
@@ -19,7 +19,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn new(info: RadarInfo, model: BaseModel) -> Self {
+    pub(crate) fn new(info: RadarInfo, model: BaseModel) -> Self {
         Command {
             key: info.key(),
             info,
@@ -28,7 +28,7 @@ impl Command {
         }
     }
 
-    pub fn set_ranges(&mut self, ranges: Ranges) {
+    pub(crate) fn set_ranges(&mut self, ranges: Ranges) {
         self.info.ranges = ranges;
     }
 

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -183,7 +183,7 @@ struct RaymarineBeacon56 {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum BaseModel {
+pub(crate) enum BaseModel {
     RD,
     Quantum,
 }

--- a/src/lib/brand/raymarine/protocol.rs
+++ b/src/lib/brand/raymarine/protocol.rs
@@ -19,10 +19,10 @@
 // =============================================================================
 
 /// Primary multicast discovery address (wired Ethernet).
-pub const DISCOVERY_ADDRESS_WIRED: &str = "224.0.0.1:5800";
+pub(crate) const DISCOVERY_ADDRESS_WIRED: &str = "224.0.0.1:5800";
 
 /// WiFi discovery address (Quantum WiFi radars).
-pub const DISCOVERY_ADDRESS_WIFI: &str = "232.1.1.1:5800";
+pub(crate) const DISCOVERY_ADDRESS_WIFI: &str = "232.1.1.1:5800";
 
 // =============================================================================
 // Beacon discovery protocol
@@ -52,29 +52,29 @@ pub const DISCOVERY_ADDRESS_WIFI: &str = "232.1.1.1:5800";
 // =============================================================================
 
 /// Subtypes in the 36-byte beacon (beacon_type = 0).
-pub mod beacon36 {
+pub(crate) mod beacon36 {
     /// Quantum radar — carries the multicast report and command addresses.
-    pub const QUANTUM: u32 = 0x28;
+    pub(crate) const QUANTUM: u32 = 0x28;
     /// RD (magnetron) radar.
-    pub const RD: u32 = 0x01;
+    pub(crate) const RD: u32 = 0x01;
     /// W3 wireless bridge forwarding a Quantum (different link_id). Ignored.
-    pub const W3: u32 = 0x29;
+    pub(crate) const W3: u32 = 0x29;
 
-    pub const LEN: usize = 36;
+    pub(crate) const LEN: usize = 36;
 }
 
 /// Subtypes in the 56-byte beacon (beacon_type = 1).
-pub mod beacon56 {
+pub(crate) mod beacon56 {
     /// Quantum radar identity — model name e.g. "QuantumRadar".
-    pub const QUANTUM: u32 = 0x66;
+    pub(crate) const QUANTUM: u32 = 0x66;
     /// RD (magnetron) radar identity.
-    pub const RD: u32 = 0x01;
+    pub(crate) const RD: u32 = 0x01;
     /// W3 wireless bridge identity — model name "Quantum_W3". Ignored.
-    pub const W3: u32 = 0x4d;
+    pub(crate) const W3: u32 = 0x4d;
     /// MFD announcement. Ignored.
-    pub const MFD: u32 = 0x11;
+    pub(crate) const MFD: u32 = 0x11;
 
-    pub const LEN: usize = 56;
+    pub(crate) const LEN: usize = 56;
 }
 
 // =============================================================================
@@ -82,132 +82,132 @@ pub mod beacon56 {
 // =============================================================================
 
 /// Quantum attributes/capabilities message.
-pub const MSG_QUANTUM_ATTRIBUTES: u32 = 0x280001;
+pub(crate) const MSG_QUANTUM_ATTRIBUTES: u32 = 0x280001;
 
 /// Quantum status report (controls state).
-pub const MSG_QUANTUM_STATUS: u32 = 0x280002;
+pub(crate) const MSG_QUANTUM_STATUS: u32 = 0x280002;
 
 /// Quantum spoke (scan) data.
-pub const MSG_QUANTUM_SPOKE: u32 = 0x280003;
+pub(crate) const MSG_QUANTUM_SPOKE: u32 = 0x280003;
 
 /// Quantum radar mode report.
-pub const MSG_QUANTUM_MODE: u32 = 0x280005;
+pub(crate) const MSG_QUANTUM_MODE: u32 = 0x280005;
 
 /// Quantum WiFi signal strength.
-pub const MSG_QUANTUM_SIGNAL: u32 = 0x280006;
+pub(crate) const MSG_QUANTUM_SIGNAL: u32 = 0x280006;
 
 /// Quantum feature flags (8 bytes: msg_id + u32 bitfield).
-pub const MSG_QUANTUM_FEATURES: u32 = 0x280007;
+pub(crate) const MSG_QUANTUM_FEATURES: u32 = 0x280007;
 
 /// Quantum parameters (per-range-channel tuning).
-pub const MSG_QUANTUM_PARAMETERS: u32 = 0x280008;
+pub(crate) const MSG_QUANTUM_PARAMETERS: u32 = 0x280008;
 
 /// Quantum Doppler status.
-pub const MSG_QUANTUM_DOPPLER_STATUS: u32 = 0x280030;
+pub(crate) const MSG_QUANTUM_DOPPLER_STATUS: u32 = 0x280030;
 
 // =============================================================================
 // RD report message IDs (radar → MFD)
 // =============================================================================
 
 /// RD (analogue) status report.
-pub const MSG_RD_STATUS: u32 = 0x010001;
+pub(crate) const MSG_RD_STATUS: u32 = 0x010001;
 
 /// RD HD status report.
-pub const MSG_RD_STATUS_HD: u32 = 0x018801;
+pub(crate) const MSG_RD_STATUS_HD: u32 = 0x018801;
 
 /// RD fixed capabilities report.
-pub const MSG_RD_FIXED: u32 = 0x010002;
+pub(crate) const MSG_RD_FIXED: u32 = 0x010002;
 
 /// RD spoke (scan) data.
-pub const MSG_RD_SPOKE: u32 = 0x010003;
+pub(crate) const MSG_RD_SPOKE: u32 = 0x010003;
 
 /// RD serial number / info report.
-pub const MSG_RD_INFO: u32 = 0x010006;
+pub(crate) const MSG_RD_INFO: u32 = 0x010006;
 
 // =============================================================================
 // Quantum command leads (first 2 bytes of command)
 // =============================================================================
 
 /// Quantum power on/off.
-pub const CMD_Q_POWER: [u8; 2] = [0x10, 0x00];
+pub(crate) const CMD_Q_POWER: [u8; 2] = [0x10, 0x00];
 
 /// Quantum set range.
-pub const CMD_Q_RANGE: [u8; 2] = [0x01, 0x01];
+pub(crate) const CMD_Q_RANGE: [u8; 2] = [0x01, 0x01];
 
 /// Quantum gain mode (auto/manual).
-pub const CMD_Q_GAIN_MODE: [u8; 2] = [0x01, 0x03];
+pub(crate) const CMD_Q_GAIN_MODE: [u8; 2] = [0x01, 0x03];
 
 /// Quantum gain value (manual).
-pub const CMD_Q_GAIN_VALUE: [u8; 2] = [0x02, 0x83];
+pub(crate) const CMD_Q_GAIN_VALUE: [u8; 2] = [0x02, 0x83];
 
 /// Quantum color gain mode.
-pub const CMD_Q_COLOR_GAIN_MODE: [u8; 2] = [0x03, 0x03];
+pub(crate) const CMD_Q_COLOR_GAIN_MODE: [u8; 2] = [0x03, 0x03];
 
 /// Quantum color gain value.
-pub const CMD_Q_COLOR_GAIN_VALUE: [u8; 2] = [0x04, 0x03];
+pub(crate) const CMD_Q_COLOR_GAIN_VALUE: [u8; 2] = [0x04, 0x03];
 
 /// Quantum sea clutter mode.
-pub const CMD_Q_SEA_MODE: [u8; 2] = [0x05, 0x03];
+pub(crate) const CMD_Q_SEA_MODE: [u8; 2] = [0x05, 0x03];
 
 /// Quantum sea clutter value.
-pub const CMD_Q_SEA_VALUE: [u8; 2] = [0x06, 0x03];
+pub(crate) const CMD_Q_SEA_VALUE: [u8; 2] = [0x06, 0x03];
 
 /// Quantum rain clutter enable.
-pub const CMD_Q_RAIN_ENABLE: [u8; 2] = [0x0b, 0x03];
+pub(crate) const CMD_Q_RAIN_ENABLE: [u8; 2] = [0x0b, 0x03];
 
 /// Quantum rain clutter value.
-pub const CMD_Q_RAIN_VALUE: [u8; 2] = [0x0c, 0x03];
+pub(crate) const CMD_Q_RAIN_VALUE: [u8; 2] = [0x0c, 0x03];
 
 /// Quantum target expansion.
-pub const CMD_Q_TARGET_EXPANSION: [u8; 2] = [0x0f, 0x03];
+pub(crate) const CMD_Q_TARGET_EXPANSION: [u8; 2] = [0x0f, 0x03];
 
 /// Quantum interference rejection.
-pub const CMD_Q_INTERFERENCE_REJECTION: [u8; 2] = [0x11, 0x03];
+pub(crate) const CMD_Q_INTERFERENCE_REJECTION: [u8; 2] = [0x11, 0x03];
 
 /// Quantum operating mode (Harbor/Coastal/Offshore/Weather).
-pub const CMD_Q_MODE: [u8; 2] = [0x14, 0x03];
+pub(crate) const CMD_Q_MODE: [u8; 2] = [0x14, 0x03];
 
 /// Quantum Doppler mode (0x00=off, 0x03=on).
-pub const CMD_Q_DOPPLER: [u8; 2] = [0x17, 0x03];
+pub(crate) const CMD_Q_DOPPLER: [u8; 2] = [0x17, 0x03];
 
 /// Quantum bearing alignment.
-pub const CMD_Q_BEARING_ALIGNMENT: [u8; 2] = [0x01, 0x04];
+pub(crate) const CMD_Q_BEARING_ALIGNMENT: [u8; 2] = [0x01, 0x04];
 
 /// Quantum main bang suppression.
-pub const CMD_Q_MBS: [u8; 2] = [0x0a, 0x04];
+pub(crate) const CMD_Q_MBS: [u8; 2] = [0x0a, 0x04];
 
 /// Quantum sea clutter curve.
-pub const CMD_Q_SEA_CURVE: [u8; 2] = [0x12, 0x03];
+pub(crate) const CMD_Q_SEA_CURVE: [u8; 2] = [0x12, 0x03];
 
 /// Quantum no-transmit sector 1.
-pub const CMD_Q_BLANK_SECTOR_1: [u8; 2] = [0x05, 0x04];
+pub(crate) const CMD_Q_BLANK_SECTOR_1: [u8; 2] = [0x05, 0x04];
 
 /// Quantum no-transmit sector 2.
-pub const CMD_Q_BLANK_SECTOR_2: [u8; 2] = [0x03, 0x04];
+pub(crate) const CMD_Q_BLANK_SECTOR_2: [u8; 2] = [0x03, 0x04];
 
 // =============================================================================
 // Quantum heartbeat / keep-alive
 // =============================================================================
 
 /// 1-second keep-alive for Quantum (12 bytes, contains "Radar").
-pub const HEARTBEAT_QUANTUM_1S: [u8; 12] = [
+pub(crate) const HEARTBEAT_QUANTUM_1S: [u8; 12] = [
     0x00, 0x00, 0x28, 0x00, 0x52, 0x61, 0x64, 0x61, 0x72, 0x00, 0x00, 0x00,
 ];
 
 /// 5-second extended keep-alive for Quantum (36 bytes).
-pub const HEARTBEAT_QUANTUM_5S: [u8; 36] = [
+pub(crate) const HEARTBEAT_QUANTUM_5S: [u8; 36] = [
     0x03, 0x89, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9e, 0x03, 0x00, 0x00, 0xb4, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00,
 ];
 
 /// 1-second keep-alive for RD/E120 (12 bytes, contains "RADAR").
-pub const HEARTBEAT_RD_1S: [u8; 12] = [
+pub(crate) const HEARTBEAT_RD_1S: [u8; 12] = [
     0x00, 0x80, 0x01, 0x00, 0x52, 0x41, 0x44, 0x41, 0x52, 0x00, 0x00, 0x00,
 ];
 
 /// 5-second extended keep-alive for RD/E120 (36 bytes).
-pub const HEARTBEAT_RD_5S: [u8; 36] = [
+pub(crate) const HEARTBEAT_RD_5S: [u8; 36] = [
     0x03, 0x89, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x68, 0x01, 0x00, 0x00, 0x9e, 0x03, 0x00, 0x00, 0xb4, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00,
@@ -217,59 +217,59 @@ pub const HEARTBEAT_RD_5S: [u8; 36] = [
 // Feature flags (from 0x280007 Features message)
 // =============================================================================
 
-pub const FEATURE_ANALOGUE: u32 = 1 << 0;
-pub const FEATURE_DIGITAL: u32 = 1 << 2;
-pub const FEATURE_QUANTUM: u32 = 1 << 4;
-pub const FEATURE_EDOME: u32 = 1 << 9;
-pub const FEATURE_BIRD_MODE: u32 = 1 << 10;
-pub const FEATURE_NO_DUAL_RANGE_RESTRICTIONS: u32 = 1 << 11;
-pub const FEATURE_MARPA: u32 = 1 << 14;
-pub const FEATURE_DUAL_RANGE_MARPA: u32 = 1 << 16;
-pub const FEATURE_MARPA_BEYOND_12NM: u32 = 1 << 17;
-pub const FEATURE_AUTO_RAIN: u32 = 1 << 18;
-pub const FEATURE_DOPPLER: u32 = 1 << 19;
-pub const FEATURE_DOPPLER_AUTO_ACQUIRE: u32 = 1 << 20;
-pub const FEATURE_CYCLONE: u32 = 1 << 23;
-pub const FEATURE_DOPPLER_BIRD_MODE: u32 = 1 << 25;
+pub(crate) const FEATURE_ANALOGUE: u32 = 1 << 0;
+pub(crate) const FEATURE_DIGITAL: u32 = 1 << 2;
+pub(crate) const FEATURE_QUANTUM: u32 = 1 << 4;
+pub(crate) const FEATURE_EDOME: u32 = 1 << 9;
+pub(crate) const FEATURE_BIRD_MODE: u32 = 1 << 10;
+pub(crate) const FEATURE_NO_DUAL_RANGE_RESTRICTIONS: u32 = 1 << 11;
+pub(crate) const FEATURE_MARPA: u32 = 1 << 14;
+pub(crate) const FEATURE_DUAL_RANGE_MARPA: u32 = 1 << 16;
+pub(crate) const FEATURE_MARPA_BEYOND_12NM: u32 = 1 << 17;
+pub(crate) const FEATURE_AUTO_RAIN: u32 = 1 << 18;
+pub(crate) const FEATURE_DOPPLER: u32 = 1 << 19;
+pub(crate) const FEATURE_DOPPLER_AUTO_ACQUIRE: u32 = 1 << 20;
+pub(crate) const FEATURE_CYCLONE: u32 = 1 << 23;
+pub(crate) const FEATURE_DOPPLER_BIRD_MODE: u32 = 1 << 25;
 
 // =============================================================================
 // Spoke geometry
 // =============================================================================
 
 /// Quantum: 250 spokes per revolution.
-pub const QUANTUM_SPOKES_PER_REVOLUTION: u16 = 250;
+pub(crate) const QUANTUM_SPOKES_PER_REVOLUTION: u16 = 250;
 
 /// RD: 2048 spokes per revolution.
-pub const RD_SPOKES_PER_REVOLUTION: u16 = 2048;
+pub(crate) const RD_SPOKES_PER_REVOLUTION: u16 = 2048;
 
 /// Quantum: maximum 252 samples per spoke.
-pub const QUANTUM_MAX_SPOKE_LEN: usize = 252;
+pub(crate) const QUANTUM_MAX_SPOKE_LEN: usize = 252;
 
 /// RD HD: maximum 1024 samples per spoke.
-pub const RD_HD_MAX_SPOKE_LEN: usize = 1024;
+pub(crate) const RD_HD_MAX_SPOKE_LEN: usize = 1024;
 
 /// RD non-HD: 512 samples per spoke.
-pub const RD_MAX_SPOKE_LEN: usize = 512;
+pub(crate) const RD_MAX_SPOKE_LEN: usize = 512;
 
 /// RLE escape byte in spoke data.
-pub const RLE_MARKER: u8 = 0x5c;
+pub(crate) const RLE_MARKER: u8 = 0x5c;
 
 // =============================================================================
 // Doppler pixel encoding
 // =============================================================================
 
 /// Spoke pixel value for Doppler receding targets.
-pub const DOPPLER_RECEDING: u8 = 0xfe;
+pub(crate) const DOPPLER_RECEDING: u8 = 0xfe;
 
 /// Spoke pixel value for Doppler approaching targets.
-pub const DOPPLER_APPROACHING: u8 = 0xff;
+pub(crate) const DOPPLER_APPROACHING: u8 = 0xff;
 
 // =============================================================================
 // NavData message
 // =============================================================================
 
 /// NavData sub-ID (prepended to the 32-byte payload).
-pub const NAVDATA_SUB_ID: u32 = 0x28000018;
+pub(crate) const NAVDATA_SUB_ID: u32 = 0x28000018;
 
 /// NavData interval.
-pub const NAVDATA_INTERVAL_MS: u64 = 100;
+pub(crate) const NAVDATA_INTERVAL_MS: u64 = 100;

--- a/src/lib/brand/raymarine/settings.rs
+++ b/src/lib/brand/raymarine/settings.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::BaseModel;
 
-pub fn new(
+pub(crate) fn new(
     radar_id: String,
     sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
     args: &Cli,
@@ -110,7 +110,7 @@ pub fn new(
     SharedControls::new(radar_id, sk_client_tx, args, controls)
 }
 
-pub fn update_when_model_known(
+pub(crate) fn update_when_model_known(
     controls: &mut SharedControls,
     model: &RaymarineModel,
     radar_info: &RadarInfo,

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -13,7 +13,7 @@ use crate::radar::RadarInfo;
 use crate::radar::range::Ranges;
 use crate::radar::settings::ControlId;
 
-pub fn get_project_dirs() -> ProjectDirs {
+pub(crate) fn get_project_dirs() -> ProjectDirs {
     directories::ProjectDirs::from("net", "verruijt", "mayara")
         .expect("Cannot find project directories")
 }
@@ -49,7 +49,7 @@ pub struct ExclusionRect {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct Radar {
+pub(crate) struct Radar {
     pub id: usize,
     pub user_name: String,
     #[serde(default)]
@@ -95,7 +95,7 @@ pub struct Radar {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct Config {
+pub(crate) struct Config {
     pub radars: HashMap<String, Radar>,
 }
 
@@ -107,7 +107,7 @@ pub(crate) struct Persistence {
 }
 
 impl Persistence {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         if crate::replay::is_active() {
             debug!("persistence disabled in pcap replay mode");
             return Persistence {
@@ -216,7 +216,7 @@ impl Persistence {
         };
     }
 
-    pub fn store(&mut self, radar_info: &RadarInfo) {
+    pub(crate) fn store(&mut self, radar_info: &RadarInfo) {
         if self.path.as_os_str().is_empty() {
             return; // Pcap replay mode — no persistence
         }
@@ -358,7 +358,7 @@ impl Persistence {
         }
     }
 
-    pub fn update_info_from_persistence(&self, info: &mut RadarInfo) {
+    pub(crate) fn update_info_from_persistence(&self, info: &mut RadarInfo) {
         if let Some(p) = self.config.radars.get(&info.key()) {
             if p.model_name.is_some() {
                 info.controls

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -37,7 +37,7 @@ pub(crate) struct LocatorAddress {
 // unsafe impl Send for LocatorAddress {}
 
 impl LocatorAddress {
-    pub fn new(
+    pub(crate) fn new(
         id: LocatorId,
         address: &SocketAddr,
         brand: Brand,
@@ -79,7 +79,7 @@ pub(crate) struct Locator {
 }
 
 impl Locator {
-    pub fn new(args: Cli, radars: SharedRadars) -> Self {
+    pub(crate) fn new(args: Cli, radars: SharedRadars) -> Self {
         Locator { radars, args }
     }
 

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -25,7 +25,7 @@ pub fn set_replay(replay: bool) {
 // This is like a SocketAddrV4 but with known layout
 #[derive(Deserialize, Copy, Clone)]
 #[repr(C)]
-pub struct NetworkSocketAddrV4 {
+pub(crate) struct NetworkSocketAddrV4 {
     addr: [u8; 4],
     port: [u8; 2],
 }
@@ -61,7 +61,7 @@ impl fmt::Debug for NetworkSocketAddrV4 {
 
 #[derive(Deserialize, Copy, Clone)]
 #[repr(C)]
-pub struct LittleEndianSocketAddrV4 {
+pub(crate) struct LittleEndianSocketAddrV4 {
     addr: [u8; 4],
     port: [u8; 2],
 }
@@ -96,7 +96,7 @@ impl fmt::Debug for LittleEndianSocketAddrV4 {
 }
 
 // this will be common for all our sockets
-pub fn new_socket() -> io::Result<socket2::Socket> {
+pub(crate) fn new_socket() -> io::Result<socket2::Socket> {
     let socket = socket2::Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
 
     // we're going to use read timeouts so that we don't hang waiting for packets
@@ -209,11 +209,12 @@ fn bind_to_broadcast(
 }
 
 /// Socket type for `create_udp_listen`.
-pub enum SocketType {
+pub(crate) enum SocketType {
     /// Auto-detect from address: multicast if the IP is in a multicast
     /// range, broadcast if in a broadcast range, unicast otherwise.
     Any,
     /// Unicast/plain: bind to INADDR_ANY on the given port.
+    #[allow(dead_code)]
     Unicast,
     /// Broadcast: set SO_BROADCAST and bind to the broadcast address.
     Broadcast,
@@ -224,7 +225,7 @@ pub enum SocketType {
 /// Create a `RadarSocket` for a listen address. If pcap replay is
 /// active, returns a replay-backed socket. Otherwise creates a real
 /// UDP socket bound according to `socket_type`.
-pub fn create_udp_listen(
+pub(crate) fn create_udp_listen(
     addr: &SocketAddrV4,
     nic_addr: &Ipv4Addr,
     socket_type: SocketType,
@@ -267,7 +268,7 @@ pub fn create_udp_listen(
     Ok(crate::replay::RadarSocket::Udp(socket))
 }
 
-pub fn create_multicast_send(addr: &SocketAddrV4, nic_addr: &Ipv4Addr) -> io::Result<UdpSocket> {
+pub(crate) fn create_multicast_send(addr: &SocketAddrV4, nic_addr: &Ipv4Addr) -> io::Result<UdpSocket> {
     let socket: socket2::Socket = new_socket()?;
 
     let socketaddr = SocketAddr::new(IpAddr::V4(*addr.ip()), addr.port());
@@ -279,7 +280,7 @@ pub fn create_multicast_send(addr: &SocketAddrV4, nic_addr: &Ipv4Addr) -> io::Re
     Ok(socket)
 }
 
-pub fn match_ipv4(addr: &Ipv4Addr, bcast: &Ipv4Addr, netmask: &Ipv4Addr) -> bool {
+pub(crate) fn match_ipv4(addr: &Ipv4Addr, bcast: &Ipv4Addr, netmask: &Ipv4Addr) -> bool {
     let r = addr & netmask;
     let b = bcast & netmask;
     r == b

--- a/src/lib/pcap.rs
+++ b/src/lib/pcap.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 /// A single UDP packet extracted from a pcap file.
 #[derive(Debug, Clone)]
-pub struct PcapPacket {
+pub(crate) struct PcapPacket {
     /// Time offset from the first packet in the capture.
     pub timestamp: Duration,
     /// Source IP and port.
@@ -43,7 +43,7 @@ const ETHERTYPE_IPV4: u16 = 0x0800;
 const IP_PROTO_UDP: u8 = 17;
 
 /// Parse a pcap file (or gzipped pcap) and return all UDP packets.
-pub fn parse_file(path: &Path) -> io::Result<Vec<PcapPacket>> {
+pub(crate) fn parse_file(path: &Path) -> io::Result<Vec<PcapPacket>> {
     let data = if path.extension().map_or(false, |e| e == "gz") {
         let file = fs::File::open(path)?;
         let mut decoder = flate2::read::GzDecoder::new(file);
@@ -57,7 +57,7 @@ pub fn parse_file(path: &Path) -> io::Result<Vec<PcapPacket>> {
 }
 
 /// Parse pcap data from a byte slice.
-pub fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
+pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
     if data.len() < 24 {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "pcap too short"));
     }
@@ -181,7 +181,8 @@ fn parse_udp_packet(data: &[u8], timestamp: Duration) -> Option<PcapPacket> {
 
 /// Write packets back to a pcap file. Creates a valid pcap with
 /// Ethernet + IPv4 + UDP headers wrapping each payload.
-pub fn write_file(path: &Path, packets: &[PcapPacket]) -> io::Result<()> {
+#[cfg(test)]
+pub(crate) fn write_file(path: &Path, packets: &[PcapPacket]) -> io::Result<()> {
     let mut data = Vec::new();
 
     // Global header (24 bytes): magic, version 2.4, timezone 0, sigfigs 0, snaplen 65535, linktype 1 (Ethernet)

--- a/src/lib/replay.rs
+++ b/src/lib/replay.rs
@@ -28,7 +28,7 @@ use crate::pcap::{self, PcapPacket};
 /// A socket that can receive UDP packets from either a real network
 /// socket or from the pcap replay dispatcher. Receivers use this
 /// instead of `tokio::net::UdpSocket` directly.
-pub enum RadarSocket {
+pub(crate) enum RadarSocket {
     /// Real network UDP socket.
     Udp(UdpSocket),
     /// Pcap replay channel.
@@ -51,14 +51,14 @@ impl RadarSocket {
 
 /// A packet received from replay, including the original source address.
 #[derive(Debug, Clone)]
-pub struct ReplayPacket {
+pub(crate) struct ReplayPacket {
     pub data: Vec<u8>,
     pub from: SocketAddrV4,
 }
 
 /// A replay receiver that can be used in place of a UDP socket.
 /// Wraps an mpsc receiver of `ReplayPacket`.
-pub struct ReplayReceiver {
+pub(crate) struct ReplayReceiver {
     rx: mpsc::Receiver<ReplayPacket>,
 }
 
@@ -117,7 +117,7 @@ pub fn init(path: &Path) -> io::Result<()> {
 }
 
 /// Returns true if pcap replay is active.
-pub fn is_active() -> bool {
+pub(crate) fn is_active() -> bool {
     REPLAY.get().is_some()
 }
 
@@ -126,7 +126,7 @@ pub fn is_active() -> bool {
 ///
 /// The returned `ReplayReceiver` has the same `recv_buf_from` API as
 /// `UdpSocket`, so receivers can use it with minimal code changes.
-pub fn create_listen(addr: &SocketAddrV4) -> Option<ReplayReceiver> {
+pub(crate) fn create_listen(addr: &SocketAddrV4) -> Option<ReplayReceiver> {
     let state = REPLAY.get()?;
 
     let (tx, rx) = mpsc::channel(512);

--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-pub fn c_string(bytes: &[u8]) -> Option<&str> {
+pub(crate) fn c_string(bytes: &[u8]) -> Option<&str> {
     let bytes_without_null = match bytes.iter().position(|&b| b == 0) {
         Some(ix) => &bytes[..ix],
         None => bytes,
@@ -10,7 +10,7 @@ pub fn c_string(bytes: &[u8]) -> Option<&str> {
 
     std::str::from_utf8(bytes_without_null).ok()
 }
-pub fn c_wide_string(bytes: &[u8]) -> String {
+pub(crate) fn c_wide_string(bytes: &[u8]) -> String {
     let mut res = String::new();
 
     let mut i = bytes.iter();
@@ -26,10 +26,10 @@ pub fn c_wide_string(bytes: &[u8]) -> String {
     res
 }
 
-pub struct PrintableSlice<'a>(&'a [u8]);
+pub(crate) struct PrintableSlice<'a>(&'a [u8]);
 
 impl<'a> PrintableSlice<'a> {
-    pub fn new<T>(data: &'a T) -> PrintableSlice<'a>
+    pub(crate) fn new<T>(data: &'a T) -> PrintableSlice<'a>
     where
         T: ?Sized + AsRef<[u8]> + 'a,
     {
@@ -56,10 +56,10 @@ impl fmt::Display for PrintableSlice<'_> {
     }
 }
 
-pub struct PrintableSpoke<'a>(&'a [u8]);
+pub(crate) struct PrintableSpoke<'a>(&'a [u8]);
 
 impl<'a> PrintableSpoke<'a> {
-    pub fn new<T>(data: &'a T) -> PrintableSpoke<'a>
+    pub(crate) fn new<T>(data: &'a T) -> PrintableSpoke<'a>
     where
         T: ?Sized + AsRef<[u8]> + 'a,
     {


### PR DESCRIPTION
## Summary
- Replace `pub` with `pub(crate)` for internal items across all brand modules, config, locator, network, pcap, replay, and util
- Gate test-only `pcap::write_file` with `#[cfg(test)]` and add `#[allow(dead_code)]` on `SocketType::Unicast` to eliminate compiler warnings
- Document the visibility preference in AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reduces the public API surface of the crate by restricting visibility of internal items from `pub` to `pub(crate)` across all brand modules, configuration, locator, network, PCAP, replay, and utility modules. Additionally, it gates test-only functionality and addresses compiler warnings while documenting the visibility preference.

## Changes

**Documentation**
- Updates `AGENTS.md` to establish a guideline: prefer minimal visibility using `pub(crate)` or private instead of `pub`, unless the item is part of the public API.

**Brand Modules (Emulator, Furuno, Garmin, Navico, Raymarine)**
- Restricts visibility of command, report receiver, and settings types and their constructors from `pub` to `pub(crate)` across all brand implementations
- Restricts visibility of protocol constants, enums, and helper functions from `pub` to `pub(crate)` (e.g., spoke geometry, message IDs, encoding constants, address/port definitions, wire index conversion utilities)
- Restricts visibility of capability-checking types and their associated methods from `pub` to `pub(crate)`
- In the Emulator module, restricts visibility of world simulation types (`Target`, `Buoy`, `CirclingTarget`, `LandArea`, `LocalCache`, `EmulatorWorld`) and their methods from `pub` to `pub(crate)`

**Configuration and Utilities**
- Restricts `config.rs` public types (`Radar`, `Config`) and `Persistence` methods (`new`, `store`, `update_info_from_persistence`) from `pub` to `pub(crate)`
- Restricts `locator.rs` constructors (`LocatorAddress::new`, `Locator::new`) from `pub` to `pub(crate)`
- Restricts `util.rs` helper functions and types (`c_string`, `c_wide_string`, `PrintableSlice`, `PrintableSpoke`) from `pub` to `pub(crate)`

**Network and I/O**
- Restricts `network/mod.rs` socket types and functions (`NetworkSocketAddrV4`, `LittleEndianSocketAddrV4`, `new_socket`, `SocketType`, `create_udp_listen`, `create_multicast_send`, `match_ipv4`) from `pub` to `pub(crate)`
- Adds `#[allow(dead_code)]` attribute to `SocketType::Unicast` to suppress compiler warnings
- Restricts `pcap.rs` types and functions (`PcapPacket`, `parse_file`, `parse_bytes`) from `pub` to `pub(crate)`
- Gates `pcap::write_file` with `#[cfg(test)]` and restricts it to `pub(crate)`, making it available only in test builds
- Restricts `replay.rs` types and functions (`RadarSocket`, `ReplayPacket`, `ReplayReceiver`, `is_active`, `create_listen`) from `pub` to `pub(crate)`

## Impact

These changes reduce the crate's public API surface, clarifying that the types and functions being restricted are internal implementation details not intended for external use. The changes preserve all internal logic and behavior while establishing clearer module boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->