### PR TITLE
fix(gui): replace Auto button with toggle switch

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -338,14 +338,16 @@ const ButtonValue = (id, name) =>
   );
 
 const AutoButton = (id) =>
-  button(
-    {
-      type: "button",
+  label(
+    { class: "myr_auto_switch" },
+    input({
+      type: "checkbox",
       class: "myr_auto_toggle",
       id: control_prefix + id + auto_postfix,
-      onclick: (e) => do_toggle_auto(e.target),
-    },
-    "Auto"
+      onchange: (e) => do_toggle_auto(e.target),
+    }),
+    span({ class: "myr_auto_slider" }),
+    " Auto"
   );
 
 const EnabledButton = (id) =>
@@ -1431,11 +1433,11 @@ function setControlValue(cv) {
         updateTickMarks(i);
       }
 
-      // Handle auto toggle button
+      // Handle auto toggle switch
       if (control.hasAuto && "auto" in cv) {
-        let autoBtn = i.parentNode.querySelector(".myr_auto_toggle");
-        if (autoBtn) {
-          autoBtn.classList.toggle("myr_auto_active", cv.auto);
+        let autoCheckbox = i.parentNode.querySelector(".myr_auto_toggle");
+        if (autoCheckbox) {
+          autoCheckbox.checked = cv.auto;
         }
         let display = cv.auto && !control.hasAutoAdjustable ? "none" : "block";
         if (n) n.style.display = display;
@@ -1524,15 +1526,14 @@ function do_change(v) {
   sendControlToServer(id, message);
 }
 
-function do_toggle_auto(btn) {
-  let id = html_to_server_id(btn.id);
+function do_toggle_auto(checkbox) {
+  let id = html_to_server_id(checkbox.id);
 
   let update = myr_control_values[id] || { id: id };
-  let newAuto = !update.auto;
-  update.auto = newAuto;
+  update.auto = checkbox.checked;
   setControlValue(update);
 
-  sendControlToServer(id, { id: id, auto: newAuto });
+  sendControlToServer(id, { id: id, auto: checkbox.checked });
 }
 
 function do_change_enabled(checkbox) {

--- a/web/gui/controls.css
+++ b/web/gui/controls.css
@@ -42,29 +42,66 @@ label.myr_auto_label,input.myr_auto {
   margin-top: 8px;
 }
 
-/* Auto toggle button */
-.myr_auto_toggle {
-  padding: 4px 10px;
+/* Auto toggle switch */
+.myr_auto_switch {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
   font-size: 12px;
   font-weight: bold;
-  border: 2px solid #558;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  background-color: #223;
   color: #88a;
   margin-left: 8px;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
-.myr_auto_toggle:hover {
+.myr_auto_switch .myr_auto_toggle {
+  display: none;
+}
+
+.myr_auto_slider {
+  display: inline-block;
+  width: 32px;
+  height: 18px;
+  background-color: #223;
+  border: 2px solid #558;
+  border-radius: 11px;
+  position: relative;
+  transition: all 0.2s ease;
+  margin-right: 6px;
+  flex-shrink: 0;
+}
+
+.myr_auto_slider::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background-color: #88a;
+  border-radius: 50%;
+  top: 3px;
+  left: 2px;
+  transition: all 0.2s ease;
+}
+
+.myr_auto_toggle:checked + .myr_auto_slider {
+  background-color: #4a8;
+  border-color: #4a8;
+}
+
+.myr_auto_toggle:checked + .myr_auto_slider::after {
+  background-color: #fff;
+  left: 16px;
+}
+
+.myr_auto_switch:hover .myr_auto_slider {
   border-color: #77a;
   background-color: #334;
 }
 
-.myr_auto_toggle.myr_auto_active {
-  background-color: #4a8;
-  border-color: #4a8;
-  color: #fff;
+.myr_auto_switch:hover .myr_auto_toggle:checked + .myr_auto_slider {
+  background-color: #3c9;
+  border-color: #3c9;
 }
 
 /* Power buttons container */


### PR DESCRIPTION
## Summary
- Replace the ambiguous Auto button with a CSS toggle switch that unambiguously shows on/off state
- The switch uses the existing color scheme (dark off, green on) with a sliding thumb indicator
- Behavior is unchanged: toggling auto still hides/shows the slider for non-adjustable controls

## Auto Toggle Switch Implementation

This PR replaces the ambiguous "Auto" button with a CSS toggle switch that clearly indicates on/off state. The switch uses the existing color scheme (dark #223 for off, green #4a8 for on) with a sliding thumb indicator for visual feedback.

### Changes in `web/gui/control.js`

The `AutoButton` component now renders as a checkbox-based toggle switch. It creates a label with class `myr_auto_switch` containing:
- A hidden checkbox input with class `myr_auto_toggle` that triggers `do_toggle_auto()` on change
- A visual slider element (span with class `myr_auto_slider`) that displays the toggle track and knob
- An "Auto" text label

The `do_toggle_auto()` handler extracts the control ID from the checkbox element and sends the checkbox's `checked` state to the server. The `setControlValue()` function synchronizes the control's auto state by setting the checkbox's `checked` property.

### Changes in `web/gui/controls.css`

The CSS replaces button-based styling with a switch component by:
- Defining `.myr_auto_switch` as an inline-flex container with cursor pointer and text styling
- Hiding the underlying checkbox input with `display: none`
- Creating visual track styling on `.myr_auto_slider` (32×18px, dark background, subtle border, border-radius 11px)
- Using `.myr_auto_slider::after` pseudo-element for the sliding knob (12×12px circle)
- Applying `:checked` state styling via adjacent sibling selectors `+` to move the knob and change colors to green when active
- Adding hover effects to the wrapper for improved UX feedback

### Behavior

The auto-toggle behavior remains unchanged: toggling auto continues to hide or show the associated slider for controls that are not adjustable, and displays the slider with an "A" prefix for controls where it should remain visible (e.g., Sea Clutter).

As suggested in issue #26.