### PR TITLE
fix(controls): round instead of truncate in value conversions

### DIFF
--- a/src/lib/brand/navico/command.rs
+++ b/src/lib/brand/navico/command.rs
@@ -87,7 +87,7 @@ impl Command {
         } else if r < 0.0 {
             r = 0.0;
         }
-        r as u8
+        r.round() as u8
     }
 
     fn mod_deci_degrees(a: i32) -> i32 {

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -97,7 +97,7 @@ impl Command {
         } else if r < 0.0 {
             r = 0.0;
         }
-        r as u8
+        r.round() as u8
     }
 }
 

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -2908,8 +2908,8 @@ impl Control {
                 auto_value = auto_value.map(|value| (value * 10.) as i32 as f64 / 10.);
             }
             1.0 => {
-                value = value as i32 as f64;
-                auto_value = auto_value.map(|value| value as i32 as f64);
+                value = value.round() as i32 as f64;
+                auto_value = auto_value.map(|value| value.round() as i32 as f64);
             }
             _ => {
                 value = (value / step).round() * step;


### PR DESCRIPTION
## Summary
- Use `f64::round()` instead of truncating casts when converting control values between user-facing (0–100) and wire (0–255) formats
- Fixes the gain value decreasing on each auto-mode toggle (e.g. gain 45 → wire 114 → back to 44)
- Applies to Navico and Raymarine `scale_100_to_byte`, and the shared `Control::set` integer-step rounding

Fixes #26

## Test plan
- [x] All 166 unit tests pass
- [x] Round-trip verification: gain values 1–100 now survive the user→wire→user conversion without loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)