### PR TITLE
fix(furuno): rebuild wire-to-legend LUT after legend reshape

### DIFF
--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -974,31 +974,37 @@ impl FurunoReportReceiver {
             );
             self.model = model;
             let low_power = model.is_low_power();
+            // `update_when_model_known` reshapes the legend for the detected
+            // model — adding rain / Doppler reservation slots on NXT shrinks
+            // the intensity-ramp portion (`pixel_colors`). The LUT must be
+            // built against the post-update legend; otherwise wire bytes
+            // map past the ramp end into Doppler / history reservation
+            // slots, painting strong stationary echoes blue.
+            settings::update_when_model_known(&mut self.common.info, model, version);
             self.wire_to_legend[0] = Self::wire_to_legend(
                 &self.common.info.get_legend(),
                 self.doppler_wire_mode_for(0),
                 low_power,
             );
-            if let Some(ref cb) = self.common_b {
-                self.wire_to_legend[1] = Self::wire_to_legend(
-                    &cb.info.get_legend(),
-                    self.doppler_wire_mode_for(1),
-                    low_power,
-                );
-            }
             if low_power {
                 log::info!("{}: using gamma echo curve for low-power radar", self.common.key);
             }
-            settings::update_when_model_known(&mut self.common.info, model, version);
             if let Some(cs) = &mut self.command_sender {
                 cs.set_ranges(self.common.info.ranges.clone());
             }
             self.common.update();
 
             // Also update Range B if present
-            if let Some(ref mut cb) = self.common_b {
-                settings::update_when_model_known(&mut cb.info, model, version);
-                cb.update();
+            if self.common_b.is_some() {
+                let legend_b = {
+                    let cb = self.common_b.as_mut().unwrap();
+                    settings::update_when_model_known(&mut cb.info, model, version);
+                    let legend = cb.info.get_legend();
+                    cb.update();
+                    legend
+                };
+                let mode_b = self.doppler_wire_mode_for(1);
+                self.wire_to_legend[1] = Self::wire_to_legend(&legend_b, mode_b, low_power);
             }
             return;
         }


### PR DESCRIPTION
## Motivation

On NXT models with Target Analyzer **off**, strong stationary echoes were rendered with the dopplerRain blue color instead of the expected red.

## Root cause

In `parse_modules()`, the `wire_to_legend` LUT was built **before** `update_when_model_known()` reshaped the legend for the detected model. On NXT this reshape calls `set_has_rain_class(true)` and `set_doppler_levels(16)`, which shrinks the intensity-ramp portion (`pixel_colors`) to reserve slots for rain / Doppler bands and history.

The LUT, built against the larger pre-update legend, then mapped strong wire bytes (e.g., `0xFC = 252`) to legend index 218 — a slot that the post-update legend now uses for `dopplerRain` (color `#0000d8`).

## Fix

Reorder so `update_when_model_known()` runs first, then build the LUT against the post-update legend. Range B follows the same order.

## Tested

- DRS4D-NXT 6424A live hardware: wire byte 252 now maps to legend index 172 (top of intensity ramp) instead of 218 (dopplerRain). Strong echoes render red, matching TimeZero Pro on the same scene.
- `cargo test --lib`: 195/195 pass.
- `cr review --plain`: 1 trivial nit (consistency in operation order between Range A and Range B), addressed before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes incorrect rendering of stationary echoes on Furuno NXT models with Target Analyzer disabled. When Target Analyzer is off, strong stationary echoes were incorrectly displayed in dopplerRain blue instead of the expected red color.

### Root Cause

The `wire_to_legend` lookup table was built before the radar legend was reshaped by `update_when_model_known()`. On NXT models, this reshape call reserves slots for rain/Doppler bands and history by shrinking the intensity-ramp portion. The pre-update lookup table therefore mapped high wire byte values (e.g., 0xFC = 252) to indices that after reshape corresponded to dopplerRain instead of the intensity ramp.

### Solution

The PR reorders initialization in `parse_modules()` so that `settings::update_when_model_known()` executes before the `wire_to_legend` lookup tables are rebuilt. This ensures the lookup tables are constructed against the post-update legend with the correct index mappings.

For Range A, the legend is updated first, then the lookup table is rebuilt using the updated legend before applying gamma logging and updating command ranges.

For dual-range configurations, Range B follows a similar pattern: the legend is updated within a scoped block via `cb.update()`, then the lookup table is rebuilt using the post-update legend and Range B's Doppler wire mode.

### Testing

The fix was verified on DRS4D-NXT 6424A hardware, confirming that byte 252 now correctly maps to legend index 172 (top of intensity ramp) instead of 218. All cargo tests pass (195/195).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->