### PR TITLE
fix(gui): convert user units to SI in do_change

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -31,7 +31,7 @@ export {
 };
 
 import van from "./vendor/van-1.5.2.js";
-import { toUser } from "./units.js";
+import { toSI, toUser } from "./units.js";
 import {
   fetchRadars,
   fetchRadarIds,
@@ -1502,15 +1502,29 @@ function do_change(v) {
     value = Number(value);
   }
 
+  // The wire/server convention is SI; setControlValue converts SI -> user
+  // for display. The input here is in user_units, so convert back to SI
+  // before storing in `update`, otherwise setControlValue would re-apply the
+  // SI -> user conversion (e.g. 30 deg -> 1718 deg).
+  let storeValue = value;
+  if (
+    "user_units" in control &&
+    control.user_units &&
+    control.units &&
+    control.user_units !== control.units
+  ) {
+    [, storeValue] = toSI(control.user_units, value);
+  }
+
   // Check if auto mode is active from current control state
   let auto = update.auto || false;
   update.auto = auto;
   message.auto = auto;
   if (auto && control.hasAutoAdjustable) {
-    update.autoValue = value;
+    update.autoValue = storeValue;
     message.autoValue = value;
   } else {
-    update.value = value;
+    update.value = storeValue;
     message.value = value;
   }
 


### PR DESCRIPTION
## Summary

When a user changed a numeric input, `do_change` stored the typed value (in user units, e.g. degrees) in the local update object and then called `setControlValue`, which assumes SI input and re-applies the SI->user conversion. For bearing alignment that turned `30 deg` into `30 * 180/π ≈ 1718` in the displayed input until the next server broadcast. The radar received the right command but the GUI flashed a nonsensical value, making the control look broken.

Convert `user_units` back to SI via `toSI` before writing to `update`, so `setControlValue`'s display path produces the correct user-units value.

Reported symptom: bearing alignment "seems not to do anything".