### PR TITLE
fix(target): wrap negative guard-zone angles

### DIFF
--- a/src/lib/radar/target/blob.rs
+++ b/src/lib/radar/target/blob.rs
@@ -200,6 +200,13 @@ struct GuardZoneInternal {
     end_pixel: usize,
 }
 
+// Guard zones allow negative head-relative angles, so conversion to the
+// circular spoke domain must wrap around 0 instead of collapsing negatives.
+fn radians_to_spoke(angle_radians: f64, spokes_per_revolution: u16) -> u16 {
+    let spoke = ((angle_radians / TAU) * spokes_per_revolution as f64) as i32;
+    spoke.rem_euclid(spokes_per_revolution as i32) as u16
+}
+
 /// Blob detector that processes spokes and identifies targets
 pub struct BlobDetector {
     spokes_per_revolution: u16,
@@ -283,14 +290,12 @@ impl BlobDetector {
                     continue;
                 }
 
-                // Convert angles from radians to spokes
-                // Guard zones are head-relative (0 = forward)
-                let start_spoke = ((zone.start_angle / TAU)
-                    * self.spokes_per_revolution as f64) as u16
-                    % self.spokes_per_revolution;
-                let end_spoke = ((zone.end_angle / TAU) * self.spokes_per_revolution as f64)
-                    as u16
-                    % self.spokes_per_revolution;
+                // Guard zones are head-relative (0 = forward) and can cross
+                // 0 with a negative start angle.
+                let start_spoke =
+                    radians_to_spoke(zone.start_angle, self.spokes_per_revolution);
+                let end_spoke =
+                    radians_to_spoke(zone.end_angle, self.spokes_per_revolution);
 
                 // Convert distances from meters to pixels
                 let start_pixel = (zone.start_distance / meters_per_pixel) as usize;
@@ -597,6 +602,8 @@ impl BlobDetector {
 
 #[cfg(test)]
 mod tests {
+    use std::f64::consts::PI;
+
     use super::*;
 
     fn blob_from_spokes(spokes: &[u16]) -> BlobInProgress {
@@ -714,5 +721,42 @@ mod tests {
         // 0 forward to 8191, which is 8190 empty slots). Center =
         // (8191 + 1) % 8192 = 0.
         assert_eq!(arc.center, 0);
+    }
+
+    #[test]
+    fn guard_zone_negative_angles_wrap_correctly() {
+        // A sector like -55 deg .. 38 deg must wrap across spoke 0.
+        let mut detector = BlobDetector::new(2048, 10, None);
+
+        // The actual range/pixel values only need to be non-zero so the guard
+        // zone cache can be rebuilt.
+        detector.current_range = 1000;
+        detector.current_spoke_len = 1000;
+        detector.set_guard_zone_1(Some(GuardZone {
+            start_angle: -55.0 * PI / 180.0,
+            end_angle: 38.0 * PI / 180.0,
+            start_distance: 0.0,
+            end_distance: 1000.0,
+            enabled: true,
+        }));
+
+        assert_eq!(detector.guard_zones.len(), 1);
+
+        let zone = &detector.guard_zones[0];
+
+        // The start must land near the end of the revolution, proving we
+        // wrapped the negative angle instead of collapsing it to 0.
+        assert!(zone.start_spoke > zone.end_spoke);
+        assert!(zone.start_spoke > 1700);
+        assert!(zone.end_spoke < 300);
+
+        // A spoke in the negative-angle part of the sector must be detected.
+        assert_eq!(detector.check_guard_zones(1800, 500), vec![1]);
+
+        // A spoke in the positive-angle part must also be detected.
+        assert_eq!(detector.check_guard_zones(150, 500), vec![1]);
+
+        // A spoke well outside the configured sector must not match.
+        assert!(detector.check_guard_zones(900, 500).is_empty());
     }
 }


### PR DESCRIPTION
Fix guard-zone auto acquisition when the configured sector includes negative head-relative angles.

The blob detector converted guard-zone angles to spoke indices with a direct integer cast, which collapsed negative angles instead of wrapping them onto the circular spoke domain. The UI still drew the requested sector correctly, so auto acquisition and the visible guard zone could disagree for sectors like `-55° .. 38°`.

This change normalizes guard-zone angles with `rem_euclid`, matching the existing exclusion-zone conversion, and adds a regression test for the wraparound case.

Tested:
- `cargo test guard_zone_negative_angles_wrap_correctly`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

Guard zone auto-acquisition fails when configured sectors include negative head-relative angles. The blob detector converts guard-zone angles to spoke indices using direct integer casting and modulo, which collapses negative angles instead of wrapping them into the circular spoke domain. The UI continues to draw the requested sector correctly, creating a mismatch for sectors such as -55° to 38°.

## Solution

This PR adds a `radians_to_spoke` helper function that normalizes guard-zone angles using Euclidean remainder (`rem_euclid`), properly handling wraparound at the spoke domain boundary. The implementation:

- Converts angle to an intermediate i32 spoke value
- Applies `rem_euclid` to wrap the value into the valid spoke range
- Casts back to u16

The `refresh_guard_zones` method now uses this helper for both start and end spoke conversions, matching the existing exclusion-zone conversion logic. The approach ensures negative angles wrap correctly around spoke 0 rather than collapsing to 0.

## Tests

A regression test validates the wraparound case with a sector from -55° to 38°, which should cross spoke 0:

- Asserts the resulting spoke indices reflect wraparound (start_spoke > end_spoke)
- Verifies `check_guard_zones` detects spokes in both the negative-angle and positive-angle regions
- Confirms spokes outside the configured sector are rejected

The test confirms proper behavior with spoke indices near the boundaries (start_spoke > 1700, end_spoke < 300 for a 2048-spoke configuration).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->