### PR TITLE
chore(release): 3.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.5.1-dev"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.5.1-dev"
+version = "3.5.1"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
## Summary

Release 3.5.1. Bumps \`Cargo.toml\` from \`3.5.1-dev\` to \`3.5.1\`.

Once merged, the \`v3.5.1\` tag will be created on the merge commit, which triggers \`.github/workflows/release.yml\` to build the multi-arch binaries and the GitHub Release. The Docker workflow will now publish images under both \`:3.5.1\` and \`:v3.5.1\` (PR #174).

## Highlights since v3.5.0

- **#174** \`ci(docker): also tag images with v-prefix matching git tag\` — \`docker pull ghcr.io/.../mayara-server:v3.5.0\` failed with "manifest unknown" because the metadata-action stripped the \`v\` prefix. \`v3.5.1\` will be the first release whose Docker image is published under both naming forms.

Plus the routine \`docs(changelog)\` (#173) and \`chore(release): begin 3.5.1-dev\` (#172) commits.

## Tested

- \`cargo build\` clean.
- \`cargo test --lib\` passes locally.
- The Docker tagging fix's effect will be observable on this tag push.