### PR TITLE
fix(gui): apply min/max/step to numeric controls

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -185,29 +185,23 @@ function convertControlToUserUnits(id, control) {
 }
 
 /**
- * Rounds a number to a limited number of decimals, for user pleasure.
+ * Rounds a number to the nearest multiple of stepValue and trims trailing
+ * float artifacts (e.g. 0.30000000000000004 -> 0.3) for display.
  */
 function roundToStep(value, stepValue) {
   value = Number(value);
   if (!Number.isFinite(value) || !Number.isFinite(stepValue)) return NaN;
+  if (stepValue <= 0) return value;
 
-  if (Math.abs(stepValue - 0.1) < Number.EPSILON) {
-    return Number((value + stepValue / 2).toFixed(1));
-  }
-  if (stepValue < 0.02) {
-    return Number((value + stepValue / 2).toFixed(2));
-  }
-  if (stepValue <= 1) {
-    return Number((value + stepValue / 2).toFixed(1));
-  }
+  const rounded = Math.round(value / stepValue) * stepValue;
 
-  const scale = 1 / stepValue;
-  const scaledVal = Math.round(value * scale);
-  const scaledStep = Math.round(stepValue * scale);
-  const roundedInt = Math.round(scaledVal / scaledStep) * scaledStep;
-  const rounded = roundedInt / scale;
+  let decimals;
+  if (stepValue >= 1) decimals = 0;
+  else if (stepValue >= 0.1) decimals = 1;
+  else if (stepValue >= 0.01) decimals = 2;
+  else decimals = 3;
 
-  return rounded;
+  return Number(rounded.toFixed(decimals));
 }
 
 // V1-style control builders adapted with v3 CSS classes
@@ -226,8 +220,19 @@ const StringValue = (id, name) =>
     button({ type: "button", onclick: (e) => do_button(e) }, "Set")
   );
 
-const NumericValue = (id, name) =>
-  div(
+const NumericValue = (id, name, control = {}) => {
+  const attrs = {
+    type: "number",
+    id: control_prefix + id,
+    onchange: (e) => do_change(e.target),
+    oninput: (e) => do_input(e),
+  };
+  if (Number.isFinite(control.minValue)) attrs.min = control.minValue;
+  if (Number.isFinite(control.maxValue)) attrs.max = control.maxValue;
+  if (Number.isFinite(control.stepValue) && control.stepValue > 0) {
+    attrs.step = control.stepValue;
+  }
+  return div(
     { class: "myr_control myr_number_control" },
     div(
       { class: "myr_control_header" },
@@ -237,13 +242,9 @@ const NumericValue = (id, name) =>
         id: control_prefix + id + "_display",
       })
     ),
-    input({
-      type: "number",
-      id: control_prefix + id,
-      onchange: (e) => do_change(e.target),
-      oninput: (e) => do_input(e),
-    })
+    input(attrs)
   );
+};
 
 const RangeValue = (id, name, min, max, def) =>
   div(
@@ -1341,7 +1342,7 @@ function buildSingleControl(k, v) {
     }
     return RangeValue(k, v.name, min, max, 0);
   } else {
-    return NumericValue(k, v.name);
+    return NumericValue(k, v.name, v);
   }
 }
 

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -184,24 +184,33 @@ function convertControlToUserUnits(id, control) {
   return cloned;
 }
 
+// Decimal places needed to represent stepValue exactly as a string.
+// Handles "0.25" -> 2 and scientific notation like "1e-7" -> 7.
+function stepPrecision(stepValue) {
+  const s = String(stepValue).toLowerCase();
+  if (s.includes("e-")) return Number(s.split("e-")[1]);
+  const dot = s.indexOf(".");
+  return dot === -1 ? 0 : s.length - dot - 1;
+}
+
 /**
- * Rounds a number to the nearest multiple of stepValue and trims trailing
- * float artifacts (e.g. 0.30000000000000004 -> 0.3) for display.
+ * Rounds a number to the nearest multiple of stepValue starting from
+ * baseValue (the capability's minValue), and trims trailing float
+ * artifacts (e.g. 0.30000000000000004 -> 0.3) for display.
+ *
+ * Rounding relative to baseValue keeps capability values like
+ * minValue=0.05, step=0.1 from snapping to a different grid (0.05
+ * stays 0.05). Precision comes from the exact step magnitude so
+ * step=0.25 keeps two decimals (1.25 stays 1.25, not 1.3).
  */
-function roundToStep(value, stepValue) {
+function roundToStep(value, stepValue, baseValue = 0) {
   value = Number(value);
   if (!Number.isFinite(value) || !Number.isFinite(stepValue)) return NaN;
   if (stepValue <= 0) return value;
 
-  const rounded = Math.round(value / stepValue) * stepValue;
-
-  let decimals;
-  if (stepValue >= 1) decimals = 0;
-  else if (stepValue >= 0.1) decimals = 1;
-  else if (stepValue >= 0.01) decimals = 2;
-  else decimals = 3;
-
-  return Number(rounded.toFixed(decimals));
+  const base = Number.isFinite(baseValue) ? baseValue : 0;
+  const rounded = Math.round((value - base) / stepValue) * stepValue + base;
+  return Number(rounded.toFixed(stepPrecision(stepValue)));
 }
 
 // V1-style control builders adapted with v3 CSS classes
@@ -579,8 +588,9 @@ function updateSectorUI(id, control, cv) {
     let [, startAngle] = toUser(control.units, cv.value);
     let [, endAngle] = toUser(control.units, cv.endValue);
     if (control.stepValue) {
-      startAngle = roundToStep(startAngle ?? 0, control.stepValue);
-      endAngle = roundToStep(endAngle ?? 0, control.stepValue);
+      const base = control.minValue ?? 0;
+      startAngle = roundToStep(startAngle ?? 0, control.stepValue, base);
+      endAngle = roundToStep(endAngle ?? 0, control.stepValue, base);
     }
     angleDisplay.textContent = `${startAngle ?? 0}° - ${endAngle ?? 0}°`;
   }
@@ -909,8 +919,9 @@ function updateZoneUI(id, control, cv) {
     let [, startAngle] = toUser(control.units, cv.value);
     let [, endAngle] = toUser(control.units, cv.endValue);
     if (control.stepValue) {
-      startAngle = roundToStep(startAngle ?? 0, control.stepValue);
-      endAngle = roundToStep(endAngle ?? 0, control.stepValue);
+      const base = control.minValue ?? 0;
+      startAngle = roundToStep(startAngle ?? 0, control.stepValue, base);
+      endAngle = roundToStep(endAngle ?? 0, control.stepValue, base);
     }
     angleDisplay.textContent = `${startAngle ?? 0}° - ${endAngle ?? 0}°`;
   }
@@ -1370,7 +1381,7 @@ function setControlValue(cv) {
     if (control.units && cv.id !== "range") {
       [units, value] = toUser(control.units, value);
       if (control.stepValue) {
-        value = roundToStep(value, control.stepValue);
+        value = roundToStep(value, control.stepValue, control.minValue ?? 0);
       }
       // Floor time values displayed in hours (operating time, transmit time)
       if (units === "h") {


### PR DESCRIPTION
## Summary

Numeric controls (antenna height, antenna offsets, etc.) rendered an unconstrained `<input type="number">` with default `step=1` and no bounds, so spinner clicks ignored the radar's actual increment (e.g. 0.1 m for Navico antenna height) and accepted out-of-range values.

This wires the capability's `minValue`/`maxValue`/`stepValue` onto the input so the browser snaps to the right grid and clamps to the supported range.

Also fixes a drift bug in `roundToStep`: the `(value + step/2).toFixed(precision)` formula double-rounds and `roundToStep(0, 0.1)` returned `0.1`, shifting clean values upward each display cycle. Replaced with `Math.round(value/step)*step`.

Reported symptom: antenna height could only be increased, never decreased.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR applies device-specific min/max/step constraints to numeric input controls in the GUI and fixes rounding drift so numeric controls align to capability-defined value grids and display clean rounded values.

## Changes

- roundToStep — Rounds values to the nearest multiple of stepValue relative to a baseValue (default 0) using Math.round((value - base)/step) * step, returns NaN for non-finite inputs, ignores non-positive stepValue, and chooses display precision from the exact step magnitude (handles scientific notation). This prevents upward drift (e.g., roundToStep(0, 0.1) returns 0) and removes EPSILON/double-rounding heuristics.
- NumericValue builder — Accepts an optional control object (id, name, control = {}) and sets HTML input attributes min, max, and step when control.minValue, control.maxValue, and control.stepValue are finite (and stepValue > 0). oninput/onchange handlers remain to update and validate values.
- buildSingleControl / control wiring — Numeric controls are passed the full capability object so inputs reflect the capability-provided minValue, maxValue, and stepValue. Sector/zone angle rounding and setControlValue now align rounding to control.minValue (base grid) instead of an absolute zero grid.
- UI behavior — Browser-enforced step and bounds make spinner clicks follow device increments (e.g., 0.1 m or 0.1°), clamp typed values to supported ranges, and eliminate display artifacts and upward drift from repeated operations.

## Behavior Improvements / Test notes

- Antenna height spinner steps in device-specific increments and respects reported 0..60 m bounds (example: Navico 0.1 m increments).
- Bearing alignment spinner steps in device-specific increments (example: 0.1°) and accepts negative values where supported.
- Display values round cleanly without upward drift.

## Other

- No exported/public API surface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->