### PR TITLE
ci(deps): add Dependabot config for GitHub Actions and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot keeps GitHub Actions and Cargo dependencies current.
+#
+# Patch/minor Cargo bumps are grouped into a single weekly PR to avoid
+# flooding the queue with 60+ separate PRs from individual transitive deps.
+# Major Cargo bumps stay individual because they often need code review.
+# All Actions updates are grouped because they're trivial YAML edits.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

Adds \`.github/dependabot.yml\` covering two ecosystems on a weekly schedule:

- **GitHub Actions** — all updates grouped into one PR per week. Catches Node.js runtime deprecations (we just hit \`softprops/action-gh-release@v2\` on Node 20) and action major bumps without surprise CI breakage.
- **Cargo** — minor and patch updates grouped into one PR per week to avoid flooding the queue. Majors stay individual since they often need real review.

Commit-message prefixes (\`ci(deps)\`, \`chore(deps)\`) match the Angular conventional-commit style required by [AGENTS.md](AGENTS.md) so git-cliff picks them up cleanly in the changelog.

## Tested

- YAML structure validated locally; matches the [Dependabot v2 schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).
- First effect observable next Monday when Dependabot runs against the repo and (likely) opens its first grouped PRs.