### PR TITLE
fix(furuno): skip set_value for unsupported controls

### DIFF
--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -551,8 +551,17 @@ impl FurunoReportReceiver {
                 if numbers.len() >= 5 {
                     let wman = numbers[2] as i32;
                     let w_send = numbers[3];
-                    target.set_value(&ControlId::TimedIdle, wman as f64);
-                    target.set_value(&ControlId::TimedRun, w_send);
+                    // Wire format always includes wman/w_send fields, but
+                    // models without the watchman capability (DRS, DRS4W)
+                    // never registered the controls — skip the set_value to
+                    // avoid spamming "not supported" errors on every Status
+                    // report.
+                    if target.info.controls.contains_key(&ControlId::TimedIdle) {
+                        target.set_value(&ControlId::TimedIdle, wman as f64);
+                    }
+                    if target.info.controls.contains_key(&ControlId::TimedRun) {
+                        target.set_value(&ControlId::TimedRun, w_send);
+                    }
                 }
 
                 // Coupled transmit: on DRS models both ranges share TX state.
@@ -638,18 +647,36 @@ impl FurunoReportReceiver {
                 // Zone 1 is enabled if width is non-zero
                 let s1_enable = s1_width != 0.0;
 
-                self.common.set_sector(
-                    &ControlId::NoTransmitSector1,
-                    s1_start,
-                    s1_end,
-                    Some(s1_enable),
-                );
-                self.common.set_sector(
-                    &ControlId::NoTransmitSector2,
-                    s2_start,
-                    s2_end,
-                    Some(s2_enable),
-                );
+                // Wire format always includes blind-sector fields, but models
+                // without sector_blanking (DRS, DRS4W) never registered the
+                // controls — skip the set_sector to avoid spamming "not
+                // supported" errors on every report.
+                if self
+                    .common
+                    .info
+                    .controls
+                    .contains_key(&ControlId::NoTransmitSector1)
+                {
+                    self.common.set_sector(
+                        &ControlId::NoTransmitSector1,
+                        s1_start,
+                        s1_end,
+                        Some(s1_enable),
+                    );
+                }
+                if self
+                    .common
+                    .info
+                    .controls
+                    .contains_key(&ControlId::NoTransmitSector2)
+                {
+                    self.common.set_sector(
+                        &ControlId::NoTransmitSector2,
+                        s2_start,
+                        s2_end,
+                        Some(s2_enable),
+                    );
+                }
             }
             CommandId::Range => {
                 // Response format: $N62,{wire_idx},{unit},{drid}


### PR DESCRIPTION
## Summary

Stops the log spam Marcel reported on issue #48 when running mayara-server against a DRS4W:

\`\`\`
ERROR mayara::radar] fur: Control timedIdle not supported on this radar
ERROR mayara::radar] fur: Control timedRun not supported on this radar
ERROR mayara::radar] fur: Control noTransmitSector1 not supported on this radar
ERROR mayara::radar] fur: Control noTransmitSector2 not supported on this radar
\`\`\`

## Root cause

The Furuno wire format is uniform — \`\$N69\` Status replies always include \`wman\`/\`w_send\` fields, and \`\$N77\` BlindSector replies always include the sector geometry, regardless of model. The DRS / DRS4W capabilities row has \`watchman: false\` and \`sector_blanking: false\`, so the controls are never registered. The report handler unconditionally called \`set_value\` / \`set_sector\` on every reply, each call returned \`ControlError::NotSupported\`, and \`CommonRadar::set\` logged it at \`error!\`. Status replies tick every few seconds, hence the spam.

## Fix

Gate the \`set_value\` / \`set_sector\` calls on \`controls.contains_key(...)\`. No behavior change for radars that actually do support these features.

## Out of scope

Whether DRS4W *should* support watchman (Marcel notes the iOS app exposes the watchman UI) is a separate question requiring hardware verification on his radar. If confirmed, the fix would be a one-line capability-table update; covered in the issue thread.

## Tested

- \`cargo build\` clean.
- \`cargo test --lib\`: 199/199 pass.
- \`cr review --plain\`: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem
Mayara-server produces repetitive error log entries when running against a DRS4W radar. Furuno wire replies ($N69 Status and $N77 BlindSector) always include watchman/sector fields even when the radar model does not support these features. The DRS/DRS4W capabilities table marks watchman and sector_blanking as false, so related controls are not registered. However, the report handler unconditionally calls set_value and set_sector on every reply, which return ControlError::NotSupported and are logged at error level, creating frequent log spam.

## Solution
This fix guards set_value and set_sector calls with controls.contains_key checks to prevent calls on unregistered controls. The change ensures that these operations only execute for radars that support the features. No behavior changes occur for radars that support watchman and sector blanking functionality.

## Changes
- In CommandId::Status handling, updates to TimedIdle and TimedRun controls now check if those controls exist in the target's info.controls before attempting updates
- In CommandId::BlindSector handling, calls to set_sector for NoTransmitSector1 and NoTransmitSector2 now check for control presence before execution
- No changes to exported or public entities
- 41 lines added, 14 lines removed

## Testing
- `cargo build` succeeds
- `cargo test --lib` passes with 199/199 tests
- Code review confirms no findings

## Out of Scope
Whether DRS4W should support watchman/sector blanking on the wire (requires hardware verification)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->