### PR TITLE
ci(release): bump softprops/action-gh-release to v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
         cat CHANGELOG.manual.md >> CHANGELOG.md
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         body_path: CHANGES.md
         files: |


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 in Actions runners on 2025-09-19; runners switch to Node 24 by default on 2026-06-02, and Node 20 is removed entirely on 2026-09-16. The v3.5.1 release run surfaced \`softprops/action-gh-release@v2\` as still on Node 20.

\`v3.0.0\` of the action (published 2026-04-12) is a **runtime-only** major bump to Node 24. No inputs or outputs changed — the v2.6.2 line continues to be supported for fleets that need Node 20.

Per the v3 release notes:
> \`3.0.0\` is a major release that moves the action runtime from Node 20 to Node 24. Use \`v3\` on GitHub-hosted runners and self-hosted fleets that already support the Node 24 Actions runtime.

GitHub-hosted runners support Node 24, so this is a safe drop-in.

## Tested

- Diff is one line: \`@v2\` → \`@v3\`.
- Effect is observable on the next tag push (the deprecation warning should disappear).