### PR TITLE
chore(release): 3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.5.0-dev"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.5.0-dev"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
## Summary

Release 3.5.0. Bumps \`Cargo.toml\` (and the project's entry in \`Cargo.lock\`) from \`3.5.0-dev\` to \`3.5.0\`.

Once merged, the \`v3.5.0\` tag will be created on the merge commit, which triggers \`.github/workflows/release.yml\` to build the multi-arch binaries and create the GitHub Release. Auto-generated changelog entry will follow via the \`Update Changelog\` workflow.

## Highlights since v3.4.2

86 commits, 3 of which are headline:

- **#165** \`fix(furuno): rebuild wire-to-legend LUT after legend reshape\` — strong stationary echoes were rendering as \`dopplerRain\` blue on Furuno NXT because the LUT was built before \`update_when_model_known()\` shrank the legend for rain/Doppler reservation slots. Reordering fixed it.
- **#167** \`fix(furuno): defer spoke decode until Target Analyzer state is known\` — gates spoke emission until the radar's TA state is confirmed (or the radar is known not to have TA), so wire bytes don't get decoded with the wrong LUT during the brief startup window before \`\$NEF\` arrives.
- **#168** \`feat(recording): faithful playback with source brand identity\` — recordings now carry the source radar's full identity (brand, legend shape, controls naming, SpokeProcessing mode). Playback reconstructs a \`RadarInfo\` that matches the original radar visually, and Signal K consumers (Freeboard-SK via the plugin) see playback as a regular radar feed. \`MRR_VERSION\` bumped to 2; v1 files are rejected.

The remaining commits are routine fixes, doc updates, and dependency bumps.

## Tested

- \`cargo build\` clean.
- \`cargo test --lib\` 199/199 pass on \`main\` post-#168 merge.
- Live verified by user on DRS4D-NXT 6424A: PPI colors match TimeZero Pro; recording → playback round-trips correctly through the Signal K plugin.