### PR TITLE
docs(furuno): clarify DRS4W network setup and model identification

### DIFF
--- a/docs/furuno-setup.md
+++ b/docs/furuno-setup.md
@@ -16,7 +16,7 @@ Mayara's _Network_ page will show a warning if no interface has an address in th
 ### DRS4W WiFi
 
 The DRS4W ("1st Watch") creates its own WiFi network. Connect the Mayara machine to the radar's WiFi access point and start Mayara with `--allow-wifi`.
-Multiple  concurrent clients are allowed, so you can use the IOS application along with the Mayara machine.
+Multiple concurrent clients are allowed, you can use the standard Marine Radar IOS application along with the Mayara machine.
 
 ## DRS / DRS-NXT Series
 

--- a/docs/furuno-setup.md
+++ b/docs/furuno-setup.md
@@ -4,7 +4,7 @@ This guide covers network configuration for all Furuno radar families supported 
 
 ## Network Requirements
 
-All Furuno radars (except DRS4W WiFi) communicate on the `172.31.0.0/16` subnet. The machine running Mayara **must** have an IP address on this subnet or the radar will not be detected.
+All Furuno radars communicate on the `172.31.0.0/16` subnet. The machine running Mayara **must** have an IP address on this subnet or the radar will not be detected.
 
 Recommended configuration:
 - IP address: `172.31.3.150` (or any unused address in `172.31.x.x`)
@@ -16,6 +16,7 @@ Mayara's _Network_ page will show a warning if no interface has an address in th
 ### DRS4W WiFi
 
 The DRS4W ("1st Watch") creates its own WiFi network. Connect the Mayara machine to the radar's WiFi access point and start Mayara with `--allow-wifi`.
+Multiple  concurrent clients are allowed, so you can use the IOS application along with the Mayara machine.
 
 ## DRS / DRS-NXT Series
 
@@ -50,6 +51,7 @@ Mayara identifies FAR models from the 7-digit part code in the `$N96` Modules re
 | 0359281 | FAR-3000 |
 | 0359286 | FAR-3000 |
 | 0359477 | FAR-3000 |
+| 0359329 | DRS4W    |
 
 Unrecognized part codes still work with default capabilities. Please report the part code and model so it can be added.
 

--- a/docs/furuno-setup.md
+++ b/docs/furuno-setup.md
@@ -32,12 +32,12 @@ Mayara identifies DRS models from the 7-digit part code in the `$N96` Modules re
 | Part Code | Model       |
 |-----------|-------------|
 | 0359235   | DRS         |
-| 0359329   | DRS4W       |
 | 0359338   | DRS4DL      |
-| 0359355   | DRS6AXCLASS |
-| 0359360   | DRS4DNXT    |
 | 0359367   | DRS4DL      |
+| 0359360   | DRS4DNXT    |
+| 0359329   | DRS4W       |
 | 0359421   | DRS6ANXT    |
+| 0359355   | DRS6AXCLASS |
 
 ## FAR Series (FAR-2xx7, FAR-15x3, FAR-3000)
 
@@ -58,15 +58,15 @@ Mayara identifies FAR models from the 7-digit part code in the `$N96` Modules re
 
 | Part Code | Model    |
 |-----------|----------|
-| 0359204   | FAR-21x7 |
+| 0359397   | FAR-14x6 |
 | 0359255   | FAR-14x7 |
-| 0359281   | FAR-3000 |
-| 0359286   | FAR-3000 |
 | 0359321   | FAR-14x7 |
 | 0359344   | FAR-15x3 |
-| 0359397   | FAR-14x6 |
-| 0359477   | FAR-3000 |
+| 0359204   | FAR-21x7 |
 | 0359560   | FAR-21x7 |
+| 0359281   | FAR-3000 |
+| 0359286   | FAR-3000 |
+| 0359477   | FAR-3000 |
 
 Unrecognized part codes still work with default capabilities. Please report the part code and model so it can be added.
 

--- a/docs/furuno-setup.md
+++ b/docs/furuno-setup.md
@@ -16,13 +16,28 @@ Mayara's _Network_ page will show a warning if no interface has an address in th
 ### DRS4W WiFi
 
 The DRS4W ("1st Watch") creates its own WiFi network. Connect the Mayara machine to the radar's WiFi access point and start Mayara with `--allow-wifi`.
-Multiple concurrent clients are allowed, you can use the standard Marine Radar IOS application along with the Mayara machine.
+
+Multiple concurrent clients are allowed; you can use the standard Marine Radar iOS application alongside Mayara.
 
 ## DRS / DRS-NXT Series
 
 DRS radars (DRS4D-NXT, DRS6A-NXT, DRS12A-NXT, DRS25A-NXT, and older DRS/X-Class models) work out of the box once the IP subnet is configured. No mode changes are needed on the radar itself.
 
 The radar broadcasts discovery beacons and Mayara detects the model automatically from the beacon data.
+
+### DRS Model Detection
+
+Mayara identifies DRS models from the 7-digit part code in the `$N96` Modules response:
+
+| Part Code | Model       |
+|-----------|-------------|
+| 0359235   | DRS         |
+| 0359329   | DRS4W       |
+| 0359338   | DRS4DL      |
+| 0359355   | DRS6AXCLASS |
+| 0359360   | DRS4DNXT    |
+| 0359367   | DRS4DL      |
+| 0359421   | DRS6ANXT    |
 
 ## FAR Series (FAR-2xx7, FAR-15x3, FAR-3000)
 
@@ -41,17 +56,17 @@ To change the IMO mode on the FAR-2xx7:
 
 Mayara identifies FAR models from the 7-digit part code in the `$N96` Modules response:
 
-| Part Code | Model |
-|-----------|-------|
-| 0359204 | FAR-21x7 |
-| 0359560 | FAR-21x7 |
-| 0359321 | FAR-14x7 |
-| 0359397 | FAR-14x6 |
-| 0359344 | FAR-15x3 |
-| 0359281 | FAR-3000 |
-| 0359286 | FAR-3000 |
-| 0359477 | FAR-3000 |
-| 0359329 | DRS4W    |
+| Part Code | Model    |
+|-----------|----------|
+| 0359204   | FAR-21x7 |
+| 0359255   | FAR-14x7 |
+| 0359281   | FAR-3000 |
+| 0359286   | FAR-3000 |
+| 0359321   | FAR-14x7 |
+| 0359344   | FAR-15x3 |
+| 0359397   | FAR-14x6 |
+| 0359477   | FAR-3000 |
+| 0359560   | FAR-21x7 |
 
 Unrecognized part codes still work with default capabilities. Please report the part code and model so it can be added.
 


### PR DESCRIPTION
Small update of the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR clarifies Furuno setup documentation and improves DRS/FAR model identification.

- States that all Furuno radars communicate on the 172.31.0.0/16 subnet (removes the previous DRS4W exception) and keeps the recommended IP/subnet guidance.
- Updates the DRS4W WiFi note to state multiple concurrent clients are supported and that the standard Marine Radar iOS app can be used alongside Mayara.
- Splits the single model-detection table into separate "DRS Model Detection" and "FAR Model Detection" tables under their respective sections, sorting entries ascending by part code.
- Adds missing DRS part-code mappings (0359235 → DRS, 0359338 → DRS4DL, 0359360 → DRS4DNXT, 0359421 → DRS6ANXT, 0359355 → DRS6AXCLASS) and adds FAR part code 0359255 → FAR-14x7 (these are already supported by src/lib/brand/furuno/protocol.rs::from_part_number).
- Fixes grammar, punctuation, and capitalization (changes "IOS" to "iOS") in the DRS4W concurrent-clients note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->