### PR TITLE
fix(koden): remove unused fields to silence dead_code warnings

### DIFF
--- a/src/lib/brand/koden/command.rs
+++ b/src/lib/brand/koden/command.rs
@@ -15,7 +15,6 @@ fn pct_to_u8(pct: f64) -> u8 {
 pub(crate) struct Command {
     key: String,
     socket: Option<UdpSocket>,
-    controls: SharedControls,
 }
 
 impl Command {
@@ -23,7 +22,6 @@ impl Command {
         Command {
             key: info.key(),
             socket: None,
-            controls: info.controls.clone(),
         }
     }
 

--- a/src/lib/brand/koden/report.rs
+++ b/src/lib/brand/koden/report.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddrV4;
 use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::time::{Instant, sleep_until};
@@ -17,7 +16,6 @@ use crate::util::PrintableSlice;
 pub(crate) struct KodenReportReceiver {
     common: CommonRadar,
     command_sender: Option<Command>,
-    radar_addr: SocketAddrV4,
 }
 
 impl KodenReportReceiver {
@@ -29,7 +27,6 @@ impl KodenReportReceiver {
             Some(Command::new(&info))
         };
 
-        let radar_addr = info.addr;
         let control_update_rx = info.control_update_subscribe();
         let blob_tx = radars.get_blob_tx();
 
@@ -46,7 +43,6 @@ impl KodenReportReceiver {
         KodenReportReceiver {
             common,
             command_sender,
-            radar_addr,
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove \`Command::controls\` and \`KodenReportReceiver::radar_addr\` — both were assigned but never read.
- Clears the two dead_code warnings from the default build.

The Koden wire protocol has no radar-ID addressing — the Coastal Explorer reference implementation (\`CKodenRadar\`) assumes a single radar on the subnet — so these were cruft rather than deferred multi-radar scaffolding.

## Test plan
- [x] \`cargo build\` completes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)