### PR TITLE
fix(gui): show feedback when heading missing in acquire mode

### DIFF
--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -1763,21 +1763,30 @@ class PPI {
       const clickDistance = Math.sqrt(dx * dx + dy * dy);
 
       // Only treat as click if mouse didn't move much (not a drag)
-      // Require heading data for MARPA acquisition
-      if (clickDistance < 5 && this.trueHeading !== null) {
-        const radarCoords = this.#pixelToRadarCoords(coords.x, coords.y);
-        // Keep bearing in radians, add true heading to get bearing true
-        let bearingRad = radarCoords.angle + this.trueHeading;
-        // Normalize to [0, 2π)
-        while (bearingRad < 0) bearingRad += 2 * Math.PI;
-        while (bearingRad >= 2 * Math.PI) bearingRad -= 2 * Math.PI;
+      if (clickDistance < 5) {
+        // MARPA requires true bearing, which needs ship heading
+        if (this.trueHeading === null) {
+          console.warn("Acquire target: no heading data, cannot compute true bearing");
+          const status = document.getElementById("myr_acquire_target_status");
+          if (status) {
+            status.textContent = "No heading data, cannot acquire";
+            status.style.display = "block";
+          }
+        } else {
+          const radarCoords = this.#pixelToRadarCoords(coords.x, coords.y);
+          // Keep bearing in radians, add true heading to get bearing true
+          let bearingRad = radarCoords.angle + this.trueHeading;
+          // Normalize to [0, 2π)
+          while (bearingRad < 0) bearingRad += 2 * Math.PI;
+          while (bearingRad >= 2 * Math.PI) bearingRad -= 2 * Math.PI;
 
-        const bearingDeg = (bearingRad * 180) / Math.PI;
-        console.log(`Acquire target click: bearing=${bearingDeg.toFixed(1)}° (${bearingRad.toFixed(3)} rad), distance=${radarCoords.distance.toFixed(0)}m`);
+          const bearingDeg = (bearingRad * 180) / Math.PI;
+          console.log(`Acquire target click: bearing=${bearingDeg.toFixed(1)}° (${bearingRad.toFixed(3)} rad), distance=${radarCoords.distance.toFixed(0)}m`);
 
-        if (this.onTargetAcquire) {
-          // Send bearing in radians to match API format
-          this.onTargetAcquire(bearingRad, radarCoords.distance);
+          if (this.onTargetAcquire) {
+            // Send bearing in radians to match API format
+            this.onTargetAcquire(bearingRad, radarCoords.distance);
+          }
         }
       }
     }

--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -1764,15 +1764,20 @@ class PPI {
 
       // Only treat as click if mouse didn't move much (not a drag)
       if (clickDistance < 5) {
+        const status = document.getElementById("myr_acquire_target_status");
         // MARPA requires true bearing, which needs ship heading
         if (this.trueHeading === null) {
           console.warn("Acquire target: no heading data, cannot compute true bearing");
-          const status = document.getElementById("myr_acquire_target_status");
           if (status) {
             status.textContent = "No heading data, cannot acquire";
             status.style.display = "block";
           }
         } else {
+          // Clear any prior error so a successful click doesn't leave the
+          // stale "No heading data" message visible.
+          if (status) {
+            status.textContent = "Click in PPI to acquire";
+          }
           const radarCoords = this.#pixelToRadarCoords(coords.x, coords.y);
           // Keep bearing in radians, add true heading to get bearing true
           let bearingRad = radarCoords.angle + this.trueHeading;


### PR DESCRIPTION
## Summary

Click-to-acquire silently dropped clicks when `trueHeading` was null, which is the default in standalone mode (no SignalK heading subscription). The cursor changed to crosshair, but clicks produced no target and no explanation, making the feature look broken.

Update the existing acquire-target status div with a "No heading data, cannot acquire" message so the user understands why nothing happens. The acquire API still requires a true bearing (computed from relative click + ship heading), so the underlying requirement is unchanged.

Reported symptom: "I can't do anything when I click acquire targets; mouse pointer changes but click has no effect."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes a UX issue where target acquisition silently fails when heading data is unavailable. In standalone mode without a SignalK heading subscription, clicking to acquire targets would show the crosshair cursor but produce no target and no explanation, making the feature appear broken.

The fix updates the `#handleMouseUp` method to check heading availability after validating that a click occurred (not a drag). When `trueHeading` is null, the code logs a warning and displays "No heading data, cannot acquire" in the acquire-target status div, providing clear feedback to users about why the acquisition failed. When heading is available, the code proceeds with the existing acquisition logic: computing the true bearing from the relative click angle plus ship heading, normalizing it to [0, 2π), and calling `onTargetAcquire` with the bearing in radians and distance in meters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->