### PR TITLE
ci(docker): also tag images with v-prefix matching git tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,7 @@ jobs:
           type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
           type=ref,event=branch
           type=semver,pattern={{version}}
+          type=semver,pattern=v{{version}}
           type=sha,prefix=
 
     - name: Build and push


### PR DESCRIPTION
## Summary

The metadata-action's \`type=semver,pattern={{version}}\` strips the \`v\` from \`v3.5.0\`, publishing the image as \`:3.5.0\`. Consumers reasonably expect \`:v3.5.0\` to match the git tag and the GitHub Release name — \`docker pull ghcr.io/.../mayara-server:v3.5.0\` currently fails with "manifest unknown".

Add a parallel \`pattern=v{{version}}\` rule so the image is published under **both** \`:3.5.0\` and \`:v3.5.0\`. Existing tags (\`:latest\`, unprefixed semver, branch, sha) keep working for callers already using them.

## Tested

- Diff is one added line in \`.github/workflows/docker.yml\`. The metadata-action's \`semver\` rule type natively supports the \`v\` prefix in its pattern, so no further escaping or special handling is needed.
- Effect verifiable on the next tag push (or by re-running the Docker workflow against \`v3.5.0\` after merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for publishing Docker images with semantic version tags prefixed with `v` (e.g., `v3.5.0`) alongside the existing non-prefixed semver tags.

## Changes

The PR modifies `.github/workflows/docker.yml` to include an additional `type=semver,pattern=v{{version}}` rule in the Docker metadata-action configuration. This enables Docker images built from git tags like `v3.5.0` to be published with both `:3.5.0` and `:v3.5.0` image tags, ensuring compatibility with Docker pull commands using the v-prefixed tag format.

The change preserves all existing image tags (`:latest` for stable releases, unprefixed semver, branch, and SHA-based tags) while extending the tagging scheme to align Docker image tags directly with the git tag and GitHub Release naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->