### PR TITLE
chore(deps): pin tungstenite forks and add permessage-deflate support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1477,6 +1478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,7 +1612,6 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
- "tungstenite 0.26.2",
  "unicase",
  "utoipa",
  "utoipa-swagger-ui",
@@ -2602,6 +2613,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,12 +3339,16 @@ dependencies = [
 [[package]]
 name = "tokio-tungstenite"
 version = "0.26.2"
-source = "git+https://github.com/keesverruijt/tokio-tungstenite#40211c97c089ab3891f2bf7458d0f31757240450"
+source = "git+https://github.com/keesverruijt/tokio-tungstenite?tag=v0.26.2-signalapp-v0.27.0#1480f0f53b1a42493aff76959c26fedbd279e8f0"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tungstenite 0.26.2",
+ "tokio-rustls",
+ "tungstenite 0.27.0",
 ]
 
 [[package]]
@@ -3424,8 +3451,8 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
-source = "git+https://github.com/keesverruijt/tungstenite-rs.git?branch=permessage-deflate#3b1c7c059dab8a46531fe2cd80d607d58e7b7902"
+version = "0.27.0"
+source = "git+https://github.com/signalapp/tungstenite-rs.git?tag=signal-v0.27.0#d9409e3622ff867e7cf77e864be95487113ae499"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3434,7 +3461,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,18 +79,18 @@ time = { version = "0.3.47", features = ["formatting"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 tokio-graceful-shutdown = "0.15.4"
-# tokio-tungstenite = "0.26.2"
-tokio-tungstenite = { git = "https://github.com/keesverruijt/tokio-tungstenite", features = [ "deflate" ] }
 tokio-util = "0.7.18"
 tower = "0.5.3"
 tower-http = { version = "0.6", features = ["trace"] }
-tungstenite = { git = "https://github.com/keesverruijt/tungstenite-rs.git", branch = "permessage-deflate", features = [ "deflate" ] }
 utoipa = { version = "5", features = ["macros", "axum_extras", "chrono", "time", "url", "repr" ] }
 serde_string_enum = "0.2.1"
 unicase = "2.9.0"
 wildmatch = "2.6.1"
 utoipa-swagger-ui = { version = "9.0.2", features = ["url", "axum"] }
-# tungstenite = { path = "../tungstenite-rs", features = [ "handshake", "deflate" ] }
+tokio-tungstenite = { version = "0.26.2", features = [ "handshake", "deflate", "rustls-tls-native-roots" ] }
+
+[patch.crates-io]
+tokio-tungstenite = { git = "https://github.com/keesverruijt/tokio-tungstenite", tag = "v0.26.2-signalapp-v0.27.0"}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.4"

--- a/src/bin/mayara-server/web/axum_extract_ws.rs
+++ b/src/bin/mayara-server/web/axum_extract_ws.rs
@@ -1,5 +1,6 @@
-#![allow(dead_code, unused_variables)]
-
+//
+// Small modification to support per-message compression, which is not supported by tungstenite-rs out of the box.
+//
 //! Handle WebSocket connections.
 //!
 //! # Example
@@ -94,18 +95,17 @@
 
 use self::rejection::*;
 use axum::extract::FromRequestParts;
-use axum::http::{
-    Method, StatusCode, Version,
-    header::{self, HeaderMap, HeaderName, HeaderValue},
-    request::Parts,
-};
 use axum::{Error, body::Bytes, response::Response};
 use axum_core::body::Body;
 use futures_util::{
     sink::{Sink, SinkExt},
-    stream::{Stream, StreamExt},
+    stream::{FusedStream, Stream, StreamExt},
 };
-use headers::HeaderMapExt;
+use http::{
+    Method, StatusCode, Version,
+    header::{self, HeaderMap, HeaderName, HeaderValue},
+    request::Parts,
+};
 use hyper_util::rt::TokioIo;
 use sha1::{Digest, Sha1};
 use std::{
@@ -118,13 +118,22 @@ use tokio_tungstenite::{
     WebSocketStream,
     tungstenite::{
         self as ts,
+        extensions::ExtensionsConfig,
         protocol::{self, WebSocketConfig},
     },
 };
-use tungstenite::extensions::DeflateConfig;
-use tungstenite::handshake::headers::SecWebsocketExtensions;
 
+/// Extractor for establishing WebSocket connections.
+///
+/// For HTTP/1.1 requests, this extractor requires the request method to be `GET`;
+/// in later versions, `CONNECT` is used instead.
+/// To support both, it should be used with [`any`](crate::routing::any).
+///
+/// See the [module docs](self) for an example.
+///
+/// [`MethodFilter`]: crate::routing::MethodFilter
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
+#[must_use]
 pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     config: WebSocketConfig,
     /// The chosen protocol sent in the `Sec-WebSocket-Protocol` header of the response.
@@ -134,7 +143,10 @@ pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     on_upgrade: hyper::upgrade::OnUpgrade,
     on_failed_upgrade: F,
     sec_websocket_protocol: Option<HeaderValue>,
-    sec_websocket_extensions: Option<SecWebsocketExtensions>,
+    /// Whether the client offered permessage-deflate in `Sec-WebSocket-Extensions`.
+    client_offers_deflate: bool,
+    /// Whether permessage-deflate was enabled via the builder.
+    permessage_deflate: bool,
 }
 
 impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
@@ -203,13 +215,17 @@ impl<F> WebSocketUpgrade<F> {
         self
     }
 
-    /// Enable compression
-    pub fn accept_compression(mut self, enable: bool) -> Self {
-        self.config.compression = if enable {
-            Some(DeflateConfig::default())
-        } else {
-            None
-        };
+    /// Enable per-message deflate compression with default settings.
+    ///
+    /// Only takes effect if the client offered `permessage-deflate` in its
+    /// `Sec-WebSocket-Extensions` request header.
+    pub fn permessage_deflate(mut self) -> Self {
+        if self.client_offers_deflate {
+            let mut extensions = ExtensionsConfig::default();
+            extensions.permessage_deflate = Some(Default::default());
+            self.config.extensions = extensions;
+            self.permessage_deflate = true;
+        }
         self
     }
 
@@ -272,6 +288,15 @@ impl<F> WebSocketUpgrade<F> {
         self
     }
 
+    /// Return the selected WebSocket subprotocol, if one has been chosen.
+    ///
+    /// If [`protocols()`][Self::protocols] has been called and a matching
+    /// protocol has been selected, the return value will be `Some` containing
+    /// said protocol. Otherwise, it will be `None`.
+    pub fn selected_protocol(&self) -> Option<&HeaderValue> {
+        self.protocol.as_ref()
+    }
+
     /// Provide a callback to call if upgrading the connection fails.
     ///
     /// The connection upgrade is performed in a background task. If that fails this callback
@@ -307,7 +332,8 @@ impl<F> WebSocketUpgrade<F> {
             on_upgrade: self.on_upgrade,
             on_failed_upgrade: callback,
             sec_websocket_protocol: self.sec_websocket_protocol,
-            sec_websocket_extensions: self.sec_websocket_extensions,
+            client_offers_deflate: self.client_offers_deflate,
+            permessage_deflate: self.permessage_deflate,
         }
     }
 
@@ -321,19 +347,12 @@ impl<F> WebSocketUpgrade<F> {
         F: OnFailedUpgrade,
     {
         let on_upgrade = self.on_upgrade;
-        let config: WebSocketConfig = self.config;
+        let config = self.config;
         let on_failed_upgrade = self.on_failed_upgrade;
 
         let protocol = self.protocol.clone();
-        let (sec_websocket_extensions, extensions) =
-            if let Some(ext) = self.sec_websocket_extensions {
-                config.accept_offers(&ext).unzip()
-            } else {
-                (None, None)
-            };
 
         tokio::spawn(async move {
-            log::debug!("on_upgrade on new tokio thread: config={:?}", config);
             let upgraded = match on_upgrade.await {
                 Ok(upgraded) => upgraded,
                 Err(err) => {
@@ -343,13 +362,9 @@ impl<F> WebSocketUpgrade<F> {
             };
             let upgraded = TokioIo::new(upgraded);
 
-            let socket = WebSocketStream::from_raw_socket_with_extensions(
-                upgraded,
-                protocol::Role::Server,
-                Some(config),
-                extensions,
-            )
-            .await;
+            let socket =
+                WebSocketStream::from_raw_socket(upgraded, protocol::Role::Server, Some(config))
+                    .await;
             let socket = WebSocket {
                 inner: socket,
                 protocol,
@@ -387,11 +402,14 @@ impl<F> WebSocketUpgrade<F> {
                 .headers_mut()
                 .insert(header::SEC_WEBSOCKET_PROTOCOL, protocol);
         }
-        if let Some(ext) = sec_websocket_extensions {
-            response
-                .headers_mut()
-                .insert(header::SEC_WEBSOCKET_EXTENSIONS, ext.to_value());
+
+        if self.permessage_deflate {
+            response.headers_mut().insert(
+                header::SEC_WEBSOCKET_EXTENSIONS,
+                HeaderValue::from_static("permessage-deflate"),
+            );
         }
+
         response
     }
 }
@@ -457,6 +475,8 @@ where
                 return Err(MethodNotConnect.into());
             }
 
+            // if this feature flag is disabled, we won’t be receiving an HTTP/2 request to begin
+            // with.
             if parts
                 .extensions
                 .get::<hyper::ext::Protocol>()
@@ -478,7 +498,13 @@ where
             .ok_or(ConnectionNotUpgradable)?;
 
         let sec_websocket_protocol = parts.headers.get(header::SEC_WEBSOCKET_PROTOCOL).cloned();
-        let sec_websocket_extensions = parts.headers.typed_get::<SecWebsocketExtensions>();
+
+        let client_offers_deflate = parts
+            .headers
+            .get(header::SEC_WEBSOCKET_EXTENSIONS)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("permessage-deflate"));
+
         let config: WebSocketConfig = Default::default();
 
         Ok(Self {
@@ -487,8 +513,9 @@ where
             sec_websocket_key,
             on_upgrade,
             sec_websocket_protocol,
-            sec_websocket_extensions,
             on_failed_upgrade: DefaultOnFailedUpgrade,
+            client_offers_deflate,
+            permessage_deflate: false,
         })
     }
 }
@@ -546,6 +573,13 @@ impl WebSocket {
     }
 }
 
+impl FusedStream for WebSocket {
+    /// Returns true if the websocket has been terminated.
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
+    }
+}
+
 impl Stream for WebSocket {
     type Item = Result<Message, Error>;
 
@@ -595,6 +629,7 @@ pub struct Utf8Bytes(ts::Utf8Bytes);
 impl Utf8Bytes {
     /// Creates from a static str.
     #[inline]
+    #[must_use]
     pub const fn from_static(str: &'static str) -> Self {
         Self(ts::Utf8Bytes::from_static(str))
     }
@@ -1064,3 +1099,4 @@ pub mod close_code {
     /// action.
     pub const AGAIN: u16 = 1013;
 }
+

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -27,13 +27,17 @@ use tokio_rustls::{TlsAcceptor, server::TlsStream};
 use tower_http::trace::TraceLayer;
 use utoipa::ToSchema;
 
-mod axum_fix;
+#[allow(dead_code)]
+mod axum_extract_ws; // Our own WebSocketUpgrade that supports compression and other features we need
+use axum_extract_ws::Message;
+use axum_extract_ws::WebSocket;
+use axum_extract_ws::WebSocketUpgrade;
+
 mod recordings;
 mod signalk;
 
 pub use signalk::v2::generate_openapi_json;
 
-use axum_fix::{Message, WebSocket, WebSocketUpgrade};
 use mayara::{
     Cli, InterfaceApi, PACKAGE, VERSION,
     radar::{RadarError, SharedRadars},
@@ -145,15 +149,13 @@ impl Web {
         socket.set_only_v6(false).map_err(WebError::Io)?;
         socket.set_reuse_address(true).map_err(WebError::Io)?;
         socket.set_nonblocking(true).map_err(WebError::Io)?;
-        socket
-            .bind(&addr.into())
-            .map_err(|e| {
-                if e.kind() == io::ErrorKind::AddrInUse {
-                    WebError::PortInUse(port)
-                } else {
-                    WebError::Io(e)
-                }
-            })?;
+        socket.bind(&addr.into()).map_err(|e| {
+            if e.kind() == io::ErrorKind::AddrInUse {
+                WebError::PortInUse(port)
+            } else {
+                WebError::Io(e)
+            }
+        })?;
         socket.listen(1024).map_err(WebError::Io)?;
         let listener = TcpListener::from_std(socket.into()).map_err(WebError::Io)?;
 
@@ -338,15 +340,14 @@ async fn spokes_handler(
 ) -> Response {
     debug!("stream request for {}", params.id);
 
-    let ws = ws.accept_compression(true);
-
     match state.radars.get_by_key(&params.id) {
         Some(radar) => {
             let shutdown_rx = state.shutdown_tx.subscribe();
             let radar_message_rx = radar.message_tx.subscribe();
             // finalize the upgrade process by returning upgrade callback.
             // we can customize the callback by sending additional info such as address.
-            ws.on_upgrade(move |socket| spokes_stream(socket, radar_message_rx, shutdown_rx))
+            ws.permessage_deflate()
+                .on_upgrade(move |socket| spokes_stream(socket, radar_message_rx, shutdown_rx))
         }
         None => RadarError::NoSuchRadar(params.id).into_response(),
     }

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1138,14 +1138,12 @@ async fn control_stream_handler(
         }
     };
 
-    let ws = ws.accept_compression(true);
-
     let radars = state.radars.clone();
     let shutdown_tx = state.shutdown_tx.clone();
 
     // finalize the upgrade process by returning upgrade callback.
     // we can customize the callback by sending additional info such as address.
-    ws.on_upgrade(move |socket| {
+    ws.permessage_deflate().on_upgrade(move |socket| {
         ws_signalk_delta_shim(socket, subscribe, send_cached_values, radars, shutdown_tx)
     })
 }

--- a/tests/api_stream.rs
+++ b/tests/api_stream.rs
@@ -12,7 +12,13 @@ use serde_json::{Value, json};
 use std::env;
 use std::time::Duration;
 use tokio::time::timeout;
-use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use tokio_tungstenite::{
+    connect_async, connect_async_with_config,
+    tungstenite::{
+        extensions::ExtensionsConfig,
+        protocol::{Message, WebSocketConfig},
+    },
+};
 
 fn ws_url() -> String {
     env::var("MAYARA_TEST_WS_URL").unwrap_or_else(|_| "ws://localhost:6502".to_string())
@@ -314,4 +320,70 @@ async fn test_signalk_delta_format() {
             }
         }
     }
+}
+
+// ============================================================================
+// WebSocket compression (permessage-deflate)
+// ============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_websocket_deflate_negotiation() {
+    let url = format!("{}/signalk/v1/stream?subscribe=none", ws_url());
+
+    let mut config = WebSocketConfig::default();
+    let mut extensions = ExtensionsConfig::default();
+    extensions.permessage_deflate = Some(Default::default());
+    config.extensions = extensions;
+
+    let (ws, response) =
+        connect_async_with_config(url, Some(config), false)
+            .await
+            .expect("Failed to connect with deflate");
+
+    // Server should echo back the extension in the response
+    let ext_header = response
+        .headers()
+        .get("sec-websocket-extensions")
+        .expect("Response missing Sec-WebSocket-Extensions header");
+    assert!(
+        ext_header
+            .to_str()
+            .unwrap()
+            .contains("permessage-deflate"),
+        "Server should negotiate permessage-deflate, got: {:?}",
+        ext_header
+    );
+
+    // Verify the connection is functional: send a subscribe and read a response
+    let (mut write, mut read) = ws.split();
+    let msg = json!({"subscribe": [{"path": "radars.*.controls.*", "policy": "instant"}]});
+    write.send(text_msg(&msg)).await.expect("Failed to send");
+
+    let result = timeout(Duration::from_secs(5), read.next()).await;
+    assert!(result.is_ok(), "Should receive data over compressed connection");
+    if let Ok(Some(Ok(Message::Text(text)))) = result {
+        let json: Value = serde_json::from_str(&text).expect("Should be valid JSON");
+        assert!(
+            json.get("updates").is_some() || json.get("name").is_some(),
+            "Should receive valid message over compressed connection"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_websocket_without_deflate() {
+    let url = format!("{}/signalk/v1/stream?subscribe=none", ws_url());
+
+    // Connect without requesting compression
+    let (_, response) = connect_async(&url)
+        .await
+        .expect("Failed to connect");
+
+    // Server should NOT include the extension header
+    assert!(
+        response.headers().get("sec-websocket-extensions").is_none(),
+        "Server should not negotiate deflate when client doesn't offer it"
+    );
 }

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -3,12 +3,11 @@ set -euo pipefail
 
 PORT="${MAYARA_TEST_PORT:-6502}"
 BASE_URL="http://localhost:${PORT}"
-SERVER="./target/release/mayara-server"
+SERVER="./target/debug/mayara-server"
 LOG_FILE=$(mktemp)
 
-# Build release binary
-echo "Building release binary..."
-cargo build --release --quiet
+echo "Building debug binary..."
+cargo build --quiet
 
 # Start emulator server, capture log to extract PID
 echo "Starting emulator on port ${PORT}..."


### PR DESCRIPTION
## Summary

- Switch to Signal's tungstenite fork (pinned at `signal-v0.27.0`) via `[patch.crates-io]` so the entire dependency graph uses a single tungstenite version with extension support
- Replace the old `axum_fix` WebSocket extractor with `axum_extract_ws`, which adds a `.permessage_deflate()` builder method that negotiates compression with the client via `Sec-WebSocket-Extensions` headers
- Compression is only activated when the client offers `permessage-deflate` in the upgrade request

## Test plan

- [x] `cargo check` passes
- [x] Verify WebSocket connections work in Chrome without RSV1 errors
- [x] Verify `Sec-WebSocket-Extensions: permessage-deflate` appears in the 101 response when the client supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR upgrades WebSocket support by pinning Signal's tungstenite fork and introducing per-message deflate (compression) negotiation. The compression feature activates only when clients explicitly offer it via the `Sec-WebSocket-Extensions` header, enabling more efficient WebSocket communication.

## Changes

### Dependencies
- Updates `tokio-tungstenite` and `tungstenite` to crates.io versions with a `[patch.crates-io]` override that pins both to Signal's fork tags (`signal-v0.27.0` for tungstenite)
- Enables `deflate`, `handshake`, and `rustls-tls-native-roots` features on the patched tungstenite crate to support compression and enhanced TLS configuration

### WebSocket Infrastructure
- Replaces the `axum_fix` WebSocket extractor with a new `axum_extract_ws` module that provides improved extension handling
- Introduces `WebSocketUpgrade::permessage_deflate()` builder method for configuring compression negotiation
- Adds client deflate offer detection via `client_offers_deflate` field tracking whether `Sec-WebSocket-Extensions: permessage-deflate` appears in the upgrade request
- Conditionally injects `Sec-WebSocket-Extensions: permessage-deflate` in the 101 response only when the client offers it
- Removes the previous boolean `accept_compression()` API in favor of the more granular `permessage_deflate()` method
- Adds `WebSocket` FusedStream trait implementation and public `selected_protocol()` method on the upgrade type

### Compression Behavior
- Negotiation occurs during the WebSocket handshake when both client and server support permessage-deflate
- Compression applies only to message payloads, not the WebSocket frame headers
- Supports both binary and text frames with transparent deflate/inflate

### Handler Updates
- Updates `spokes_handler` and `ws_signalk_delta_shim` to use the new `permessage_deflate()` configuration method instead of the removed `accept_compression(true)` approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->