### PR TITLE
chore(release): begin 3.5.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.5.0"
+version = "3.5.1-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.5.0"
+version = "3.5.1-dev"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
Bump version to 3.5.1-dev for next development cycle. Routine post-release housekeeping.