### PR TITLE
feat(koden): add Koden RADARpc radar support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ path = "src/lib/mod.rs"
 navico = []
 furuno = []
 garmin = []
+koden = []
 raymarine = []
 emulator = []
 # default = ["navico", "furuno", "raymarine"]
-default = ["navico", "furuno", "garmin", "raymarine", "emulator"]
+default = ["navico", "furuno", "garmin", "koden", "raymarine", "emulator"]
 
 [dependencies]
 ctor = "0.1"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Implemented but awaiting real-hardware validation:
 
 - [**Garmin**](docs/garmin-setup.md) — HD, xHD, xHD2, xHD3, Fantom, Fantom Pro (all models including dual range and MotionScope/Doppler)
 - [**Furuno**](docs/furuno-setup.md) — DRS, DRS4DL, DRS6A X-Class, FAR-15x3, FAR-3000
-- [**Koden**](docs/koden-setup.md) — MDS-5R, MDS-9R, MDS-10R, MDS-50R, MDS-51R, MDS-52R, MDS-61R, MDS-62R, MDS-63R (RADARpc series)
+- [**Koden**](docs/koden-setup.md) — MDS-1R/8R, MDS-5R, MDS-9R, MDS-10R, MDS-50R, MDS-51R, MDS-52R, MDS-61R, MDS-62R, MDS-63R (RADARpc series)
 - [**Raymarine**](docs/raymarine-setup.md) — HD, Magnum, Cyclone
 
 If your radar is not on the fully supported list, contact us to help with testing!

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Implemented but awaiting real-hardware validation:
 
 - [**Garmin**](docs/garmin-setup.md) — HD, xHD, xHD2, xHD3, Fantom, Fantom Pro (all models including dual range and MotionScope/Doppler)
 - [**Furuno**](docs/furuno-setup.md) — DRS, DRS4DL, DRS6A X-Class, FAR-15x3, FAR-3000
+- [**Koden**](docs/koden-setup.md) — MDS-5R, MDS-9R, MDS-10R, MDS-50R, MDS-51R, MDS-52R, MDS-61R, MDS-62R, MDS-63R (RADARpc series)
 - [**Raymarine**](docs/raymarine-setup.md) — HD, Magnum, Cyclone
 
 If your radar is not on the fully supported list, contact us to help with testing!

--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@ Fully supported and tested with real hardware:
 
 - [**Navico**](docs/navico-setup.md) — BR24, 3G, 4G, HALO 20, HALO 20+, HALO 24, HALO 2000–6000
 - [**Raymarine**](docs/raymarine-setup.md) — Quantum, RD series
-- [**Furuno**](docs/furuno-setup.md) — DRS-NXT series (DRS4D-NXT, DRS6A-NXT, DRS12A-NXT, DRS25A-NXT) including dual range
-- [**Furuno**](docs/furuno-setup.md) — DRS4W WiFi ("1st Watch")
-- [**Furuno**](docs/furuno-setup.md) — FAR-2xx7 series
+- [**Furuno**](docs/furuno-setup.md) — DRS-NXT series (DRS4D-NXT, DRS6A-NXT, DRS12A-NXT, DRS25A-NXT) including dual range, DRS4W WiFi ("1st Watch"), FAR-2xx7 series
 
 Implemented but awaiting real-hardware validation:
 
 - [**Garmin**](docs/garmin-setup.md) — HD, xHD, xHD2, xHD3, Fantom, Fantom Pro (all models including dual range and MotionScope/Doppler)
 - [**Furuno**](docs/furuno-setup.md) — DRS, DRS4DL, DRS6A X-Class, FAR-15x3, FAR-3000
-- [**Koden**](docs/koden-setup.md) — MDS-1R/8R, MDS-5R, MDS-9R, MDS-10R, MDS-50R, MDS-51R, MDS-52R, MDS-61R, MDS-62R, MDS-63R (RADARpc series)
+- [**Koden**](docs/koden-setup.md) — MDS-xxR control boxes with any antenna unit (RADARpc series)
 - [**Raymarine**](docs/raymarine-setup.md) — HD, Magnum, Cyclone
 
 If your radar is not on the fully supported list, contact us to help with testing!

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -16,7 +16,7 @@ Mayara is structured in three layers:
 │    Controls · Ranges · Spokes · Target Tracking   │
 ├──────────────────────────────────────────────────┤
 │              Brand Implementations                │
-│     Navico · Furuno · Garmin · Raymarine          │
+│  Navico · Furuno · Garmin · Koden · Raymarine     │
 │     Locator · Report Parser · Command Sender      │
 └──────────────────────────────────────────────────┘
          │                            │

--- a/docs/koden-setup.md
+++ b/docs/koden-setup.md
@@ -1,0 +1,51 @@
+# Koden Radar Setup
+
+This guide covers connecting Mayara to Koden marine radars via the RADARpc Ethernet control boxes (MDS-5R, MDS-6R, MDS-11R).
+
+## Network Requirements
+
+Koden radars communicate via UDP broadcast on port 10001. The machine running Mayara must be on the same subnet as the radar.
+
+The default Koden radar IP is typically in the `192.168.0.x` range. Configure the machine running Mayara with a static IP on the same subnet.
+
+## Supported Models
+
+| Model Code | Model   | Power  | Antenna        |
+| ---------- | ------- | ------ | -------------- |
+| 0          | MDS-50R | 2 kW   | Dome           |
+| 1          | MDS-51R | 4 kW   | Dome           |
+| 2          | MDS-52R | 4 kW   | Open Array     |
+| 3          | MDS-61R | 6 kW   | Open Array     |
+| 4          | MDS-62R | 12 kW  | Open Array     |
+| 5          | MDS-63R | 25 kW  | Open Array     |
+| 6          | MDS-1R/8R | 2 kW | Dome           |
+| 10         | MDS-10R | 4 kW   | Open Array     |
+| 14         | MDS-9R  | 4 kW   | Dome           |
+| 15         | MDS-5R  | —      | Interface only |
+
+Model detection is automatic via the model code response from the radar.
+
+## Controls
+
+Mayara supports the following Koden controls:
+
+- **Power** — standby / transmit
+- **Gain** — manual (0–100%) or auto
+- **Sea clutter (STC)** — manual (0–100%)
+- **Rain clutter (FTC)** — manual (0–100%)
+- **Sea state** — manual / auto / harbor mode
+- **Interference rejection** — off / low / medium / high
+- **Target expansion** — on / off
+- **Scan speed** — normal / fast
+- **Tune** — coarse tuning (0–255) with manual / auto mode
+- **Fine tune** — fine tuning adjustment (0–15)
+- **Pulse width** — short / long
+- **Display timing** — trigger delay compensation for cable length (0–124)
+- **No-transmit sector** — blanking sector start/end angles
+- **Park position** — antenna park angle
+
+## Troubleshooting
+
+**Radar not detected**: Verify the machine and radar are on the same subnet. Koden radars use UDP broadcast on port 10001 — ensure no firewall is blocking this port. Try running with `--brand koden` to limit detection to Koden radars only.
+
+**No spokes displayed**: The radar must be in transmit mode. Use the power control to switch from standby to transmit. New radars may require a warmup period before transmitting.

--- a/docs/koden-setup.md
+++ b/docs/koden-setup.md
@@ -10,20 +10,26 @@ The default Koden radar IP is typically in the `192.168.0.x` range. Configure th
 
 ## Supported Models
 
-| Model Code | Model   | Power  | Antenna        |
-| ---------- | ------- | ------ | -------------- |
-| 0          | MDS-50R | 2 kW   | Dome           |
-| 1          | MDS-51R | 4 kW   | Dome           |
-| 2          | MDS-52R | 4 kW   | Open Array     |
-| 3          | MDS-61R | 6 kW   | Open Array     |
-| 4          | MDS-62R | 12 kW  | Open Array     |
-| 5          | MDS-63R | 25 kW  | Open Array     |
-| 6          | MDS-1R/8R | 2 kW | Dome           |
-| 10         | MDS-10R | 4 kW   | Open Array     |
-| 14         | MDS-9R  | 4 kW   | Dome           |
-| 15         | MDS-5R  | —      | Interface only |
+| Model Code | Model     | Power | Antenna        | Control box |
+| ---------- | --------- | ----- | -------------- | ----------- |
+| 0          | MDS-50R   | 2 kW  | Dome           | MDS-5R      |
+| 1          | MDS-51R   | 4 kW  | Dome           | MDS-5R      |
+| 2          | MDS-52R   | 4 kW  | Open Array     | MDS-5R      |
+| 3          | MDS-61R   | 6 kW  | Open Array     | MDS-6R      |
+| 4          | MDS-62R   | 12 kW | Open Array     | MDS-6R      |
+| 5          | MDS-63R   | 25 kW | Open Array     | MDS-6R      |
+| 6          | MDS-1R/8R | 2 kW  | Dome           | -           |
+| 10         | MDS-10R   | 4 kW  | Open Array     | -           |
+| 14         | MDS-9R    | 4 kW  | Dome           | -           |
+| 15         | MDS-5R    | —     | Interface only | MDS-5R      |
 
-Model detection is automatic via the model code response from the radar.
+Model detection is automatic via the model code response from the radar. From what we know, all control
+boxes use exactly the same protocol so it should work as long as you have an Ethernet port on the MDS 
+control box. We do not know what model code is reported by combos using the newer MDS-11R control box,
+please report this.
+
+Unfortunately, Koden radars with a Koden display unit all seem not to use Ethernet to provide features
+such as dual display units, and thus are not supportable by _Mayara_.
 
 ## Controls
 
@@ -49,3 +55,8 @@ Mayara supports the following Koden controls:
 **Radar not detected**: Verify the machine and radar are on the same subnet. Koden radars use UDP broadcast on port 10001 — ensure no firewall is blocking this port. Try running with `--brand koden` to limit detection to Koden radars only.
 
 **No spokes displayed**: The radar must be in transmit mode. Use the power control to switch from standby to transmit. New radars may require a warmup period before transmitting.
+
+## Caveat
+
+The current Koden support has NOT been tested AT ALL with real radars and depends on knowledge learned
+from other sources. If you have a Koden radar, please contact us.

--- a/src/lib/brand/koden/command.rs
+++ b/src/lib/brand/koden/command.rs
@@ -7,12 +7,15 @@ use crate::brand::CommandSender;
 use crate::radar::settings::{ControlId, ControlValue, SharedControls};
 use crate::radar::{Power, RadarError, RadarInfo};
 
+/// Scale a percentage (0–100) to a wire byte (0–255) with rounding.
+fn pct_to_u8(pct: f64) -> u8 {
+    (pct.clamp(0.0, 100.0) * 255.0 / 100.0).round() as u8
+}
+
 pub(crate) struct Command {
     key: String,
     socket: Option<UdpSocket>,
-    radar_addr: SocketAddrV4,
     controls: SharedControls,
-    broadcast: bool,
 }
 
 impl Command {
@@ -20,9 +23,7 @@ impl Command {
         Command {
             key: info.key(),
             socket: None,
-            radar_addr: info.addr,
             controls: info.controls.clone(),
-            broadcast: true, // Default to broadcast mode
         }
     }
 
@@ -30,15 +31,11 @@ impl Command {
         self.socket = Some(socket);
     }
 
-    /// Send a raw byte slice to the radar.
+    /// Send a raw byte slice to the radar via broadcast.
     async fn send_raw(&self, data: &[u8]) -> Result<(), RadarError> {
         match &self.socket {
             Some(s) => {
-                let dest = if self.broadcast {
-                    SocketAddrV4::new(std::net::Ipv4Addr::BROADCAST, RADAR_PORT)
-                } else {
-                    self.radar_addr
-                };
+                let dest = SocketAddrV4::new(std::net::Ipv4Addr::BROADCAST, RADAR_PORT);
                 s.send_to(data, dest).await.map_err(RadarError::Io)?;
                 Ok(())
             }
@@ -59,7 +56,6 @@ impl Command {
     }
 
     /// Send a 5-byte SetWord command: `& cmd hi lo \r`
-    #[allow(dead_code)]
     async fn set_word(&self, cmd: u8, value: u16) -> Result<(), RadarError> {
         let packet = [
             CONTROL_PREFIX,
@@ -127,18 +123,14 @@ impl CommandSender for Command {
                     self.set_byte(CMD_AUTO_GAIN_MODE, WIRE_TRUE).await
                 } else {
                     self.set_byte(CMD_AUTO_GAIN_MODE, WIRE_FALSE).await?;
-                    // Scale 0–100 to 0–255
-                    let wire_val = (value_f64 * 2.55) as u8;
-                    self.set_byte(CMD_GAIN, wire_val).await
+                    self.set_byte(CMD_GAIN, pct_to_u8(value_f64)).await
                 }
             }
             ControlId::Sea => {
-                let wire_val = (value_f64 * 2.55) as u8;
-                self.set_byte(CMD_STC, wire_val).await
+                self.set_byte(CMD_STC, pct_to_u8(value_f64)).await
             }
             ControlId::Rain => {
-                let wire_val = (value_f64 * 2.55) as u8;
-                self.set_byte(CMD_FTC, wire_val).await
+                self.set_byte(CMD_FTC, pct_to_u8(value_f64)).await
             }
             ControlId::SeaState => {
                 // 0=Manual, 1=Auto, 2=Harbor

--- a/src/lib/brand/koden/command.rs
+++ b/src/lib/brand/koden/command.rs
@@ -1,0 +1,213 @@
+use async_trait::async_trait;
+use std::net::SocketAddrV4;
+use tokio::net::UdpSocket;
+
+use super::protocol::*;
+use crate::brand::CommandSender;
+use crate::radar::settings::{ControlId, ControlValue, SharedControls};
+use crate::radar::{Power, RadarError, RadarInfo};
+
+pub(crate) struct Command {
+    key: String,
+    socket: Option<UdpSocket>,
+    radar_addr: SocketAddrV4,
+    controls: SharedControls,
+    broadcast: bool,
+}
+
+impl Command {
+    pub(crate) fn new(info: &RadarInfo) -> Self {
+        Command {
+            key: info.key(),
+            socket: None,
+            radar_addr: info.addr,
+            controls: info.controls.clone(),
+            broadcast: true, // Default to broadcast mode
+        }
+    }
+
+    pub(crate) fn set_socket(&mut self, socket: UdpSocket) {
+        self.socket = Some(socket);
+    }
+
+    /// Send a raw byte slice to the radar.
+    async fn send_raw(&self, data: &[u8]) -> Result<(), RadarError> {
+        match &self.socket {
+            Some(s) => {
+                let dest = if self.broadcast {
+                    SocketAddrV4::new(std::net::Ipv4Addr::BROADCAST, RADAR_PORT)
+                } else {
+                    self.radar_addr
+                };
+                s.send_to(data, dest).await.map_err(RadarError::Io)?;
+                Ok(())
+            }
+            None => Err(RadarError::NotConnected),
+        }
+    }
+
+    /// Send a 4-byte SetByte command: `& cmd value \r`
+    async fn set_byte(&self, cmd: u8, value: u8) -> Result<(), RadarError> {
+        let packet = [CONTROL_PREFIX, cmd, value, PACKET_END];
+        log::trace!(
+            "{}: SetByte cmd=0x{:02X} val=0x{:02X}",
+            self.key,
+            cmd,
+            value
+        );
+        self.send_raw(&packet).await
+    }
+
+    /// Send a 5-byte SetWord command: `& cmd hi lo \r`
+    #[allow(dead_code)]
+    async fn set_word(&self, cmd: u8, value: u16) -> Result<(), RadarError> {
+        let packet = [
+            CONTROL_PREFIX,
+            cmd,
+            (value >> 8) as u8,
+            (value & 0xFF) as u8,
+            PACKET_END,
+        ];
+        log::trace!(
+            "{}: SetWord cmd=0x{:02X} val=0x{:04X}",
+            self.key,
+            cmd,
+            value
+        );
+        self.send_raw(&packet).await
+    }
+
+    /// Send the startup info request sequence.
+    pub(crate) async fn send_startup(&self) -> Result<(), RadarError> {
+        log::debug!("{}: Sending startup info request", self.key);
+        self.send_raw(&STARTUP_REQUEST).await
+    }
+
+    /// Send a keep-alive packet.
+    pub(crate) async fn send_keepalive(&self) -> Result<(), RadarError> {
+        log::trace!("{}: Sending keep-alive", self.key);
+        self.send_raw(&KEEPALIVE_PACKET).await
+    }
+}
+
+#[async_trait]
+impl CommandSender for Command {
+    async fn set_control(
+        &mut self,
+        cv: &ControlValue,
+        controls: &SharedControls,
+    ) -> Result<(), RadarError> {
+        let value = match cv.as_i32() {
+            Ok(v) => v,
+            Err(_) if cv.auto.is_some() && cv.value.is_none() => controls
+                .get(&cv.id)
+                .and_then(|c| c.value)
+                .map(|v| v as i32)
+                .unwrap_or(0),
+            Err(e) => return Err(e),
+        };
+        let value_f64 = cv.as_f64().unwrap_or(value as f64);
+
+        match cv.id {
+            ControlId::Power => {
+                if value == Power::Transmit as u32 as i32 {
+                    // Send transfer mode 0x22 to begin transmitting.
+                    // The radar starts transmitting upon receiving this
+                    // and confirms with a 0x74=0x11 response.
+                    self.set_byte(CMD_TRANSFER_MODE, 0x22).await
+                } else if value == Power::Standby as u32 as i32 {
+                    // Send transfer mode 0x00 to go to standby.
+                    self.set_byte(CMD_TRANSFER_MODE, 0x00).await
+                } else {
+                    Ok(())
+                }
+            }
+            ControlId::Gain => {
+                if cv.auto.unwrap_or(false) {
+                    self.set_byte(CMD_AUTO_GAIN_MODE, WIRE_TRUE).await
+                } else {
+                    self.set_byte(CMD_AUTO_GAIN_MODE, WIRE_FALSE).await?;
+                    // Scale 0–100 to 0–255
+                    let wire_val = (value_f64 * 2.55) as u8;
+                    self.set_byte(CMD_GAIN, wire_val).await
+                }
+            }
+            ControlId::Sea => {
+                let wire_val = (value_f64 * 2.55) as u8;
+                self.set_byte(CMD_STC, wire_val).await
+            }
+            ControlId::Rain => {
+                let wire_val = (value_f64 * 2.55) as u8;
+                self.set_byte(CMD_FTC, wire_val).await
+            }
+            ControlId::SeaState => {
+                // 0=Manual, 1=Auto, 2=Harbor
+                let wire_val = match value {
+                    0 => 0x00,
+                    1 => 0x11,
+                    2 => 0x22,
+                    _ => 0x00,
+                };
+                self.set_byte(CMD_AUTO_STC_MODE, wire_val).await
+            }
+            ControlId::PulseWidth => {
+                self.set_byte(CMD_PULSE_LENGTH, value as u8).await
+            }
+            ControlId::InterferenceRejection => {
+                let wire_val = match value {
+                    0 => 0x00,
+                    1 => 0x11,
+                    2 => 0x22,
+                    3 => 0x33,
+                    _ => 0x00,
+                };
+                self.set_byte(CMD_INTERFERENCE_REJECTION, wire_val).await
+            }
+            ControlId::TargetExpansion => {
+                // Koden wire protocol: 0x00=expansion ON, 0x11=OFF
+                let wire_val = if value == 0 { WIRE_TRUE } else { WIRE_FALSE };
+                self.set_byte(CMD_TARGET_EXPANSION, wire_val).await
+            }
+            ControlId::Tune => {
+                if cv.auto.unwrap_or(false) {
+                    self.set_byte(CMD_TUNING_MODE, WIRE_AUTO).await
+                } else {
+                    self.set_byte(CMD_TUNING_MODE, WIRE_FALSE).await?;
+                    self.set_byte(CMD_COARSE_TUNING, value as u8).await
+                }
+            }
+            ControlId::TuneFine => self.set_byte(CMD_FINE_TUNING, value as u8).await,
+            ControlId::DisplayTiming => self.set_byte(CMD_TRIGGER_DELAY, value as u8).await,
+            ControlId::ScanSpeed => self.set_byte(CMD_ANTENNA_SPEED, value as u8).await,
+            ControlId::NoTransmitSector1 => {
+                // Blanking sector: 7 bytes [0x26, 0x9C, start_hi, start_lo, end_hi, end_lo, 0x0D]
+                // Wire angles: 0-1023 for 0-360 degrees
+                let start = radians_to_koden_angle(value_f64);
+                let end = radians_to_koden_angle(cv.end_as_f64().unwrap_or(0.));
+                let packet = [
+                    CONTROL_PREFIX,
+                    CMD_BLANKING_SECTOR,
+                    (start >> 8) as u8,
+                    (start & 0xFF) as u8,
+                    (end >> 8) as u8,
+                    (end & 0xFF) as u8,
+                    PACKET_END,
+                ];
+                self.send_raw(&packet).await
+            }
+            ControlId::ParkPosition => {
+                let wire = radians_to_koden_angle(value_f64);
+                self.set_word(CMD_PARK_ANGLE, wire).await
+            }
+            _ => {
+                log::debug!(
+                    "{}: Unhandled control {:?} = {:?}",
+                    self.key,
+                    cv.id,
+                    cv.value
+                );
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -1,0 +1,150 @@
+use std::io;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
+
+use crate::locator::LocatorAddress;
+use crate::radar::{RadarInfo, SharedRadars};
+use crate::util::PrintableSlice;
+use crate::{Brand, Cli};
+
+use super::{LocatorId, RadarLocator};
+
+mod command;
+mod protocol;
+mod report;
+mod settings;
+
+use protocol::{
+    BEACON_ADDRESS, CONTROL_PREFIX, IMAGE_MARKER, IMG_MIN_SIZE, KEEPALIVE_PACKET, PIXEL_VALUES,
+    RADAR_PORT, RESP_POWER, RESP_WARMUP, SPOKE_LEN, SPOKES, STATUS_PREFIX,
+};
+
+#[derive(Clone)]
+struct KodenLocator {
+    args: Cli,
+}
+
+impl RadarLocator for KodenLocator {
+    fn process(
+        &mut self,
+        message: &[u8],
+        from: &SocketAddrV4,
+        nic_addr: &Ipv4Addr,
+        radars: &SharedRadars,
+        subsys: &SubsystemHandle,
+    ) -> Result<(), io::Error> {
+        self.process_locator_report(message, from, nic_addr, radars, subsys)
+    }
+
+    fn clone(&self) -> Box<dyn RadarLocator> {
+        Box::new(Clone::clone(self))
+    }
+}
+
+impl KodenLocator {
+    fn new(args: Cli) -> Self {
+        KodenLocator { args }
+    }
+
+    fn process_locator_report(
+        &mut self,
+        report: &[u8],
+        from: &SocketAddrV4,
+        nic_addr: &Ipv4Addr,
+        radars: &SharedRadars,
+        subsys: &SubsystemHandle,
+    ) -> io::Result<()> {
+        if report.len() < 3 {
+            return Ok(());
+        }
+
+        // Koden radars respond with control (&) or status (#) packets.
+        // We detect the radar when we receive any valid response from it.
+        let first = report[0];
+        let is_koden = match first {
+            CONTROL_PREFIX => {
+                let cmd = report[1];
+                cmd == RESP_POWER || cmd == RESP_WARMUP || cmd == b'e'
+            }
+            STATUS_PREFIX => {
+                let cmd = report[1];
+                // Model info, model code, MAC address, or keepalive ACK are
+                // reliable indicators of a Koden radar.
+                cmd == 0x4E || cmd == 0x72 || cmd == 0xA7 || cmd == 0xAB || cmd == 0xFF
+            }
+            b'{' => {
+                // Image data frame — only if it has the full 4-byte marker
+                report.len() >= IMG_MIN_SIZE && report[0..4] == IMAGE_MARKER
+            }
+            _ => false,
+        };
+
+        if !is_koden {
+            return Ok(());
+        }
+
+        log::debug!(
+            "Koden radar detected at {} via {} (packet: {})",
+            from,
+            nic_addr,
+            PrintableSlice::new(&report[..report.len().min(16)])
+        );
+
+        self.found(*from, *nic_addr, radars, subsys);
+        Ok(())
+    }
+
+    fn found(
+        &self,
+        radar_addr: SocketAddrV4,
+        nic_addr: Ipv4Addr,
+        radars: &SharedRadars,
+        subsys: &SubsystemHandle,
+    ) {
+        let spoke_data_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
+        let report_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
+        let send_command_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
+
+        let radar_info = RadarInfo::new(
+            radars,
+            &self.args,
+            Brand::Koden,
+            None, // serial number discovered later
+            None, // no dual range
+            PIXEL_VALUES,
+            SPOKES,
+            SPOKE_LEN,
+            radar_addr,
+            nic_addr,
+            spoke_data_addr,
+            report_addr,
+            send_command_addr,
+            |id, tx| settings::new(id, tx, &self.args),
+            false, // no doppler
+            false, // not sparse spokes
+        );
+
+        if let Some(info) = radars.add(radar_info) {
+            let report_name = info.key();
+            info.start_forwarding_radar_messages_to_stdout(&subsys);
+
+            let report_receiver =
+                report::KodenReportReceiver::new(&self.args, radars.clone(), info);
+            subsys.start(SubsystemBuilder::new(report_name, |s| {
+                report_receiver.run(s)
+            }));
+        }
+    }
+}
+
+pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
+    if !addresses.iter().any(|i| i.id == LocatorId::Koden) {
+        addresses.push(LocatorAddress::new(
+            LocatorId::Koden,
+            &BEACON_ADDRESS,
+            Brand::Koden,
+            vec![&KEEPALIVE_PACKET],
+            Box::new(KodenLocator::new(args.clone())),
+        ));
+    }
+}

--- a/src/lib/brand/koden/protocol.rs
+++ b/src/lib/brand/koden/protocol.rs
@@ -1,0 +1,253 @@
+//! Koden RADARpc radar protocol — wire-level constants.
+//!
+//! The protocol is shared by all Koden Ethernet control boxes: MDS-5R,
+//! MDS-6R, and MDS-11R.
+//!
+//! ## Transport
+//!
+//! All communication uses **UDP port 10001** — discovery, control, keep-alive,
+//! and spoke image data share the same port.
+//!
+//! ## Packet framing
+//!
+//! Three packet types, distinguished by the first byte:
+//!
+//! - `&` (0x26) — control commands and responses (warmup, power, error)
+//! - `#` (0x23) — status/setting responses
+//! - `{{{{` (4 × 0x7B) — image data (spoke frames)
+//!
+//! Control and status packets are terminated by `\r` (0x0D).
+
+#![allow(dead_code)]
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+// =============================================================================
+// Spoke geometry
+// =============================================================================
+
+/// Koden radars report spokes with angles relative to total_spokes_per_revolution
+/// (typically 4096). We normalise to this internal count.
+pub(crate) const SPOKES: usize = 4096;
+
+/// Maximum spoke length in pixels. Koden sends 240, 480, or 960
+/// samples per spoke depending on range; spokes are passed at their
+/// native resolution without stretching.
+pub(crate) const SPOKE_LEN: usize = 960;
+
+/// Number of echo intensity levels. Koden sends raw 8-bit values, but we scale to 128
+/// to fit into our standard spoke format and preserve headroom for other pixel values.
+pub(crate) const PIXEL_VALUES: u8 = 128;
+
+// =============================================================================
+// Network
+// =============================================================================
+
+/// UDP port for all Koden radar communication.
+pub(crate) const RADAR_PORT: u16 = 10001;
+
+/// Broadcast address for radar discovery.
+/// We listen on 0.0.0.0:10001 and broadcast to 255.255.255.255:10001.
+pub(crate) const BEACON_ADDRESS: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), RADAR_PORT);
+
+// =============================================================================
+// Timing
+// =============================================================================
+
+/// Keep-alive interval in seconds.
+pub(crate) const KEEPALIVE_INTERVAL_SECS: u64 = 10;
+
+/// Radar is declared lost after this many seconds of silence.
+pub(crate) const RADAR_LOST_TIMEOUT_SECS: u64 = 15;
+
+// =============================================================================
+// Packet start/end markers
+// =============================================================================
+
+pub(crate) const CONTROL_PREFIX: u8 = b'&'; // 0x26
+pub(crate) const STATUS_PREFIX: u8 = b'#'; // 0x23
+pub(crate) const IMAGE_MARKER: [u8; 4] = [b'{', b'{', b'{', b'{'];
+pub(crate) const PACKET_END: u8 = b'\r'; // 0x0D
+
+// =============================================================================
+// Boolean values on the wire
+// =============================================================================
+
+pub(crate) const WIRE_FALSE: u8 = 0x00;
+pub(crate) const WIRE_TRUE: u8 = 0x11;
+pub(crate) const WIRE_AUTO: u8 = 0x22;
+
+// =============================================================================
+// Control response types (byte 1 of `&` packets)
+// =============================================================================
+
+pub(crate) const RESP_WARMUP: u8 = b'a';
+pub(crate) const RESP_ERROR: u8 = b'e';
+pub(crate) const RESP_POWER: u8 = b'p';
+
+/// Warmup-complete sentinel (byte 2 of `&a` packet).
+pub(crate) const WARMUP_COMPLETE: u8 = 0x11;
+
+// =============================================================================
+// Status command IDs (byte 1 of `#` packets, sent TO and FROM radar)
+// =============================================================================
+
+pub(crate) const CMD_HEADING_LINE: u8 = 0x30;
+pub(crate) const CMD_TUNING_MODE: u8 = 0x41;
+pub(crate) const CMD_TRIGGER_DELAY: u8 = 0x44;
+pub(crate) const CMD_TARGET_EXPANSION: u8 = 0x45;
+pub(crate) const CMD_FTC: u8 = 0x46;
+pub(crate) const CMD_GAIN: u8 = 0x47;
+pub(crate) const CMD_INTERFERENCE_REJECTION: u8 = 0x49;
+pub(crate) const CMD_MODEL_INFO: u8 = 0x4E;
+pub(crate) const CMD_STC: u8 = 0x53;
+pub(crate) const CMD_FINE_TUNING: u8 = 0x54;
+pub(crate) const CMD_COARSE_TUNING: u8 = 0x55;
+pub(crate) const CMD_TUNING_METER: u8 = 0x63;
+pub(crate) const CMD_WRITE_IP: u8 = 0x64;
+pub(crate) const CMD_SYSTEM_ERROR: u8 = 0x65;
+pub(crate) const CMD_AUTO_GAIN_MODE: u8 = 0x67;
+pub(crate) const CMD_TRANSFER_MODE: u8 = 0x69;
+pub(crate) const CMD_MODEL_CODE: u8 = 0x72;
+pub(crate) const CMD_TRANSMISSION_MODE: u8 = 0x74;
+
+// =============================================================================
+// Model code → model name mapping
+// =============================================================================
+
+/// Map a model code byte (from CMD_MODEL_CODE response) to a model name.
+///
+/// Map a model code byte to a human-readable model name.
+pub(crate) fn model_name(code: u8) -> &'static str {
+    match code {
+        0 => "MDS-50R 2kW Dome",
+        1 => "MDS-51R 4kW Dome",
+        2 => "MDS-52R 4kW Open Array",
+        3 => "MDS-61R 6kW Open Array",
+        4 => "MDS-62R 12kW Open Array",
+        5 => "MDS-63R 25kW Open Array",
+        6 => "MDS-1R/8R 2kW Dome",
+        10 => "MDS-10R 4kW Open Array",
+        14 => "MDS-9R 4kW Dome",
+        15 => "MDS-5R Interface",
+        _ => "Unknown",
+    }
+}
+pub(crate) const CMD_AUTO_STC_MODE: u8 = 0x80;
+pub(crate) const CMD_AUTO_GAIN_PRESET: u8 = 0x81;
+pub(crate) const CMD_MANUAL_GAIN_PRESET: u8 = 0x82;
+pub(crate) const CMD_AUTO_STC_PRESET: u8 = 0x83;
+pub(crate) const CMD_MANUAL_STC_PRESET: u8 = 0x84;
+pub(crate) const CMD_AUTO_TUNE_PRESET: u8 = 0x85;
+pub(crate) const CMD_MANUAL_TUNE_PRESET: u8 = 0x86;
+pub(crate) const CMD_HARBOR_STC_PRESET: u8 = 0x87;
+pub(crate) const CMD_STC_CURVE_PRESET: u8 = 0x88;
+pub(crate) const CMD_INFO_BLOCK: u8 = 0x9A;
+pub(crate) const CMD_BLANKING_SECTOR: u8 = 0x9C;
+pub(crate) const CMD_PULSE_LENGTH: u8 = 0xA4;
+pub(crate) const CMD_ANTENNA_SPEED: u8 = 0xA5;
+pub(crate) const CMD_MAC_ADDRESS: u8 = 0xA7;
+pub(crate) const CMD_SET_IP: u8 = 0xA8;
+pub(crate) const CMD_RECEIVED_IP: u8 = 0xA9;
+pub(crate) const CMD_PARK_ANGLE: u8 = 0xAA;
+pub(crate) const CMD_KEEPALIVE_ACK: u8 = 0xAB;
+pub(crate) const CMD_DEMO_MODE: u8 = 0xAC;
+pub(crate) const CMD_TRANSFER_SIZE: u8 = 0xAD;
+pub(crate) const CMD_BROADCAST_SETTING: u8 = 0xFF;
+
+// =============================================================================
+// Startup packet sequence
+// =============================================================================
+
+/// Information request sent after radar responds to discovery.
+/// Five 4-byte sub-commands packed into one 20-byte send.
+pub(crate) const STARTUP_REQUEST: [u8; 20] = [
+    0x26, 0xFF, 0x11, 0x0D, // Broadcast setting = 0x11
+    0x26, 0x9A, 0x11, 0x0D, // Request info block
+    0x26, 0xA7, 0x11, 0x0D, // Request MAC address
+    0x24, 0x4E, 0x11, 0x0D, // Request model/serial info
+    0x26, 0x72, 0xFF, 0x0D, // Request model code
+];
+
+/// Keep-alive packet (4 bytes).
+pub(crate) const KEEPALIVE_PACKET: [u8; 4] = [0x26, 0x69, 0x22, 0x0D];
+
+// =============================================================================
+// Image header offsets (from start of `{{{{` packet)
+// =============================================================================
+
+pub(crate) const IMG_TRANSFER_TYPE: usize = 0x0E;
+pub(crate) const IMG_STATUS_CHANGED: usize = 0x0F;
+pub(crate) const IMG_RANGE_INDEX: usize = 0x10;
+pub(crate) const IMG_RANGE_INDEX_2: usize = 0x11;
+pub(crate) const IMG_NUM_SPOKES: usize = 0x25;
+pub(crate) const IMG_SAMPLES_PER_SPOKE_LO: usize = 0x26;
+pub(crate) const IMG_SAMPLES_PER_SPOKE_HI: usize = 0x27;
+pub(crate) const IMG_TOTAL_SPOKES_LO: usize = 0x28;
+pub(crate) const IMG_TOTAL_SPOKES_HI: usize = 0x29;
+pub(crate) const IMG_START_ANGLE_LO: usize = 0x2A;
+pub(crate) const IMG_START_ANGLE_HI: usize = 0x2B;
+pub(crate) const IMG_SPOKE_DATA: usize = 0x2C;
+
+/// Offset of spoke data for 'R' (rotated) transfer type.
+pub(crate) const IMG_SPOKE_DATA_ROTATED: usize = 0xA8;
+
+/// Transfer type values.
+pub(crate) const TRANSFER_NORMAL: u8 = 2;
+pub(crate) const TRANSFER_ROTATED: u8 = 0x52; // 'R'
+
+/// Minimum image packet size (header only, no spoke data).
+pub(crate) const IMG_MIN_SIZE: usize = 0x2C;
+
+// =============================================================================
+// Range table
+// =============================================================================
+
+/// Range table: index → nautical miles.
+/// 20 entries mapping range index to nautical miles.
+pub(crate) const RANGE_TABLE_NM: [f64; 20] = [
+    0.125, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 16.0, 24.0, 32.0, 36.0, 48.0,
+    64.0, 72.0, 96.0,
+];
+
+const NM_TO_METERS: f64 = 1852.0;
+
+/// Convert a range index to meters.
+pub(crate) fn range_index_to_meters(index: u8) -> f64 {
+    let idx = index as usize;
+    if idx < RANGE_TABLE_NM.len() {
+        RANGE_TABLE_NM[idx] * NM_TO_METERS
+    } else {
+        // Fallback for unknown indices
+        RANGE_TABLE_NM[RANGE_TABLE_NM.len() - 1] * NM_TO_METERS
+    }
+}
+
+// =============================================================================
+// Spoke sample count mapping
+// =============================================================================
+
+/// Map the wire samples_per_spoke to the actual pixel count.
+pub(crate) fn actual_spoke_pixels(wire_samples: u16) -> u16 {
+    match wire_samples {
+        0x100 => 0xF0,  // 256 → 240
+        0x200 => 0x1E0, // 512 → 480
+        0x400 => 0x3C0, // 1024 → 960
+        _ => 0,
+    }
+}
+
+pub(crate) const KODEN_ANGLE_SCALE: f64 = 1024.0 / 360.0;
+
+/// Koden wire angle (0–1023) to radians (0–2π).
+pub(crate) fn koden_angle_to_radians(angle: u16) -> f64 {
+    (angle as f64) * std::f64::consts::TAU / 1024.0
+}
+
+/// Radians to Koden wire angle (0–1023, unsigned).
+/// Accepts any input range; the result is normalized to 0–1023.
+pub(crate) fn radians_to_koden_angle(rad: f64) -> u16 {
+    let normalized = rad.rem_euclid(std::f64::consts::TAU);
+    (normalized * 1024.0 / std::f64::consts::TAU).round() as u16 % 1024
+}

--- a/src/lib/brand/koden/report.rs
+++ b/src/lib/brand/koden/report.rs
@@ -512,8 +512,8 @@ impl KodenReportReceiver {
 
             let mut scaled = Vec::with_capacity(spoke_byte_len);
             for pixel in spoke_data.iter() {
-                // Scale raw 0-255 to 0-PIXEL_VALUES
-                scaled.push((*pixel as u16 * PIXEL_VALUES as u16 / 255) as u8);
+                // Scale raw 0-255 to 0-127, make room for history colors
+                scaled.push(*pixel >> 1);
             }
 
             self.common.add_spoke(range_meters, angle, heading, scaled);

--- a/src/lib/brand/koden/report.rs
+++ b/src/lib/brand/koden/report.rs
@@ -483,8 +483,11 @@ impl KodenReportReceiver {
 
         // Get heading from navdata if available
         let heading: Option<u16> = {
-            let h = crate::navdata::get_heading_true();
-            h.map(|h| (h * SPOKES as f64 / std::f64::consts::TAU) as u16)
+            crate::navdata::get_heading_true().map(|h| {
+                let normalized = h.rem_euclid(std::f64::consts::TAU);
+                ((normalized * SPOKES as f64 / std::f64::consts::TAU).floor() as u16)
+                    .min(SPOKES as u16 - 1)
+            })
         };
 
         // Process each spoke in this frame
@@ -508,7 +511,7 @@ impl KodenReportReceiver {
             let spoke_data = &data[spoke_offset..spoke_end];
 
             let mut scaled = Vec::with_capacity(spoke_byte_len);
-            for (i, pixel) in spoke_data.iter().enumerate() {
+            for pixel in spoke_data.iter() {
                 // Scale raw 0-255 to 0-PIXEL_VALUES
                 scaled.push((*pixel as u16 * PIXEL_VALUES as u16 / 255) as u8);
             }

--- a/src/lib/brand/koden/report.rs
+++ b/src/lib/brand/koden/report.rs
@@ -1,0 +1,521 @@
+use std::net::SocketAddrV4;
+use std::time::Duration;
+use tokio::net::UdpSocket;
+use tokio::time::{Instant, sleep_until};
+use tokio_graceful_shutdown::SubsystemHandle;
+
+use super::command::Command;
+use super::protocol::*;
+use crate::Cli;
+use crate::radar::CommonRadar;
+use crate::radar::SharedRadars;
+use crate::radar::SpokeBearing;
+use crate::radar::settings::ControlId;
+use crate::radar::{Power, RadarError, RadarInfo};
+use crate::util::PrintableSlice;
+
+pub(crate) struct KodenReportReceiver {
+    common: CommonRadar,
+    command_sender: Option<Command>,
+    radar_addr: SocketAddrV4,
+}
+
+impl KodenReportReceiver {
+    pub(crate) fn new(args: &Cli, radars: SharedRadars, info: RadarInfo) -> Self {
+        let key = info.key();
+        let command_sender = if args.is_replay() {
+            None
+        } else {
+            Some(Command::new(&info))
+        };
+
+        let radar_addr = info.addr;
+        let control_update_rx = info.control_update_subscribe();
+        let blob_tx = radars.get_blob_tx();
+
+        let common = CommonRadar::new(
+            args,
+            key,
+            info,
+            radars.clone(),
+            control_update_rx,
+            args.is_replay(),
+            blob_tx,
+        );
+
+        KodenReportReceiver {
+            common,
+            command_sender,
+            radar_addr,
+        }
+    }
+
+    pub(crate) async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+        loop {
+            if let Err(e) = self.data_loop(&subsys).await {
+                log::error!("{}: Data loop error: {}, restarting", self.common.key, e);
+            }
+            if subsys.is_shutdown_requested() {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    async fn data_loop(&mut self, subsys: &SubsystemHandle) -> Result<(), RadarError> {
+        // Bind a UDP socket for sending commands
+        if let Some(ref mut cmd) = self.command_sender {
+            let send_socket = UdpSocket::bind("0.0.0.0:0").await.map_err(RadarError::Io)?;
+            send_socket.set_broadcast(true).map_err(RadarError::Io)?;
+            cmd.set_socket(send_socket);
+
+            // Send startup request
+            cmd.send_startup().await?;
+        }
+
+        // Bind receive socket on the Koden port
+        let recv_socket = UdpSocket::bind(("0.0.0.0", RADAR_PORT))
+            .await
+            .map_err(RadarError::Io)?;
+        recv_socket.set_broadcast(true).map_err(RadarError::Io)?;
+
+        let mut buf = [0u8; 4096];
+        let mut next_keepalive = Instant::now() + Duration::from_secs(KEEPALIVE_INTERVAL_SECS);
+
+        loop {
+            tokio::select! {
+                _ = subsys.on_shutdown_requested() => {
+                    return Ok(());
+                }
+
+                _ = sleep_until(next_keepalive) => {
+                    if let Some(ref cmd) = self.command_sender {
+                        cmd.send_keepalive().await?;
+                    }
+                    next_keepalive = Instant::now() + Duration::from_secs(KEEPALIVE_INTERVAL_SECS);
+                }
+
+                result = recv_socket.recv_from(&mut buf) => {
+                    match result {
+                        Ok((len, _from)) => {
+                            if len >= 3 {
+                                self.process_packet(&buf[..len]);
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("{}: recv error: {}", self.common.key, e);
+                            return Err(RadarError::Io(e));
+                        }
+                    }
+                }
+
+                r = self.common.control_update_rx.recv() => {
+                    match r {
+                        Err(_) => {},
+                        Ok(cv) => {
+                            if let Err(e) = self.common.process_control_update(cv, &mut self.command_sender).await {
+                                return Err(e);
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    fn process_packet(&mut self, data: &[u8]) {
+        if data.len() < 3 {
+            return;
+        }
+
+        match data[0] {
+            CONTROL_PREFIX => self.process_control_response(data),
+            STATUS_PREFIX => self.process_status_response(data),
+            b'{' => {
+                if data.len() >= IMG_MIN_SIZE && data[0..4] == IMAGE_MARKER {
+                    self.process_image_data(data);
+                }
+            }
+            _ => {
+                log::trace!(
+                    "{}: Unknown packet start 0x{:02X}",
+                    self.common.key,
+                    data[0]
+                );
+            }
+        }
+    }
+
+    fn process_control_response(&mut self, data: &[u8]) {
+        if data.len() < 3 || data[data.len() - 1] != PACKET_END {
+            return;
+        }
+
+        match data[1] {
+            RESP_WARMUP => {
+                let seconds = data[2];
+                if seconds == WARMUP_COMPLETE {
+                    log::info!("{}: Warmup complete, standby", self.common.key);
+                    let _ = self.common.info.controls.set(
+                        &ControlId::Power,
+                        Power::Standby as u32 as f64,
+                        None,
+                    );
+                } else {
+                    log::debug!(
+                        "{}: Warming up: {}:{:02}",
+                        self.common.key,
+                        seconds / 60,
+                        seconds % 60
+                    );
+                    let _ = self.common.info.controls.set(
+                        &ControlId::Power,
+                        Power::Preparing as u32 as f64,
+                        None,
+                    );
+                }
+            }
+            RESP_POWER => {
+                log::info!("{}: Power on", self.common.key);
+                let _ = self.common.info.controls.set(
+                    &ControlId::Power,
+                    Power::Preparing as u32 as f64,
+                    None,
+                );
+            }
+            RESP_ERROR => {
+                if data.len() >= 4 {
+                    log::warn!("{}: Radar error code: 0x{:02X}", self.common.key, data[2]);
+                }
+            }
+            _ => {
+                log::trace!(
+                    "{}: Unknown control response: {}",
+                    self.common.key,
+                    PrintableSlice::new(data)
+                );
+            }
+        }
+    }
+
+    fn process_status_response(&mut self, data: &[u8]) {
+        if data.len() < 3 || data[data.len() - 1] != PACKET_END {
+            return;
+        }
+
+        let cmd = data[1];
+        match cmd {
+            CMD_GAIN => {
+                if data.len() == 4 {
+                    let val = (data[2] as f64) / 2.55;
+                    let _ = self.common.info.controls.set(&ControlId::Gain, val, None);
+                }
+            }
+            CMD_STC => {
+                if data.len() == 4 {
+                    let val = (data[2] as f64) / 2.55;
+                    let _ = self.common.info.controls.set(&ControlId::Sea, val, None);
+                }
+            }
+            CMD_FTC => {
+                if data.len() == 4 {
+                    let val = (data[2] as f64) / 2.55;
+                    let _ = self.common.info.controls.set(&ControlId::Rain, val, None);
+                }
+            }
+            CMD_AUTO_GAIN_MODE => {
+                if data.len() == 4 {
+                    let auto = data[2] == WIRE_TRUE;
+                    let _ = self.common.info.controls.set(
+                        &ControlId::Gain,
+                        self.common
+                            .info
+                            .controls
+                            .get(&ControlId::Gain)
+                            .and_then(|c| c.value)
+                            .unwrap_or(0.),
+                        Some(auto),
+                    );
+                }
+            }
+            CMD_TARGET_EXPANSION => {
+                if data.len() == 4 {
+                    // Wire: 0x00=on, 0x11=off (inverted)
+                    let val = if data[2] == WIRE_FALSE { 0. } else { 1. };
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set(&ControlId::TargetExpansion, val, None);
+                }
+            }
+            CMD_AUTO_STC_MODE => {
+                if data.len() == 4 {
+                    let val = match data[2] {
+                        0x00 => 0., // Manual
+                        0x11 => 1., // Auto
+                        0x22 => 2., // Harbor
+                        _ => 0.,
+                    };
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set(&ControlId::SeaState, val, None);
+                }
+            }
+            CMD_PULSE_LENGTH => {
+                if data.len() == 4 {
+                    let _ =
+                        self.common
+                            .info
+                            .controls
+                            .set(&ControlId::PulseWidth, data[2] as f64, None);
+                }
+            }
+            CMD_INTERFERENCE_REJECTION => {
+                if data.len() == 4 {
+                    let val = match data[2] {
+                        0x00 => 0.,
+                        0x11 => 1.,
+                        0x22 => 2.,
+                        0x33 => 3.,
+                        _ => 0.,
+                    };
+                    let _ =
+                        self.common
+                            .info
+                            .controls
+                            .set(&ControlId::InterferenceRejection, val, None);
+                }
+            }
+            CMD_TRANSMISSION_MODE => {
+                if data.len() == 4 {
+                    if data[2] == WIRE_TRUE {
+                        log::info!("{}: Transmitting", self.common.key);
+                        let _ = self.common.info.controls.set(
+                            &ControlId::Power,
+                            Power::Transmit as u32 as f64,
+                            None,
+                        );
+                    } else {
+                        log::info!("{}: Standby", self.common.key);
+                        let _ = self.common.info.controls.set(
+                            &ControlId::Power,
+                            Power::Standby as u32 as f64,
+                            None,
+                        );
+                    }
+                }
+            }
+            CMD_MODEL_INFO => {
+                if data.len() >= 4 {
+                    let rom_version = data[2] as char;
+                    let sw_version = if data.len() >= 5 { data[3] } else { 0 };
+                    let serial = if data.len() >= 8 {
+                        u32::from_be_bytes([data[4], data[5], data[6], data[7]])
+                    } else {
+                        0
+                    };
+                    log::info!(
+                        "{}: Model info: ROM={}, SW={}, serial={}",
+                        self.common.key,
+                        rom_version,
+                        sw_version,
+                        serial
+                    );
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set_string(&ControlId::SerialNumber, format!("{}", serial));
+                }
+            }
+            CMD_MAC_ADDRESS => {
+                if data.len() >= 9 {
+                    log::info!(
+                        "{}: MAC address: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+                        self.common.key,
+                        data[2],
+                        data[3],
+                        data[4],
+                        data[5],
+                        data[6],
+                        data[7]
+                    );
+                }
+            }
+            CMD_MODEL_CODE => {
+                if data.len() == 4 {
+                    let name = model_name(data[2]);
+                    log::info!("{}: Model code {}: {}", self.common.key, data[2], name);
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set_string(&ControlId::ModelName, name.to_string());
+                }
+            }
+            CMD_KEEPALIVE_ACK => {
+                log::trace!("{}: Keep-alive ACK", self.common.key);
+            }
+            CMD_TUNING_MODE => {
+                if data.len() == 4 {
+                    let auto = data[2] == WIRE_AUTO;
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set_auto_state(&ControlId::Tune, auto);
+                }
+            }
+            CMD_COARSE_TUNING => {
+                if data.len() == 4 {
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set(&ControlId::Tune, data[2] as f64, None);
+                }
+            }
+            CMD_FINE_TUNING => {
+                if data.len() == 4 {
+                    let _ =
+                        self.common
+                            .info
+                            .controls
+                            .set(&ControlId::TuneFine, data[2] as f64, None);
+                }
+            }
+            CMD_TRIGGER_DELAY => {
+                if data.len() == 4 {
+                    let _ = self.common.info.controls.set(
+                        &ControlId::DisplayTiming,
+                        data[2] as f64,
+                        None,
+                    );
+                }
+            }
+            CMD_ANTENNA_SPEED => {
+                if data.len() == 4 {
+                    let _ =
+                        self.common
+                            .info
+                            .controls
+                            .set(&ControlId::ScanSpeed, data[2] as f64, None);
+                }
+            }
+            CMD_BLANKING_SECTOR => {
+                if data.len() == 7 {
+                    let start = ((data[2] as u16) << 8 | data[3] as u16) as f64;
+                    let end = ((data[4] as u16) << 8 | data[5] as u16) as f64;
+                    let enabled = start != end;
+                    self.common.set_sector(
+                        &ControlId::NoTransmitSector1,
+                        start,
+                        end,
+                        Some(enabled),
+                    );
+                }
+            }
+            CMD_PARK_ANGLE => {
+                if data.len() == 5 {
+                    let wire = ((data[2] as u16) << 8 | data[3] as u16) as f64;
+                    let _ = self
+                        .common
+                        .info
+                        .controls
+                        .set(&ControlId::ParkPosition, wire, None);
+                }
+            }
+            _ => {
+                log::trace!(
+                    "{}: Status cmd=0x{:02X} len={}",
+                    self.common.key,
+                    cmd,
+                    data.len()
+                );
+            }
+        }
+    }
+
+    fn process_image_data(&mut self, data: &[u8]) {
+        let transfer_type = data[IMG_TRANSFER_TYPE];
+
+        // Only handle normal (2) and rotated ('R') transfers
+        if transfer_type != TRANSFER_NORMAL && transfer_type != TRANSFER_ROTATED {
+            return;
+        }
+
+        // Mark as transmitting
+        let _ =
+            self.common
+                .info
+                .controls
+                .set(&ControlId::Power, Power::Transmit as u32 as f64, None);
+
+        let range_index = data[IMG_RANGE_INDEX];
+        let range_meters = range_index_to_meters(range_index) as u32;
+        let num_spokes = data[IMG_NUM_SPOKES] as u16;
+        let samples_per_spoke =
+            (data[IMG_SAMPLES_PER_SPOKE_HI] as u16) << 8 | data[IMG_SAMPLES_PER_SPOKE_LO] as u16;
+        let total_spokes =
+            (data[IMG_TOTAL_SPOKES_HI] as u16) << 8 | data[IMG_TOTAL_SPOKES_LO] as u16;
+        let start_angle = (data[IMG_START_ANGLE_HI] as u16) << 8 | data[IMG_START_ANGLE_LO] as u16;
+
+        let actual_pixels = actual_spoke_pixels(samples_per_spoke);
+        if actual_pixels == 0 || num_spokes == 0 || total_spokes == 0 {
+            return;
+        }
+
+        let spoke_data_offset = if transfer_type == TRANSFER_ROTATED {
+            IMG_SPOKE_DATA_ROTATED
+        } else {
+            IMG_SPOKE_DATA
+        };
+
+        // Update range
+        let _ = self
+            .common
+            .info
+            .controls
+            .set(&ControlId::Range, range_meters as f64, None);
+
+        // Get heading from navdata if available
+        let heading: Option<u16> = {
+            let h = crate::navdata::get_heading_true();
+            h.map(|h| (h * SPOKES as f64 / std::f64::consts::TAU) as u16)
+        };
+
+        // Process each spoke in this frame
+        let spoke_byte_len = actual_pixels as usize;
+
+        self.common.new_spoke_message();
+
+        for spoke_idx in 0..num_spokes {
+            let angle_raw = start_angle.wrapping_add(spoke_idx) % total_spokes;
+
+            // Map to our internal spoke count
+            let angle: SpokeBearing =
+                (angle_raw as u32 * SPOKES as u32 / total_spokes as u32) as u16;
+
+            let spoke_offset = spoke_data_offset + (spoke_idx as usize) * spoke_byte_len;
+            let spoke_end = spoke_offset + spoke_byte_len;
+            if spoke_end > data.len() {
+                break;
+            }
+
+            let spoke_data = &data[spoke_offset..spoke_end];
+
+            let mut scaled = Vec::with_capacity(spoke_byte_len);
+            for (i, pixel) in spoke_data.iter().enumerate() {
+                // Scale raw 0-255 to 0-PIXEL_VALUES
+                scaled.push((*pixel as u16 * PIXEL_VALUES as u16 / 255) as u8);
+            }
+
+            self.common.add_spoke(range_meters, angle, heading, scaled);
+        }
+
+        self.common.send_spoke_message();
+    }
+}

--- a/src/lib/brand/koden/settings.rs
+++ b/src/lib/brand/koden/settings.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+use super::protocol::KODEN_ANGLE_SCALE;
+use crate::{
+    Cli,
+    radar::settings::{
+        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
+        new_sector, new_string,
+    },
+    stream::SignalKDelta,
+};
+
+pub(crate) fn new(
+    radar_id: String,
+    sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
+    args: &Cli,
+) -> SharedControls {
+    let mut controls = HashMap::new();
+
+    new_string(ControlId::UserName).build(&mut controls);
+    new_string(ControlId::ModelName)
+        .read_only(true)
+        .build(&mut controls);
+    new_string(ControlId::SerialNumber)
+        .read_only(true)
+        .build(&mut controls);
+
+    new_auto(ControlId::Gain, 0., 100., HAS_AUTO_NOT_ADJUSTABLE).build(&mut controls);
+    new_numeric(ControlId::Sea, 0., 100.).build(&mut controls);
+    new_numeric(ControlId::Rain, 0., 100.).build(&mut controls);
+    new_list(ControlId::SeaState, &["Manual", "Auto", "Harbor"]).build(&mut controls);
+    new_list(
+        ControlId::InterferenceRejection,
+        &["Off", "Low", "Medium", "High"],
+    )
+    .build(&mut controls);
+    new_list(ControlId::TargetExpansion, &["Off", "On"]).build(&mut controls);
+    new_list(ControlId::ScanSpeed, &["Normal", "Fast"]).build(&mut controls);
+    new_auto(ControlId::Tune, 0., 255., HAS_AUTO_NOT_ADJUSTABLE).build(&mut controls);
+    new_numeric(ControlId::TuneFine, 0., 15.).build(&mut controls);
+    new_list(ControlId::PulseWidth, &["Short", "Long"]).build(&mut controls);
+
+    new_numeric(ControlId::DisplayTiming, 0., 124.).build(&mut controls);
+
+    new_sector(ControlId::NoTransmitSector1, -180., 180.)
+        .wire_scale_factor(KODEN_ANGLE_SCALE * 180. / PI, true)
+        .wire_offset(-1.)
+        .build(&mut controls);
+
+    new_numeric(ControlId::ParkPosition, -PI, PI)
+        .wire_scale_factor(KODEN_ANGLE_SCALE * 180. / PI, false)
+        .wire_offset(-1.)
+        .build(&mut controls);
+
+    SharedControls::new(radar_id, sk_client_tx, args, controls)
+}

--- a/src/lib/brand/koden/settings.rs
+++ b/src/lib/brand/koden/settings.rs
@@ -43,7 +43,7 @@ pub(crate) fn new(
 
     new_numeric(ControlId::DisplayTiming, 0., 124.).build(&mut controls);
 
-    new_sector(ControlId::NoTransmitSector1, -180., 180.)
+    new_sector(ControlId::NoTransmitSector1, -PI, PI)
         .wire_scale_factor(KODEN_ANGLE_SCALE * 180. / PI, true)
         .wire_offset(-1.)
         .build(&mut controls);

--- a/src/lib/brand/mod.rs
+++ b/src/lib/brand/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod emulator;
 pub(crate) mod furuno;
 #[cfg(feature = "garmin")]
 pub(crate) mod garmin;
+#[cfg(feature = "koden")]
+pub(crate) mod koden;
 #[cfg(feature = "navico")]
 pub(crate) mod navico;
 #[cfg(feature = "raymarine")]
@@ -29,6 +31,7 @@ pub(crate) enum LocatorId {
     Furuno,
     Garmin,
     GarminCdm,
+    Koden,
     Raymarine,
 }
 
@@ -64,6 +67,11 @@ pub(crate) fn create_brand_listeners(
     if args.brand.unwrap_or(Brand::Garmin) == Brand::Garmin {
         garmin::new(args, listen_addresses);
         brands.insert(Brand::Garmin);
+    }
+    #[cfg(feature = "koden")]
+    if args.brand.unwrap_or(Brand::Koden) == Brand::Koden {
+        koden::new(args, listen_addresses);
+        brands.insert(Brand::Koden);
     }
 }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -182,6 +182,7 @@ impl Cli {
 pub enum Brand {
     Furuno,
     Garmin,
+    Koden,
     Navico,
     Raymarine,
     Emulator,
@@ -193,6 +194,7 @@ impl Brand {
         match self {
             Self::Furuno => "fur",
             Self::Garmin => "gar",
+            Self::Koden => "kod",
             Self::Navico => "nav",
             Self::Raymarine => "ray",
             Self::Emulator => "emu",
@@ -206,6 +208,7 @@ impl Into<Brand> for &str {
         match self.to_ascii_lowercase().as_str() {
             "furuno" => Brand::Furuno,
             "garmin" => Brand::Garmin,
+            "koden" => Brand::Koden,
             "navico" => Brand::Navico,
             "raymarine" => Brand::Raymarine,
             "emulator" => Brand::Emulator,
@@ -223,6 +226,7 @@ impl Serialize for Brand {
         match self {
             Self::Furuno => serializer.serialize_str("Furuno"),
             Self::Garmin => serializer.serialize_str("Garmin"),
+            Self::Koden => serializer.serialize_str("Koden"),
             Self::Navico => serializer.serialize_str("Navico"),
             Self::Raymarine => serializer.serialize_str("Raymarine"),
             Self::Emulator => serializer.serialize_str("Emulator"),
@@ -236,6 +240,7 @@ impl std::fmt::Display for Brand {
         match self {
             Self::Furuno => write!(f, "Furuno"),
             Self::Garmin => write!(f, "Garmin"),
+            Self::Koden => write!(f, "Koden"),
             Self::Navico => write!(f, "Navico"),
             Self::Raymarine => write!(f, "Raymarine"),
             Self::Emulator => write!(f, "Emulator"),

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -125,8 +125,7 @@ pub enum ControlId {
     ScanSpeed,
     SideLobeSuppression,
     Tune,
-    // TuneCoarse,
-    // TuneFine,
+    TuneFine,
     // ColorGain,
     // DisplayTiming,
     Ftc,
@@ -272,6 +271,7 @@ impl ControlId {
             | ControlId::ScanSpeed
             | ControlId::SideLobeSuppression
             | ControlId::Tune
+            | ControlId::TuneFine
             | ControlId::Ftc
             | ControlId::MainBangSuppression
             | ControlId::SeaClutterCurve
@@ -341,6 +341,7 @@ impl ControlId {
             ControlId::ScanSpeed => "Desired rotation speed of the radar antenna",
             ControlId::SideLobeSuppression => "Level of side lobe suppression",
             ControlId::Tune => "Method to finely tune the radar receiver",
+            ControlId::TuneFine => "Fine adjustment of the radar receiver tuning",
             ControlId::Ftc => "FTC",
             ControlId::RangeUnits => "Which unit system to use for range values",
             ControlId::MainBangSuppression => "Main bang suppression",
@@ -458,7 +459,7 @@ impl ControlId {
             // ControlId::TimedRun => "Timed run",
             ControlId::TrailsMotion => "Target trails motion",
             ControlId::Tune => "Tune",
-            // ControlId::TuneFine => "Fine tune",
+            ControlId::TuneFine => "Fine tune",
             ControlId::Spokes => "Spokes",
             ControlId::SpokeLength => "Spoke length",
             ControlId::SpokeProcessing => "Spoke Processing",
@@ -527,6 +528,7 @@ impl ControlId {
             ControlId::ScanSpeed => ControlDestination::Command,
             ControlId::SideLobeSuppression => ControlDestination::Command,
             ControlId::Tune => ControlDestination::Command,
+            ControlId::TuneFine => ControlDestination::Command,
             ControlId::Ftc => ControlDestination::Command,
             ControlId::MainBangSuppression => ControlDestination::Command,
             ControlId::SeaClutterCurve => ControlDestination::Command,

--- a/src/lib/recording/recorder.rs
+++ b/src/lib/recording/recorder.rs
@@ -309,6 +309,7 @@ pub fn brand_to_id(brand: Brand) -> u32 {
         Brand::Raymarine => 4,
         Brand::Emulator => 5,
         Brand::Playback => 6,
+        Brand::Koden => 7,
     }
 }
 
@@ -320,6 +321,7 @@ pub fn id_to_brand(id: u32) -> Option<Brand> {
         4 => Some(Brand::Raymarine),
         5 => Some(Brand::Emulator),
         6 => Some(Brand::Playback),
+        7 => Some(Brand::Koden),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- Full Koden MDS-series radar support: UDP discovery, control commands, spoke reception
- 11 known models identified via model code (MDS-50R through MDS-10R)
- Controls: power, gain (auto), sea, rain, sea state (manual/auto/harbor), interference rejection, target expansion, scan speed, display timing, tune (coarse with auto), fine tune, pulse width, no-transmit sector, park position
- Spokes passed at native resolution (240/480/960 pixels) without stretching
- New `TuneFine` ControlId added to radar settings

## Test plan
- [x] `cargo check` compiles clean
- [ ] Test with live Koden MDS-5R or MDS-11R hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds comprehensive support for Koden MDS-series RADARpc radars, enabling UDP-based discovery, control commands, and spoke reception at native resolutions (240/480/960 pixels).

## Feature & build integration

- Adds a new Cargo feature flag `koden` and includes it in the default feature set.
- Introduces `Brand::Koden` with string parsing, serialization, display formatting, and the "kod" prefix.
- Registers Koden in the recording subsystem with brand ID 7.

## New modules & protocol

- Adds a Koden implementation under src/lib/brand/koden with modules:
  - protocol.rs — wire-level protocol constants, framing markers, timing, model/range tables, and helpers for angle/range conversions.
  - mod.rs — UDP locator that recognizes Koden control/status and image-frame packets, registers radars, and spawns a report-receiver subsystem.
  - report.rs — KodenReportReceiver that manages UDP I/O, startup/keepalive logic, decodes status packets into shared controls, and decodes image packets into spoke frames.
  - command.rs — Command sender that formats and transmits Koden control commands over UDP.
  - settings.rs — Builds SharedControls for Koden-specific controls and enumerations.

## Discovery, reception & decoding

- Performs UDP discovery/identification via control/status prefixes and an image-frame marker on port 10001 (broadcast).
- Runs a receive loop with restart-on-error behavior, optional startup/keepalive sending, and control-subscription handling.
- Decodes image frames to extract transfer type, range, spoke counts, sample counts, start angle, and per-spoke bearings; converts Koden wire angles (0–1023) to radians; scales pixel intensities and publishes spokes at native sample counts without stretching.
- Optionally derives heading from nav data and includes it in spoke metadata.

## Models & capabilities

- Detects 11 known models via model-code mapping (MDS-50R through MDS-10R) and exposes model, serial, and related metadata.
- Supports controls with proper wire encodings and auto/manual handling:
  - Power (transmit/standby via transfer mode), Gain (with auto), Sea clutter (STC), Rain (FTC)
  - Sea state (manual/auto/harbor), Interference rejection, Target expansion, Scan speed
  - Display timing (trigger delay), Tune (coarse with auto), TuneFine (fine tuning), Pulse width
  - No-transmit blanking sectors and Park position (angle controls)
- Encodes multi-byte angle/sector and park position via 16-bit word packets with appropriate scaling.

## State reporting & controls mapping

- Parses status/control responses to update shared controls: gain/STC/FTC and auto modes, transmission/warmup state, scan/antenna parameters, MAC/model/serial, tuning/presets, and park/blanking sectors.
- Implements CommandSender to translate ControlValue → Koden wire commands and send startup/keepalive packets.

## Documentation & configuration

- Adds docs/koden-setup.md describing network requirements (UDP broadcast on port 10001, same-subnet), supported models, controls, and troubleshooting steps.
- Updates README and internal docs to list Koden as implemented (awaiting live-hardware validation).

## Tests & status

- cargo check passes (compiles clean).
- Live hardware verification remains pending (to be tested with Koden MDS-series units such as MDS-5R or MDS-11R).

## Notable implementation details

- Publishes spokes at native resolutions (240/480/960) without stretching.
- Re-enables TuneFine control and maps it to command destination.
- Encodes blanking sectors and park position using radians → word encoding and includes angle normalization helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->