### PR TITLE
feat(furuno): wire 3-band Target Analyzer Doppler format into wire_to_legend

### DIFF
--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -31,6 +31,16 @@ use crate::radar::settings::ControlId;
 use crate::radar::{Power, RadarError, RadarInfo};
 use crate::util::PrintableSpoke;
 
+/// Furuno wire-format decoding mode. When Target Analyzer is active on NXT
+/// radars, each echo byte encodes `[dopplerClass:2 | intensity:4 | 00:2]`
+/// rather than a plain intensity in 0..PIXEL_VALUES. The report receiver
+/// rebuilds the `wire_to_legend` table when this mode changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DopplerWireMode {
+    Off,
+    On,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ReceiveAddressType {
     Both,
@@ -79,7 +89,7 @@ pub(crate) struct FurunoReportReceiver {
     /// Precomputed raw-byte → palette-index lookup table. Built when the model
     /// and legend are known. DRS4W/DRS use an 18th-root gamma curve to spread
     /// the bottom-heavy echo distribution; other models use a linear mapping.
-    echo_lut: [u8; 256],
+    wire_to_legend: [u8; 256],
 }
 
 impl FurunoReportReceiver {
@@ -99,7 +109,8 @@ impl FurunoReportReceiver {
             .map(RadarModel::from_model_name)
             .unwrap_or(RadarModel::Unknown);
         let low_power = model.is_low_power();
-        let echo_lut = Self::build_echo_lut(info.pixel_colors(), low_power);
+        let wire_to_legend =
+            Self::wire_to_legend(&info.get_legend(), DopplerWireMode::Off, low_power);
 
         let control_update_rx = info.control_update_subscribe();
         let blob_tx = radars.get_blob_tx();
@@ -129,7 +140,7 @@ impl FurunoReportReceiver {
             prev_angle: [0, 0],
             guard_zone_alarm: [false, false],
             alarm_active: false,
-            echo_lut,
+            wire_to_legend,
         }
     }
 
@@ -930,8 +941,9 @@ impl FurunoReportReceiver {
             );
             self.model = model;
             let low_power = model.is_low_power();
-            self.echo_lut = Self::build_echo_lut(
-                self.common.info.pixel_colors(),
+            self.wire_to_legend = Self::wire_to_legend(
+                &self.common.info.get_legend(),
+                self.doppler_wire_mode(),
                 low_power,
             );
             if low_power {
@@ -1154,7 +1166,7 @@ impl FurunoReportReceiver {
                 SPOKE_LEN,
             );
 
-            let echo_lut = &self.echo_lut;
+            let wire_to_legend = &self.wire_to_legend;
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1162,7 +1174,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
-                    echo_lut,
+                    wire_to_legend,
                 );
             } else {
                 Self::add_spoke_to_common(
@@ -1171,7 +1183,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
-                    echo_lut,
+                    wire_to_legend,
                 );
             }
 
@@ -1297,7 +1309,7 @@ impl FurunoReportReceiver {
                 scale: TILE_SCALE,
             };
 
-            let echo_lut = &self.echo_lut;
+            let wire_to_legend = &self.wire_to_legend;
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1305,7 +1317,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
-                    echo_lut,
+                    wire_to_legend,
                 );
             } else {
                 Self::add_spoke_to_common(
@@ -1314,7 +1326,7 @@ impl FurunoReportReceiver {
                     angle,
                     heading,
                     &send_spoke,
-                    echo_lut,
+                    wire_to_legend,
                 );
             }
 
@@ -1477,14 +1489,23 @@ impl FurunoReportReceiver {
         out
     }
 
-    /// Build the raw-byte → palette-index lookup table.
+    /// Build the raw-byte → legend-index lookup table.
     ///
     /// Low-power radars (DRS4W, DRS) have a bottom-heavy echo distribution
     /// where 95% of returns are below raw value 64. An 18th-root (gamma 0.056)
     /// curve aggressively compresses the range so that even weak returns
     /// reach red, matching the Furuno iOS app's vivid visual output.
     /// Full-power models (NXT, FAR) use a linear mapping.
-    fn build_echo_lut(pixel_colors: u8, low_power: bool) -> [u8; 256] {
+    ///
+    /// When `doppler_mode` is `On`, the Target Analyzer wire format is
+    /// decoded — this is populated in a later commit. For now both modes
+    /// produce the same intensity mapping.
+    fn wire_to_legend(
+        legend: &crate::radar::Legend,
+        _doppler_mode: DopplerWireMode,
+        low_power: bool,
+    ) -> [u8; 256] {
+        let pixel_colors = legend.pixel_colors;
         let pixel_max = pixel_colors.saturating_sub(1) as u16;
         let usable = pixel_max.saturating_sub(ECHO_FLOOR);
         let mut lut = [0u8; 256];
@@ -1500,13 +1521,30 @@ impl FurunoReportReceiver {
         lut
     }
 
+    /// Derive the wire-decoding mode from the current Doppler control value.
+    /// `0` (Off) → `Off`; any non-zero value (Target, Rain) → `On`.
+    fn doppler_wire_mode(&self) -> DopplerWireMode {
+        let v = self
+            .common
+            .info
+            .controls
+            .get(&ControlId::Doppler)
+            .and_then(|c| c.value)
+            .unwrap_or(0.0);
+        if v == 0.0 {
+            DopplerWireMode::Off
+        } else {
+            DopplerWireMode::On
+        }
+    }
+
     fn add_spoke_to_common(
         common: &mut CommonRadar,
         metadata: &FurunoSpokeMetadata,
         angle: SpokeBearing,
         heading: SpokeBearing,
         sweep: &[u8],
-        echo_lut: &[u8; 256],
+        wire_to_legend: &[u8; 256],
     ) {
         if common.replay {
             let _ = common
@@ -1530,7 +1568,7 @@ impl FurunoReportReceiver {
         let mut data = vec![0; sweep.len()];
 
         for (i, b) in sweep.iter().enumerate() {
-            data[i] = echo_lut[*b as usize];
+            data[i] = wire_to_legend[*b as usize];
         }
 
         log::trace!(

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -779,7 +779,22 @@ impl FurunoReportReceiver {
                     2.0 // Rain
                 };
 
+                let old_mode = self.doppler_wire_mode();
                 self.common.set_value(&ControlId::Doppler, value);
+                let new_mode = self.doppler_wire_mode();
+                if old_mode != new_mode {
+                    let low_power = self.model.is_low_power();
+                    self.wire_to_legend = Self::wire_to_legend(
+                        &self.common.info.get_legend(),
+                        new_mode,
+                        low_power,
+                    );
+                    log::debug!(
+                        "{}: Doppler wire mode changed to {:?}",
+                        self.common.key,
+                        new_mode
+                    );
+                }
             }
 
             CommandId::Tune => {
@@ -1491,20 +1506,31 @@ impl FurunoReportReceiver {
 
     /// Build the raw-byte → legend-index lookup table.
     ///
-    /// Low-power radars (DRS4W, DRS) have a bottom-heavy echo distribution
-    /// where 95% of returns are below raw value 64. An 18th-root (gamma 0.056)
-    /// curve aggressively compresses the range so that even weak returns
-    /// reach red, matching the Furuno iOS app's vivid visual output.
-    /// Full-power models (NXT, FAR) use a linear mapping.
+    /// With `doppler_mode == Off` each wire byte is a plain intensity in
+    /// `0..=PIXEL_VALUES`. Low-power radars (DRS4W, DRS) have a bottom-heavy
+    /// echo distribution where 95% of returns are below raw value 64; an
+    /// 18th-root (gamma 0.056) curve aggressively compresses the range so
+    /// that even weak returns reach red, matching the Furuno iOS app's vivid
+    /// visual output. Full-power models (NXT, FAR) use a linear mapping.
     ///
-    /// When `doppler_mode` is `On`, the Target Analyzer wire format is
-    /// decoded — this is populated in a later commit. For now both modes
-    /// produce the same intensity mapping.
+    /// With `doppler_mode == On` (NXT Target Analyzer active) each byte is
+    /// `[dopplerClass:2 | intensity:4 | 00:2]`. The top two bits select the
+    /// class (rain / stationary / approaching); the middle four bits are a
+    /// 16-level intensity within the band. Separator ranges `0x3D..=0x3F`,
+    /// `0x7D..=0x7F`, `0xBD..=0xBF` are never emitted by the radar and map
+    /// to transparent. See research/furuno/mfd-radar-palette.md.
     fn wire_to_legend(
         legend: &crate::radar::Legend,
-        _doppler_mode: DopplerWireMode,
+        doppler_mode: DopplerWireMode,
         low_power: bool,
     ) -> [u8; 256] {
+        match doppler_mode {
+            DopplerWireMode::Off => Self::wire_to_legend_off(legend, low_power),
+            DopplerWireMode::On => Self::wire_to_legend_on(legend, low_power),
+        }
+    }
+
+    fn wire_to_legend_off(legend: &crate::radar::Legend, low_power: bool) -> [u8; 256] {
         let pixel_colors = legend.pixel_colors;
         let pixel_max = pixel_colors.saturating_sub(1) as u16;
         let usable = pixel_max.saturating_sub(ECHO_FLOOR);
@@ -1518,6 +1544,55 @@ impl FurunoReportReceiver {
             };
             lut[raw as usize] = mapped.min(pixel_max) as u8;
         }
+        lut
+    }
+
+    fn wire_to_legend_on(legend: &crate::radar::Legend, low_power: bool) -> [u8; 256] {
+        // Per-band constants derived from the 3-band wire encoding:
+        // high 2 bits = class, middle 4 bits = intensity, low 2 bits = 00.
+        // Valid intra-band bytes are `base..=(base + BAND_TOP_OFFSET)`, giving
+        // 16 distinct intensity levels per band.
+        const BAND_SIZE: u16 = 0x40;
+        const BAND_TOP_OFFSET: u16 = 0x3C; // 60 = 15 * 4
+        const RAIN_BASE: u16 = 0x00;
+        const STATIONARY_BASE: u16 = 0x40;
+        const APPROACHING_BASE: u16 = 0x80;
+
+        let stationary_lut = Self::wire_to_legend_off(legend, low_power);
+        let mut lut = [0u8; 256];
+
+        let (rain_start, rain_count) = legend.doppler_rain.unwrap_or((0, 0));
+        let (appr_start, appr_count) = legend.doppler_approaching.unwrap_or((0, 0));
+
+        for b in 0u16..BAND_SIZE {
+            if b > BAND_TOP_OFFSET {
+                continue; // separator bytes 0x3D..=0x3F stay 0 (transparent)
+            }
+            let sub = (b >> 2) as u8; // 0..=15 intensity within band
+            // Rain band
+            if rain_count > 0 {
+                lut[(RAIN_BASE + b) as usize] = rain_start + sub * rain_count / 16;
+            } else {
+                // No rain slot available: fall through to the low end of the
+                // stationary intensity ramp so rain is still visible.
+                lut[(RAIN_BASE + b) as usize] = stationary_lut[(STATIONARY_BASE + b) as usize];
+            }
+            // Stationary band: reuse the TA-off intensity mapping for the
+            // equivalent raw byte (b + 0x40).
+            lut[(STATIONARY_BASE + b) as usize] = stationary_lut[(STATIONARY_BASE + b) as usize];
+            // Approaching band
+            if appr_count > 0 {
+                lut[(APPROACHING_BASE + b) as usize] = appr_start + sub * appr_count / 16;
+            } else {
+                // No approaching slot available: fall through to the stationary
+                // intensity ramp so approaching targets are still visible.
+                lut[(APPROACHING_BASE + b) as usize] =
+                    stationary_lut[(STATIONARY_BASE + b) as usize];
+            }
+        }
+        // Byte 0 is always transparent; explicitly restate for clarity.
+        lut[0] = 0;
+        // The 0xC0..=0xFF band is unused in TA mode on NXT; leave as 0.
         lut
     }
 
@@ -1733,5 +1808,98 @@ async fn conditional_read(
     match reader {
         Some(s) => Some(s.read_line(line).await),
         None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::radar::Legend;
+
+    /// Minimal `Legend` shaped like a post-TA NXT: 120 intensity slots,
+    /// 1 approaching slot, 1 receding slot, 1 rain slot, mirroring what
+    /// `default_legend(.., doppler_levels=1, has_rain_class=true, 120)`
+    /// would produce. Only the fields used by `wire_to_legend_{off,on}`
+    /// are populated.
+    fn nxt_ta_legend() -> Legend {
+        Legend {
+            pixels: Vec::new(),
+            pixel_colors: 120,
+            history_start: 0,
+            doppler_approaching: Some((121, 1)),
+            doppler_receding: Some((122, 1)),
+            doppler_rain: Some((123, 1)),
+            strong_return: 0,
+            medium_return: 0,
+            low_return: 0,
+            static_background: None,
+        }
+    }
+
+    #[test]
+    fn wire_to_legend_off_nxt_is_linear() {
+        let legend = nxt_ta_legend();
+        let lut =
+            FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::Off, false);
+        assert_eq!(lut[0], 0, "raw 0 must be transparent");
+        // raw 252 (PIXEL_VALUES) should reach the top of the intensity ramp.
+        assert_eq!(lut[PIXEL_VALUES as usize], legend.pixel_colors - 1);
+    }
+
+    #[test]
+    fn wire_to_legend_off_drs4w_is_nonlinear() {
+        let legend = nxt_ta_legend();
+        let lut_linear =
+            FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::Off, false);
+        let lut_gamma =
+            FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::Off, true);
+        // 18th-root curve must lift low raw values above the linear mapping.
+        assert!(lut_gamma[4] > lut_linear[4]);
+    }
+
+    #[test]
+    fn wire_to_legend_on_maps_three_bands() {
+        let legend = nxt_ta_legend();
+        let lut =
+            FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::On, false);
+
+        let rain_start = legend.doppler_rain.unwrap().0;
+        let appr_start = legend.doppler_approaching.unwrap().0;
+
+        // Transparent / separators
+        assert_eq!(lut[0], 0, "byte 0 is transparent");
+        assert_eq!(lut[0x3D], 0, "rain/stationary separator is transparent");
+        assert_eq!(lut[0x3F], 0);
+        assert_eq!(lut[0x7D], 0, "stationary/approaching separator");
+        assert_eq!(lut[0x7F], 0);
+        assert_eq!(lut[0xBD], 0, "approaching/unused separator");
+        assert_eq!(lut[0xBF], 0);
+        assert_eq!(lut[0xFC], 0, "unused band stays transparent");
+
+        // Rain band: 0x00..=0x3C with single-slot rain legend
+        assert_eq!(lut[0x04], rain_start);
+        assert_eq!(lut[0x3C], rain_start);
+
+        // Stationary band: reuses the TA-off intensity ramp for the same
+        // raw byte value.
+        let off = FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::Off, false);
+        assert_eq!(lut[0x40], off[0x40]);
+        assert_eq!(lut[0x7C], off[0x7C]);
+
+        // Approaching band
+        assert_eq!(lut[0x80], appr_start);
+        assert_eq!(lut[0xBC], appr_start);
+    }
+
+    #[test]
+    fn wire_to_legend_on_without_rain_slot_falls_back_to_intensity() {
+        let mut legend = nxt_ta_legend();
+        legend.doppler_rain = None;
+        let lut =
+            FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::On, false);
+        let off = FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::Off, false);
+        // Without a rain slot, rain-range bytes reuse the stationary
+        // intensity mapping at (b + 0x40).
+        assert_eq!(lut[0x04], off[0x44]);
     }
 }

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -1922,6 +1922,33 @@ mod tests {
     }
 
     #[test]
+    fn wire_to_legend_on_uses_16_level_gradient_per_band() {
+        // Legend with 16 sub-levels per Doppler band, mirroring what
+        // set_doppler_levels(16) + set_has_rain_class(true) produces.
+        let legend = Legend {
+            pixels: Vec::new(),
+            pixel_colors: 120,
+            history_start: 0,
+            doppler_approaching: Some((120, 16)),
+            doppler_receding: Some((136, 16)),
+            doppler_rain: Some((152, 16)),
+            strong_return: 0,
+            medium_return: 0,
+            low_return: 0,
+            static_background: None,
+        };
+        let lut =
+            FurunoReportReceiver::wire_to_legend(&legend, DopplerWireMode::On, false);
+        // Each step of 4 in the raw byte moves one slot in the legend.
+        assert_eq!(lut[0x80], 120, "approaching lowest intensity");
+        assert_eq!(lut[0x84], 121);
+        assert_eq!(lut[0xBC], 135, "approaching highest intensity");
+        assert_eq!(lut[0x00], 0, "raw byte 0 is transparent");
+        assert_eq!(lut[0x04], 153, "rain second-lowest intensity");
+        assert_eq!(lut[0x3C], 167, "rain highest intensity");
+    }
+
+    #[test]
     fn wire_to_legend_on_without_rain_slot_falls_back_to_intensity() {
         let mut legend = nxt_ta_legend();
         legend.doppler_rain = None;

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -86,10 +86,12 @@ pub(crate) struct FurunoReportReceiver {
     prev_angle: [u16; 2],
     guard_zone_alarm: [bool; 2],
     alarm_active: bool,
-    /// Precomputed raw-byte → palette-index lookup table. Built when the model
-    /// and legend are known. DRS4W/DRS use an 18th-root gamma curve to spread
-    /// the bottom-heavy echo distribution; other models use a linear mapping.
-    wire_to_legend: [u8; 256],
+    /// Precomputed raw-byte → legend-index lookup tables, one per range
+    /// (index 0 = Range A, 1 = Range B). Range A and B can have independent
+    /// Target Analyzer state in dual-range mode, so each needs its own LUT.
+    /// DRS4W/DRS use an 18th-root gamma curve to spread the bottom-heavy
+    /// echo distribution; other models use a linear mapping.
+    wire_to_legend: [[u8; 256]; 2],
 }
 
 impl FurunoReportReceiver {
@@ -109,8 +111,9 @@ impl FurunoReportReceiver {
             .map(RadarModel::from_model_name)
             .unwrap_or(RadarModel::Unknown);
         let low_power = model.is_low_power();
-        let wire_to_legend =
+        let initial_lut =
             Self::wire_to_legend(&info.get_legend(), DopplerWireMode::Off, low_power);
+        let wire_to_legend = [initial_lut, initial_lut];
 
         let control_update_rx = info.control_update_subscribe();
         let blob_tx = radars.get_blob_tx();
@@ -417,10 +420,11 @@ impl FurunoReportReceiver {
                 // $N69,{status},{drid},{wman},{w_send},{w_stop},0
                 numbers.get(1).copied().unwrap_or(0.0)
             }
-            CommandId::Gain | CommandId::Range | CommandId::Tune => {
+            CommandId::Gain | CommandId::Range | CommandId::Tune | CommandId::TargetAnalyzer => {
                 // $N63,{auto},{val},{drid},{auto_val},0
                 // $N62,{wire_idx},{unit},{drid}
                 // $N75,{auto},{value},{drid}
+                // $NEF,{enabled},{mode},{screen}
                 numbers.get(2).copied().unwrap_or(0.0)
             }
             CommandId::Sea | CommandId::Rain => {
@@ -779,19 +783,33 @@ impl FurunoReportReceiver {
                     2.0 // Rain
                 };
 
-                let old_mode = self.doppler_wire_mode();
-                self.common.set_value(&ControlId::Doppler, value);
-                let new_mode = self.doppler_wire_mode();
+                let drid = self.extract_drid(&command_id, &numbers);
+                let range_idx = if drid == 1 && self.common_b.is_some() {
+                    1
+                } else {
+                    0
+                };
+                let old_mode = self.doppler_wire_mode_for(range_idx);
+                self.common_for_range(drid)
+                    .set_value(&ControlId::Doppler, value);
+                let new_mode = self.doppler_wire_mode_for(range_idx);
                 if old_mode != new_mode {
                     let low_power = self.model.is_low_power();
-                    self.wire_to_legend = Self::wire_to_legend(
-                        &self.common.info.get_legend(),
-                        new_mode,
-                        low_power,
-                    );
+                    let legend = if range_idx == 1 {
+                        self.common_b.as_ref().unwrap().info.get_legend()
+                    } else {
+                        self.common.info.get_legend()
+                    };
+                    self.wire_to_legend[range_idx] =
+                        Self::wire_to_legend(&legend, new_mode, low_power);
+                    let key = if range_idx == 1 {
+                        &self.common_b.as_ref().unwrap().key
+                    } else {
+                        &self.common.key
+                    };
                     log::debug!(
                         "{}: Doppler wire mode changed to {:?}",
-                        self.common.key,
+                        key,
                         new_mode
                     );
                 }
@@ -956,11 +974,18 @@ impl FurunoReportReceiver {
             );
             self.model = model;
             let low_power = model.is_low_power();
-            self.wire_to_legend = Self::wire_to_legend(
+            self.wire_to_legend[0] = Self::wire_to_legend(
                 &self.common.info.get_legend(),
-                self.doppler_wire_mode(),
+                self.doppler_wire_mode_for(0),
                 low_power,
             );
+            if let Some(ref cb) = self.common_b {
+                self.wire_to_legend[1] = Self::wire_to_legend(
+                    &cb.info.get_legend(),
+                    self.doppler_wire_mode_for(1),
+                    low_power,
+                );
+            }
             if low_power {
                 log::info!("{}: using gamma echo curve for low-power radar", self.common.key);
             }
@@ -1181,7 +1206,7 @@ impl FurunoReportReceiver {
                 SPOKE_LEN,
             );
 
-            let wire_to_legend = &self.wire_to_legend;
+            let wire_to_legend = &self.wire_to_legend[range_idx];
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1324,7 +1349,7 @@ impl FurunoReportReceiver {
                 scale: TILE_SCALE,
             };
 
-            let wire_to_legend = &self.wire_to_legend;
+            let wire_to_legend = &self.wire_to_legend[range_idx];
             if is_range_b {
                 Self::add_spoke_to_common(
                     self.common_b.as_mut().unwrap(),
@@ -1596,11 +1621,16 @@ impl FurunoReportReceiver {
         lut
     }
 
-    /// Derive the wire-decoding mode from the current Doppler control value.
-    /// `0` (Off) → `Off`; any non-zero value (Target, Rain) → `On`.
-    fn doppler_wire_mode(&self) -> DopplerWireMode {
-        let v = self
-            .common
+    /// Derive the wire-decoding mode from the current Doppler control value
+    /// for the given range (0 = A, 1 = B). `0` (Off) → `Off`; any non-zero
+    /// value (Target, Rain) → `On`.
+    fn doppler_wire_mode_for(&self, range_idx: usize) -> DopplerWireMode {
+        let common = if range_idx == 1 {
+            self.common_b.as_ref().unwrap_or(&self.common)
+        } else {
+            &self.common
+        };
+        let v = common
             .info
             .controls
             .get(&ControlId::Doppler)
@@ -1826,9 +1856,9 @@ mod tests {
             pixels: Vec::new(),
             pixel_colors: 120,
             history_start: 0,
-            doppler_approaching: Some((121, 1)),
-            doppler_receding: Some((122, 1)),
-            doppler_rain: Some((123, 1)),
+            doppler_approaching: Some((120, 1)),
+            doppler_receding: Some((121, 1)),
+            doppler_rain: Some((122, 1)),
             strong_return: 0,
             medium_return: 0,
             low_return: 0,

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -363,6 +363,9 @@ pub(crate) fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, v
         };
         info.controls
             .add(new_list(ControlId::Doppler, doppler_options));
+        // NXT radars encode rain as a distinct class on the wire when
+        // Target Analyzer is active. Reserve a legend slot for it.
+        info.set_has_rain_class(true);
     }
     if cap.watchman {
         info.controls

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -366,6 +366,10 @@ pub(crate) fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, v
         // NXT radars encode rain as a distinct class on the wire when
         // Target Analyzer is active. Reserve a legend slot for it.
         info.set_has_rain_class(true);
+        // Each Doppler band carries a 4-bit intensity on the wire (16 levels).
+        // Reserve 16 legend slots per direction so the UI can render an
+        // intensity gradient instead of a single flat color.
+        info.set_doppler_levels(16);
     }
     if cap.watchman {
         info.controls

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -1529,6 +1529,7 @@ mod tests {
             history_start: 0,
             doppler_approaching: None,
             doppler_receding: None,
+            doppler_rain: None,
             strong_return: 0,
             medium_return: 0,
             low_return: 0,

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -572,10 +572,6 @@ impl RadarInfo {
     pub fn get_legend(&self) -> Legend {
         self.legend.clone()
     }
-
-    pub(crate) fn pixel_colors(&self) -> u8 {
-        self.legend.pixel_colors
-    }
 }
 
 impl Display for RadarInfo {

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -124,6 +124,7 @@ enum PixelType {
     Normal,
     DopplerApproaching,
     DopplerReceding,
+    DopplerRain,
     History,
 }
 
@@ -221,6 +222,10 @@ pub struct Legend {
     pub doppler_approaching: Option<(u8, u8)>,
     /// Doppler receding pixel range: `(first_index, count)`.
     pub doppler_receding: Option<(u8, u8)>,
+    /// Doppler rain pixel range: `(first_index, count)`.
+    /// Only populated for radars that classify rain on the wire (Furuno NXT
+    /// Target Analyzer). `None` for all other radars.
+    pub doppler_rain: Option<(u8, u8)>,
     pub history_start: u8,
     pub low_return: u8,
     pub medium_return: u8,
@@ -308,6 +313,7 @@ pub struct RadarInfo {
     pub ranges: Ranges,                  // Ranges for this radar, empty in beginning
     pub doppler: bool,      // Does it support Doppler?
     doppler_levels: u8,     // Intensity sub-levels per direction (0, 1, or 4)
+    has_rain_class: bool,   // Radar classifies rain on the wire (Furuno NXT)
     pub dual_range: bool,                               // Is it dual range capable?
     pub sparse_spokes: bool, // Does it produce fewer spokes than spokes_per_revolution?
     pub stationary: bool,    // Is radar stationary (shore-based)?
@@ -349,7 +355,8 @@ impl RadarInfo {
             )
         };
         let doppler_levels = if doppler { 1 } else { 0 };
-        let legend = default_legend(&targets, doppler_levels, pixel_values);
+        let has_rain_class = false;
+        let legend = default_legend(&targets, doppler_levels, has_rain_class, pixel_values);
 
         let mut key = brand.to_prefix().to_string();
         if let Some(serial_no) = serial_no {
@@ -386,6 +393,7 @@ impl RadarInfo {
             controls,
             doppler,
             doppler_levels,
+            has_rain_class,
             dual_range: false,
             sparse_spokes,
             stationary: args.stationary,
@@ -428,8 +436,12 @@ impl RadarInfo {
         if doppler != self.doppler {
             self.doppler = doppler;
             self.doppler_levels = if doppler { 1 } else { 0 };
-            self.legend =
-                default_legend(&self.targets, self.doppler_levels, self.pixel_values);
+            self.legend = default_legend(
+                &self.targets,
+                self.doppler_levels,
+                self.has_rain_class,
+                self.pixel_values,
+            );
             log::debug!("Doppler changed to {}", doppler);
         }
     }
@@ -439,8 +451,12 @@ impl RadarInfo {
     pub fn set_doppler_levels(&mut self, levels: u8) {
         self.doppler = levels > 0;
         self.doppler_levels = levels;
-        self.legend =
-            default_legend(&self.targets, self.doppler_levels, self.pixel_values);
+        self.legend = default_legend(
+            &self.targets,
+            self.doppler_levels,
+            self.has_rain_class,
+            self.pixel_values,
+        );
         log::debug!(
             "Doppler levels changed to {} (doppler={})",
             levels,
@@ -448,10 +464,30 @@ impl RadarInfo {
         );
     }
 
+    /// Enable the rain Doppler class on this radar. Used by Furuno NXT where
+    /// the wire format encodes a third Doppler band (rain) in addition to
+    /// stationary and approaching.
+    pub(crate) fn set_has_rain_class(&mut self, has_rain_class: bool) {
+        if has_rain_class != self.has_rain_class {
+            self.has_rain_class = has_rain_class;
+            self.legend = default_legend(
+                &self.targets,
+                self.doppler_levels,
+                self.has_rain_class,
+                self.pixel_values,
+            );
+            log::debug!("Rain class changed to {}", has_rain_class);
+        }
+    }
+
     pub fn set_pixel_values(&mut self, pixel_values: u8) {
         if pixel_values != self.pixel_values {
-            self.legend =
-                default_legend(&self.targets, self.doppler_levels, pixel_values);
+            self.legend = default_legend(
+                &self.targets,
+                self.doppler_levels,
+                self.has_rain_class,
+                pixel_values,
+            );
             log::debug!("Pixel_values changed to {}", pixel_values);
         }
         self.pixel_values = pixel_values;
@@ -872,20 +908,31 @@ const OPAQUE: u8 = 255;
 /// - `0` — no Doppler (HD, plain xHD)
 /// - `1` — single flat Doppler color per direction (Navico HALO)
 /// - `4` — 4-level brightness gradient per direction (Garmin Fantom)
-fn default_legend(targets: &TargetMode, doppler_levels: u8, pixel_values: u8) -> Legend {
+fn default_legend(
+    targets: &TargetMode,
+    doppler_levels: u8,
+    has_rain_class: bool,
+    pixel_values: u8,
+) -> Legend {
     let mut legend = Legend {
         pixels: Vec::new(),
         pixel_colors: 0,
         history_start: 0,
         doppler_approaching: None,
         doppler_receding: None,
+        doppler_rain: None,
         strong_return: 0,
         medium_return: 0,
         low_return: 0,
         static_background: None,
     };
 
-    let doppler_total = doppler_levels * 2; // approaching + receding
+    let rain_levels: u8 = if has_rain_class && doppler_levels > 0 {
+        doppler_levels
+    } else {
+        0
+    };
+    let doppler_total = doppler_levels * 2 + rain_levels;
 
     // Calculate extra colors needed for special purposes
     let arpa_extra_colors: u8 = if *targets == TargetMode::Arpa {
@@ -1002,6 +1049,27 @@ fn default_legend(targets: &TargetMode, doppler_levels: u8, pixel_values: u8) ->
             });
         }
         legend.doppler_receding = Some((receding_start, doppler_levels));
+
+        if rain_levels > 0 {
+            let rain_start = legend.pixels.len() as u8;
+            for i in 0..rain_levels {
+                let brightness = if rain_levels == 1 {
+                    255
+                } else {
+                    64 + (i as u16 * 191 / (rain_levels as u16 - 1)) as u8
+                };
+                legend.pixels.push(Lookup {
+                    r#type: PixelType::DopplerRain,
+                    color: Color {
+                        r: 0,
+                        g: 0,
+                        b: brightness,
+                        a: OPAQUE,
+                    }, // Blue at varying brightness
+                });
+            }
+            legend.doppler_rain = Some((rain_start, rain_levels));
+        }
     }
 
     if *targets != TargetMode::None {
@@ -1038,7 +1106,7 @@ mod tests {
     #[test]
     fn legend() {
         let targets = crate::TargetMode::Arpa;
-        let legend = default_legend(&targets, 1, 16);
+        let legend = default_legend(&targets, 1, false, 16);
         let json = serde_json::to_string_pretty(&legend).unwrap();
         println!("{}", json);
     }


### PR DESCRIPTION
Brings Furuno in line with the unified `wire_to_legend` pipeline used by
Navico, Garmin and Raymarine (PR #125), and teaches it the 3-band wire
encoding NXT radars emit when Target Analyzer is active.

## Why

Furuno's old `build_echo_lut` assumed every byte on the wire was a plain
intensity in `0..=PIXEL_VALUES`. That is only true with TA off. With TA
on, each byte encodes `[dopplerClass:2 | intensity:4 | 00:2]`: 16-level
intensities in three bands (rain / stationary / approaching). See
[research/furuno/mfd-radar-palette.md](https://github.com/MarineYachtRadar/research/blob/e708be2/furuno/mfd-radar-palette.md)
for the spec and the live-hardware histograms that verify it.

## How

Four commits:

1. `feat(radar): add DopplerRain class to Legend` — new `PixelType::DopplerRain`
   and `Legend.doppler_rain`; opt-in via `RadarInfo::set_has_rain_class`.
   Navico / Garmin / Raymarine unaffected.
2. `refactor(furuno): rename build_echo_lut to wire_to_legend` — signature
   becomes `(&Legend, DopplerWireMode, low_power)`. TA-off behaviour
   (including the DRS4W 18th-root gamma curve) is byte-for-byte identical.
3. `feat(furuno): decode 3-band Target Analyzer wire format` — decode the
   three bands into their legend slots, enable the rain slot on NXT, and
   rebuild the LUT when the Doppler control changes.
4. `refactor(radar): remove unused RadarInfo::pixel_colors accessor` — last
   caller disappeared in commit 2.

Verified against `drs4dnxt-ta-off-halfNM-30s.pcap` captures in
`MarineYachtRadar/research`.

## Tested

- `cargo test` — 165 lib + 15 integration tests pass
- Unit tests cover TA-off linear + gamma paths and TA-on 3-band mapping
- Live DRS4D-NXT at the dock: TA-off renders identically to `main`; TA-on
  renders stationary / rain / approaching in distinct palette ranges

## Known follow-ups (not in this PR)

- UI rendering tweaks for the new rain class
- Stretching intensity sub-levels to full palette range (currently linear
  within each 16-level band)
- Client-side Target-vs-Rain display filter
- Tile-format Doppler decoding (this PR covers IMO encoding 3 only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR integrates Furuno radars into the unified wire_to_legend decoding pipeline used across Navico, Garmin, and Raymarine, and adds support for the 3-band Target Analyzer (TA) Doppler wire format emitted by NXT radars when TA is active.

## Changes

**Core infrastructure changes** (`src/lib/radar/mod.rs`)
- Adds PixelType::DopplerRain and extends Legend with doppler_rain: Option<(u8, u8)> to represent the rain-class pixel index range.
- Adds RadarInfo.has_rain_class: bool and a crate-visible set_has_rain_class() method to enable/disable rain classification.
- Updates default_legend(...) to accept has_rain_class and, when has_rain_class && doppler_levels > 0, appends a rain classification band (blue brightness gradient), reserves 16 levels per Doppler band, and populates doppler_rain.
- Removes the unused RadarInfo::pixel_colors() accessor.

**Furuno decoding changes** (`src/lib/brand/furuno/report.rs`)
- Replaces the single echo_lut with a range-aware wire_to_legend: [[u8; 256]; 2] so each A/B range stores its own LUT and Doppler state.
- Introduces DopplerWireMode (Off/On) and decodes ControlId::Doppler/CommandId::TargetAnalyzer to derive mode per range; rebuilds only the affected range's LUT when the mode transitions.
- Preserves TA-off behavior byte-for-byte (linear or DRS4W low-power gamma curve) and implements TA-on decoding of the 3-band format where each wire byte is [dopplerClass:2 | intensity:4 | 00:2], mapping the three bands (rain / stationary / approaching) into reserved legend slots and leaving separator/unused ranges transparent.
- Stores per-range LUTs to prevent dual-range NXT Doppler state from clobbering the other range.
- Adds unit tests covering TA-off linear vs gamma paths and TA-on three-band mapping (including separator transparency and fallback when rain/approaching legend slots are absent).

**Configuration changes** (`src/lib/brand/furuno/settings.rs`)
- When the Target Analyzer capability is present, calls info.set_has_rain_class(true) and sets doppler_levels to reserve 16 levels per band so the UI can render intra-band gradients.

**Test updates** (`src/lib/brand/garmin/report.rs`)
- Updates the empty_legend() test helper to initialize the new doppler_rain field to None.

## Verification

- cargo test passes (165 library + 15 integration tests).
- Unit tests validate TA-off linear and gamma LUTs and TA-on three-band decoding.
- Implementation is verified against research pcaps and live DRS4D-NXT hardware: TA-off rendering is identical to main; TA-on rendering shows distinct stationary / rain / approaching palette ranges.

## Notes & Follow-ups

- Follow-ups include UI rendering tweaks, intensity stretching, client filters, and tile-format Doppler decoding. Reference: research/furuno/mfd-radar-palette.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->