### PR TITLE
feat(recording): faithful playback with source brand identity

### DIFF
--- a/src/bin/mayara-server/web/recordings.rs
+++ b/src/bin/mayara-server/web/recordings.rs
@@ -217,7 +217,7 @@ async fn get_recordable_radars(State(state): State<Web>) -> impl IntoResponse {
     let radars = state.radars.get_active();
     let recordable: Vec<RecordableRadar> = radars
         .iter()
-        .filter(|r| r.brand != mayara::Brand::Playback)
+        .filter(|r| !r.replay())
         .map(|r| RecordableRadar {
             id: r.key(),
             name: r.controls.user_name(),
@@ -268,13 +268,20 @@ async fn start_recording_handler(
         }
     };
 
-    let capabilities_json = serde_json::to_vec(&serde_json::json!({
-        "brand": format!("{}", radar.brand),
-        "spokesPerRevolution": radar.spokes_per_revolution,
-        "maxSpokeLen": radar.max_spoke_len,
-        "pixelValues": radar.pixel_values,
-    }))
-    .unwrap_or_default();
+    // Recording a playback radar would copy the recorded stream back into
+    // a new file. Reject it at the API boundary so callers can't bypass
+    // the GUI filter in get_recordable_radars.
+    if radar.replay() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Cannot record a playback radar"})),
+        );
+    }
+
+    // Capture the source radar's full identity so playback can reproduce
+    // the same legend and brand shape rather than rendering against a
+    // generic Brand::Playback default.
+    let capabilities_json = mayara::recording::RecordingIdentity::from_radar_info(&radar).to_json();
 
     let initial_state = build_initial_state(&radar);
 

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -198,6 +198,12 @@ struct RadarApiV3 {
     /// IP address of the radar unit on the network
     #[schema(value_type = String, example = "192.168.1.50")]
     radar_ip_address: Ipv4Addr,
+    /// True if this radar is sourced from a recording playback rather than a
+    /// live network connection. Clients should treat playback radars as
+    /// read-only — the server still accepts control writes via the WebSocket
+    /// path but they have no effect on the recorded data stream.
+    #[schema(example = false)]
+    replay: bool,
 }
 
 #[utoipa::path(
@@ -241,6 +247,7 @@ async fn get_radars(State(state): State<Web>, headers: hyper::header::HeaderMap)
             spoke_data_url: format!("{}://{}{}", ws_scheme, host, spoke_data_uri),
             stream_url: format!("{}://{}{}", ws_scheme, host, CONTROL_URI),
             radar_ip_address: *info.addr.ip(),
+            replay: info.replay(),
         };
 
         api.insert(info.key(), v);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -5,7 +5,7 @@ use locator::Locator;
 use miette::Result;
 use radar::SharedRadars;
 use radar::target::{BlobMessage, TrackerManager};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
     collections::{HashMap, HashSet},
     net::Ipv4Addr,
@@ -40,7 +40,7 @@ pub const SIGNALK_RADAR_API_VERSION: &str = env!("SIGNALK_RADAR_API_VERSION");
 /// so late-joining GUI clients can receive it.
 const STATIC_NAV_REBROADCAST_INTERVAL_SECS: u64 = 2;
 
-#[derive(clap::ValueEnum, Clone, Default, Debug, PartialEq, Serialize)]
+#[derive(clap::ValueEnum, Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TargetMode {
     #[default]

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -418,6 +418,29 @@ impl RadarInfo {
         self.key.to_owned()
     }
 
+    pub fn replay(&self) -> bool {
+        self.replay
+    }
+
+    pub fn targets(&self) -> TargetMode {
+        self.targets.clone()
+    }
+
+    pub fn doppler_levels(&self) -> u8 {
+        self.doppler_levels
+    }
+
+    pub fn has_rain_class(&self) -> bool {
+        self.has_rain_class
+    }
+
+    /// Override the replay flag. Used by the recording player when constructing
+    /// a playback radar so brand-specific receivers know not to attempt live
+    /// network operations.
+    pub fn set_replay(&mut self, replay: bool) {
+        self.replay = replay;
+    }
+
     //
     // Once the ranges are set non-zero the radar is findable by the GUI,
     // this version only to be called by config() that does not have CommonRadar.

--- a/src/lib/recording/file_format.rs
+++ b/src/lib/recording/file_format.rs
@@ -11,8 +11,14 @@ pub const MRR_MAGIC: [u8; 4] = *b"MRR1";
 /// Magic bytes for MRR file footer
 pub const MRR_FOOTER_MAGIC: [u8; 4] = *b"MRRF";
 
-/// Current format version
-pub const MRR_VERSION: u16 = 1;
+/// Current format version.
+///
+/// Version 2 stores the source radar's full identity (brand, legend-shaping
+/// flags, controls) in the capabilities JSON so playback can reproduce the
+/// exact `RadarInfo` shape live recording had. V1 files are rejected — they
+/// rendered with a generic Brand::Playback legend and never matched the
+/// source radar visually. Re-record old captures.
+pub const MRR_VERSION: u16 = 2;
 
 /// Header size in bytes (fixed)
 pub const HEADER_SIZE: usize = 256;
@@ -104,10 +110,18 @@ impl MrrHeader {
         }
 
         let version = u16::from_le_bytes([buf[4], buf[5]]);
-        if version > MRR_VERSION {
+        if version != MRR_VERSION {
+            let hint = if version < MRR_VERSION {
+                " — re-record from live radar."
+            } else {
+                " — this server is older than the recording; upgrade Mayara."
+            };
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Unsupported MRR version: {}", version),
+                format!(
+                    "Unsupported MRR version: {} (this build expects {}){}",
+                    version, MRR_VERSION, hint
+                ),
             ));
         }
 
@@ -542,7 +556,7 @@ mod tests {
     #[test]
     fn test_header_roundtrip() {
         let header = MrrHeader {
-            version: 1,
+            version: MRR_VERSION,
             flags: 0,
             radar_brand: 42,
             spokes_per_rev: 2048,
@@ -663,5 +677,18 @@ mod tests {
         let second = reader.read_frame().unwrap().unwrap();
         assert_eq!(second.timestamp_ms, 100);
         assert_eq!(second.data, vec![1u8; 10]);
+    }
+
+    #[test]
+    fn test_rejects_v1_recordings() {
+        let mut buf = vec![0u8; HEADER_SIZE];
+        buf[0..4].copy_from_slice(&MRR_MAGIC);
+        buf[4..6].copy_from_slice(&1u16.to_le_bytes()); // V1
+        let err = MrrHeader::read(&mut Cursor::new(buf)).unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported MRR version: 1"),
+            "expected v1 rejection, got: {}",
+            err
+        );
     }
 }

--- a/src/lib/recording/identity.rs
+++ b/src/lib/recording/identity.rs
@@ -1,0 +1,194 @@
+//! Persisted radar identity for `.mrr` recordings.
+//!
+//! Captures everything needed to reconstruct a `RadarInfo` whose legend and
+//! brand-specific shape match the source radar's at record time. The recorder
+//! serializes this struct into the capabilities JSON of the file; the player
+//! deserializes it and replays the spoke stream against a faithful copy of
+//! the original radar.
+
+use serde::{Deserialize, Serialize};
+
+use crate::TargetMode;
+use crate::radar::RadarInfo;
+
+/// Identity of the source radar at record time. Stored as the capabilities
+/// JSON inside an `.mrr` file. Field set is the minimum required for the
+/// player to reproduce the same `RadarInfo` shape — adding fields is
+/// backwards-compatible (deserializer treats them as optional) but bumping
+/// `MRR_VERSION` is required if old data becomes meaningless.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingIdentity {
+    /// Numeric `Brand` id, mirroring `recorder::brand_to_id`. JSON-numeric
+    /// rather than the brand's string form so we don't need a `Deserialize`
+    /// impl on `Brand`.
+    pub brand_id: u32,
+    pub spokes_per_revolution: u16,
+    pub max_spoke_len: u16,
+    pub pixel_values: u8,
+    /// Doppler intensity sub-levels per direction. 0 = no Doppler, 1 = single
+    /// flat color (Navico), 4 = brightness gradient (Garmin), 16 = NXT bands.
+    pub doppler_levels: u8,
+    /// Whether the wire format encodes a rain Doppler class (Furuno NXT).
+    pub has_rain_class: bool,
+    /// Doppler enabled flag (separate from `doppler_levels` because
+    /// `RadarInfo::doppler` and `doppler_levels` are independently set).
+    pub doppler: bool,
+    /// Target tracking mode at record time.
+    pub targets: TargetMode,
+    pub dual_range: bool,
+    /// Dual-radar side identifier ("A" or "B" for Furuno NXT dual range,
+    /// `None` for single-side units). Captured so the playback radar's key
+    /// matches the source side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dual: Option<String>,
+    pub sparse_spokes: bool,
+    pub stationary: bool,
+    /// Source radar's serial number, if any. Used to keep the playback radar
+    /// key visually identifiable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial_no: Option<String>,
+    /// User-defined name carried over so playback shows the same label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_name: Option<String>,
+    /// Detected model name from the source radar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+}
+
+impl RecordingIdentity {
+    /// Snapshot the source radar's identity at record time.
+    pub fn from_radar_info(info: &RadarInfo) -> Self {
+        let user_name = {
+            let name = info.controls.user_name();
+            if name.is_empty() || name == info.key() {
+                None
+            } else {
+                Some(name)
+            }
+        };
+        let model_name = info.controls.model_name();
+        Self {
+            brand_id: crate::recording::recorder::brand_to_id(info.brand),
+            spokes_per_revolution: info.spokes_per_revolution,
+            max_spoke_len: info.max_spoke_len,
+            pixel_values: info.pixel_values,
+            doppler_levels: info.doppler_levels(),
+            has_rain_class: info.has_rain_class(),
+            doppler: info.doppler,
+            targets: info.targets(),
+            dual_range: info.dual_range,
+            dual: info.dual.clone(),
+            sparse_spokes: info.sparse_spokes,
+            stationary: info.stationary,
+            serial_no: info.serial_no.clone(),
+            user_name,
+            model_name,
+        }
+    }
+
+    /// Serialize to JSON bytes for writing into the `.mrr` capabilities slot.
+    pub fn to_json(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("RecordingIdentity always serializes")
+    }
+
+    /// Parse from the capabilities slot of an `.mrr` file.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_identity() -> RecordingIdentity {
+        RecordingIdentity {
+            brand_id: 1,
+            spokes_per_revolution: 8192,
+            max_spoke_len: 1024,
+            pixel_values: 252,
+            doppler_levels: 16,
+            has_rain_class: true,
+            doppler: true,
+            targets: TargetMode::Arpa,
+            dual_range: true,
+            dual: Some("A".to_string()),
+            sparse_spokes: true,
+            stationary: false,
+            serial_no: Some("PB-fixture".to_string()),
+            user_name: Some("Test Radar".to_string()),
+            model_name: Some("DRS4D-NXT".to_string()),
+        }
+    }
+
+    #[test]
+    fn json_roundtrip_preserves_all_fields() {
+        let original = sample_identity();
+        let bytes = original.to_json();
+        let decoded = RecordingIdentity::from_json(&bytes).unwrap();
+
+        assert_eq!(decoded.brand_id, original.brand_id);
+        assert_eq!(decoded.spokes_per_revolution, original.spokes_per_revolution);
+        assert_eq!(decoded.max_spoke_len, original.max_spoke_len);
+        assert_eq!(decoded.pixel_values, original.pixel_values);
+        assert_eq!(decoded.doppler_levels, original.doppler_levels);
+        assert_eq!(decoded.has_rain_class, original.has_rain_class);
+        assert_eq!(decoded.doppler, original.doppler);
+        assert_eq!(decoded.targets, original.targets);
+        assert_eq!(decoded.dual_range, original.dual_range);
+        assert_eq!(decoded.dual, original.dual);
+        assert_eq!(decoded.sparse_spokes, original.sparse_spokes);
+        assert_eq!(decoded.stationary, original.stationary);
+        assert_eq!(decoded.serial_no, original.serial_no);
+        assert_eq!(decoded.user_name, original.user_name);
+        assert_eq!(decoded.model_name, original.model_name);
+    }
+
+    #[test]
+    fn omitted_optional_fields_deserialize_as_none() {
+        // An identity with all Option fields absent must round-trip cleanly.
+        let mut identity = sample_identity();
+        identity.dual = None;
+        identity.serial_no = None;
+        identity.user_name = None;
+        identity.model_name = None;
+
+        let bytes = identity.to_json();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // skip_serializing_if = "Option::is_none" must elide them entirely.
+        assert!(json.get("dual").is_none());
+        assert!(json.get("serialNo").is_none());
+        assert!(json.get("userName").is_none());
+        assert!(json.get("modelName").is_none());
+
+        let decoded = RecordingIdentity::from_json(&bytes).unwrap();
+        assert_eq!(decoded.dual, None);
+        assert_eq!(decoded.serial_no, None);
+        assert_eq!(decoded.user_name, None);
+        assert_eq!(decoded.model_name, None);
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored_for_forward_compat() {
+        // Future versions may add fields; the current parser must still
+        // accept them by ignoring extras rather than rejecting the file.
+        let json = br#"{
+            "brandId": 1,
+            "spokesPerRevolution": 2048,
+            "maxSpokeLen": 1024,
+            "pixelValues": 64,
+            "dopplerLevels": 0,
+            "hasRainClass": false,
+            "doppler": false,
+            "targets": "none",
+            "dualRange": false,
+            "sparseSpokes": false,
+            "stationary": false,
+            "futureField": 42
+        }"#;
+        let decoded = RecordingIdentity::from_json(json).expect("should parse");
+        assert_eq!(decoded.brand_id, 1);
+        assert_eq!(decoded.spokes_per_revolution, 2048);
+    }
+}

--- a/src/lib/recording/mod.rs
+++ b/src/lib/recording/mod.rs
@@ -28,11 +28,13 @@
 //! ```
 
 pub mod file_format;
+mod identity;
 pub mod manager;
 pub mod player;
 pub mod recorder;
 
 pub use file_format::{MrrFooter, MrrHeader, MrrReader, MrrWriter};
+pub use identity::RecordingIdentity;
 pub use manager::{RecordingInfo, RecordingManager, recordings_dir};
 pub use player::{ActivePlayback, PlaybackSettings, PlaybackState, PlaybackStatus};
 pub use recorder::{ActiveRecording, RecordingState, RecordingStatus};

--- a/src/lib/recording/player.rs
+++ b/src/lib/recording/player.rs
@@ -17,6 +17,7 @@ use crate::radar::SharedRadars;
 use crate::radar::settings::{ControlId, SharedControls, new_string};
 
 use super::file_format::MrrReader;
+use super::identity::RecordingIdentity;
 use super::manager::RecordingManager;
 use super::recorder::id_to_brand;
 
@@ -164,25 +165,41 @@ impl ActivePlayback {
     }
 }
 
-/// Create minimal controls for a playback radar (read-only)
+/// Create minimal controls for a playback radar (read-only). UserName and
+/// ModelName are populated from the recorded identity when available so the
+/// GUI's radar list matches what was recorded.
+///
+/// Full control reproduction (Range, Gain, etc.) is intentionally out of
+/// scope: the player would need to dispatch to brand-specific control
+/// initializers and replay control deltas. This function only ensures the
+/// radar shows up with a recognizable name.
 fn playback_controls(
     radar_id: String,
     sk_client_tx: broadcast::Sender<crate::stream::SignalKDelta>,
     args: &Cli,
+    identity: &RecordingIdentity,
 ) -> SharedControls {
     let mut controls = HashMap::new();
 
     new_string(ControlId::UserName).build(&mut controls);
+    let label = identity
+        .user_name
+        .clone()
+        .unwrap_or_else(|| format!("Playback: {}", radar_id));
     controls
         .get_mut(&ControlId::UserName)
         .unwrap()
-        .set_string(format!("Playback: {}", radar_id));
+        .set_string(label);
 
     new_string(ControlId::ModelName).build(&mut controls);
+    let model = identity
+        .model_name
+        .clone()
+        .unwrap_or_else(|| "Recording Playback".to_string());
     controls
         .get_mut(&ControlId::ModelName)
         .unwrap()
-        .set_string("Recording Playback".to_string());
+        .set_string(model);
 
     SharedControls::new(radar_id, sk_client_tx, args, controls)
 }
@@ -211,31 +228,79 @@ pub async fn load_recording(
     let header = mrr_reader.header();
     let footer = mrr_reader.footer();
 
-    let brand = id_to_brand(header.radar_brand).unwrap_or(Brand::Playback);
-    let _ = brand; // Original brand recorded, but we register as Playback
+    // Recover the source radar's identity so the playback radar wears the
+    // original brand, legend shape, and pixel-value layout. If the
+    // capabilities slot is missing or malformed we synthesize a minimal
+    // identity from the file header (still using its `radar_brand` id);
+    // Brand::Playback is only used further down as the fallback when
+    // `id_to_brand(identity.brand_id)` itself fails to resolve.
+    let identity = match RecordingIdentity::from_json(mrr_reader.capabilities()) {
+        Ok(id) => id,
+        Err(e) => {
+            warn!(
+                "Recording {} has unreadable identity ({}); falling back to generic Playback brand",
+                filename, e
+            );
+            // Synthesize a minimal identity from the header so we can still play
+            // the file, even if the legend won't match the source radar.
+            RecordingIdentity {
+                brand_id: header.radar_brand,
+                spokes_per_revolution: header.spokes_per_rev as u16,
+                max_spoke_len: header.max_spoke_len as u16,
+                pixel_values: header.pixel_values as u8,
+                doppler_levels: 0,
+                has_rain_class: false,
+                doppler: false,
+                targets: crate::TargetMode::None,
+                dual_range: false,
+                dual: None,
+                sparse_spokes: false,
+                stationary: false,
+                serial_no: None,
+                user_name: None,
+                model_name: None,
+            }
+        }
+    };
+
+    let brand = id_to_brand(identity.brand_id).unwrap_or(Brand::Playback);
 
     let base_name = filename.trim_end_matches(".mrr");
+    // Tag the serial so the radar key is stable per-file and identifiable as
+    // a playback radar via the `replay` flag (not the brand itself).
     let serial_no = format!("PB-{}", base_name);
     let fake_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
 
-    let info = crate::radar::RadarInfo::new(
+    let mut info = crate::radar::RadarInfo::new(
         radars,
         args,
-        Brand::Playback,
+        brand,
         Some(&serial_no),
-        None,
-        header.pixel_values as u8,
-        header.spokes_per_rev as usize,
-        header.max_spoke_len as usize,
+        identity.dual.as_deref(),
+        identity.pixel_values,
+        identity.spokes_per_revolution as usize,
+        identity.max_spoke_len as usize,
         fake_addr,
         Ipv4Addr::LOCALHOST,
         fake_addr,
         fake_addr,
         fake_addr,
-        |id, tx| playback_controls(id, tx, args),
-        false,
-        false,
+        |id, tx| playback_controls(id, tx, args, &identity),
+        identity.doppler,
+        identity.sparse_spokes,
     );
+
+    // Reshape the legend to match the source radar's wire format. Without
+    // these calls the legend would default to the no-Doppler / no-rain-class
+    // shape and incoming spoke indices would land in the wrong palette slots
+    // (see fix(furuno): rebuild wire-to-legend LUT after legend reshape).
+    if identity.doppler_levels > 0 {
+        info.set_doppler_levels(identity.doppler_levels);
+    }
+    if identity.has_rain_class {
+        info.set_has_rain_class(identity.has_rain_class);
+    }
+    info.set_replay(true);
 
     let radar_key = info.key();
 
@@ -254,6 +319,35 @@ pub async fn load_recording(
             crate::radar::Power::Transmit as i32 as f64,
             None,
         );
+
+        // Apply the recorded `SpokeProcessing` value so playback uses the
+        // same processor mode the source radar was set to (e.g. Reduce for
+        // Furuno NXT). Without this the GUI defaults to Auto, which picks
+        // Smooth for high-spoke-count radars and renders sparse-spoke data
+        // as moiré interference.
+        //
+        // Range-check the value at this file → memory boundary: the only
+        // valid modes are 0=Clean, 1=Fill, 2=Reduce, 3=Smooth.
+        match serde_json::from_slice::<serde_json::Value>(mrr_reader.initial_state()) {
+            Ok(state) => {
+                if let Some(val) = state.get("SpokeProcessing").and_then(|v| v.as_i64()) {
+                    if (0..=3).contains(&val) {
+                        info.controls.set_spoke_processing(val as i32);
+                    } else {
+                        warn!(
+                            "Recording {}: ignoring out-of-range SpokeProcessing value {}",
+                            filename, val
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Recording {}: malformed initial_state JSON ({}); SpokeProcessing not restored",
+                    filename, e
+                );
+            }
+        }
 
         radars.update(&mut info);
 

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1827,13 +1827,15 @@ async function loadRadar(id) {
     }
 
     radarId = id;
-    playbackMode = isPlaybackRadar(id);
-    console.log(
-      `Loading radar: ${radarId}${playbackMode ? " (playback mode)" : ""}`
-    );
 
     const radars = await fetchRadars();
     const radarInfo = radars[radarId];
+    // Server marks playback radars via the `replay` flag. Fall back to the
+    // legacy `playback-` key prefix for older recordings or stale clients.
+    playbackMode = (radarInfo && radarInfo.replay === true) || isPlaybackRadar(id);
+    console.log(
+      `Loading radar: ${radarId}${playbackMode ? " (playback mode)" : ""}`
+    );
 
     myr_capabilities = await fetchCapabilities(radarId);
     console.log("Capabilities:", myr_capabilities);


### PR DESCRIPTION
## Motivation

Spokes from a recording rendered with the wrong colors and the playback radar surfaced as a generic \`Brand::Playback\` to consumers — both visible in the GUI and forwarded into Signal K. Goal: record any brand, play it back, and have it look identical to live (PPI rendering, brand exposed via API). The Signal K plugin then picks it up automatically since it just forwards what's on the WebSocket.

## Approach

- New \`RecordingIdentity\` struct captures the source radar's brand, legend-shaping flags (\`doppler_levels\`, \`has_rain_class\`), pixel-value layout, and naming. Serialized as the capabilities JSON of the \`.mrr\` file.
- Player constructs the playback \`RadarInfo\` with the **source brand**, applies the recorded \`set_doppler_levels\` / \`set_has_rain_class\` so the legend matches the wire format the recorded byte indices were mapped against, and sets \`replay = true\` so brand-specific live receivers don't try to attach.
- New \`replay\` field on the \`/radars\` API entry lets the GUI detect playback radars without sniffing the radar key. Filter on \`info.replay()\` instead of \`Brand::Playback\` for "available to record from".
- Bumps \`MRR_VERSION\` to 2; v1 files are rejected with a clear error since they rendered with a generic legend that never matched the source radar.

## Out of scope

Full reproduction of brand-specific controls (Range, Gain, etc.) requires a recorder change to capture control deltas plus a player-side replay scheduler — better as a follow-up. UserName and ModelName are reproduced so the radar list still matches what was recorded.

## Tested

- \`cargo test --lib\`: 196/196 pass (one new test: v1 rejection).
- \`cr review --plain\`: 3 findings on the original commit, all addressed before push (replay doc wording clarified; \`dual\` field added to identity for dual-range A/B preservation; the third was a false positive about a missing PR title).
- Live test pending — the user will validate end-to-end on the DRS4D-NXT 6424A by recording a session and replaying it via the same viewer URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds faithful playback of recorded radar sessions with source brand identity preservation. It introduces a `RecordingIdentity` struct to capture source radar metadata in `.mrr` files, updates the recording player to reconstruct radars with their original brand and appearance settings, and exposes a new `replay` field in the radar discovery API for reliable playback detection.

## Key Changes

### Recording Identity Capture and Restoration
A new `RecordingIdentity` struct captures the source radar's defining characteristics: brand ID, spoke/pixel layout parameters, legend-shaping flags (doppler_levels, has_rain_class), naming (UserName, ModelName), and dual-range settings. The struct serializes to the capabilities JSON within `.mrr` files and provides JSON conversion methods.

### Recording Playback Enhancement
The recording player now parses `RecordingIdentity` from the `.mrr` capabilities JSON and uses it to configure the playback radar instance. This ensures the playback radar inherits the original source radar's brand identity, spoke and pixel layouts, legend configuration, and UI naming. If the capabilities cannot be parsed, the player logs a warning and falls back to a minimal identity synthesized from the recording header, then to `Brand::Playback` if brand resolution fails. The playback radar is marked with `replay = true` to prevent brand-specific live receivers from attaching.

### API Exposure of Playback Status
The `/signalk/v2/api/vessels/self/radars` endpoint response model gains a new boolean `replay` field indicating whether a radar is sourced from playback. The recordable-radars endpoint now filters radars using the `replay()` getter rather than brand equality against `Brand::Playback`, enabling consistent detection of playback radars.

### Radar Metadata API
`RadarInfo` gains public getter methods (`replay()`, `targets()`, `doppler_levels()`, `has_rain_class()`) and a setter (`set_replay()`) to expose and override runtime radar state. `TargetMode` now derives `Deserialize` in addition to `Serialize` for full serde support.

### MRR File Format Version Bump
The MRR file format is updated to version 2. Version 1 recordings are now rejected with a clear error message, as v1 used a generic legend that did not match source radars. The version check is tightened to reject any file whose header version is not exactly `MRR_VERSION`.

### Client-Side Playback Detection
The GUI's `loadRadar` function now prefers the radar's `replay` flag from fetched metadata, with fallback to the existing `isPlaybackRadar()` check for backward compatibility.

## Testing
Unit tests verify JSON round-trip preservation, optional field handling, forward compatibility with unknown fields, and explicit v1 rejection. Cargo test passes with 196/196 tests.

## Out of Scope
Full replay of brand-specific controls (range, gain, etc.) is deferred to a follow-up requiring recorder-side capture of control deltas and a player scheduler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->