### PR TITLE
fix(recordings): clean up orphaned .upload files at startup

### DIFF
--- a/src/bin/mayara-server/main.rs
+++ b/src/bin/mayara-server/main.rs
@@ -13,6 +13,7 @@ use web::Web;
 mod web;
 
 use mayara;
+use mayara::recording::RecordingManager;
 use mayara::{Cli, network};
 #[cfg(feature = "pcap-replay")]
 use mayara::replay;
@@ -69,6 +70,8 @@ async fn main() -> Result<()> {
                 .unwrap_or(&"MDNS".to_string())
         );
     }
+
+    RecordingManager::new().cleanup_orphaned_uploads();
 
     Toplevel::new(|s| async move {
         let web = Web::new(&s, args).await;

--- a/src/lib/recording/manager.rs
+++ b/src/lib/recording/manager.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles listing, metadata extraction, and deletion of recordings.
 
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::BufReader;
@@ -265,6 +265,44 @@ impl RecordingManager {
         Ok(())
     }
 
+    /// Remove any `<name>.upload` temp files left in the base directory.
+    ///
+    /// Uploads stream into `<filename>.upload` and atomically rename to the
+    /// final name on success. A crash or dropped connection leaves the temp
+    /// file behind, and `create_new(true)` then rejects future uploads of the
+    /// same name with 409 Conflict. At startup no upload can be in progress,
+    /// so anything matching `*.upload` is orphaned and safe to delete.
+    pub fn cleanup_orphaned_uploads(&self) {
+        let entries = match fs::read_dir(&self.base_dir) {
+            Ok(e) => e,
+            Err(e) => {
+                error!(
+                    "Failed to scan recordings directory for orphaned uploads: {}",
+                    e
+                );
+                return;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("upload") {
+                continue;
+            }
+            match fs::remove_file(&path) {
+                Ok(()) => info!("Removed orphaned upload: {}", path.display()),
+                Err(e) => warn!(
+                    "Failed to remove orphaned upload {}: {}",
+                    path.display(),
+                    e
+                ),
+            }
+        }
+    }
+
     pub fn create_directory(&self, name: &str) -> Result<(), String> {
         if !is_valid_name(name) {
             return Err("Invalid directory name".to_string());
@@ -446,6 +484,32 @@ mod tests {
 
         // Delete directory traversal
         assert!(manager.delete_directory("../escape").is_err());
+    }
+
+    #[test]
+    fn test_cleanup_orphaned_uploads() {
+        let (manager, _temp) = create_test_manager();
+
+        let orphan_a = manager.base_dir.join("a.mrr.upload");
+        let orphan_b = manager.base_dir.join("b.mrr.gz.upload");
+        let recording = manager.base_dir.join("kept.mrr");
+        fs::write(&orphan_a, b"partial").unwrap();
+        fs::write(&orphan_b, b"partial").unwrap();
+        fs::write(&recording, b"data").unwrap();
+
+        // Subdirectories must not be touched even if a stray .upload appears
+        // there; the upload handler only writes to base_dir, but cleanup
+        // shouldn't recurse and accidentally pick up unrelated content.
+        manager.create_directory("sub").unwrap();
+        let nested = manager.base_dir.join("sub").join("c.mrr.upload");
+        fs::write(&nested, b"partial").unwrap();
+
+        manager.cleanup_orphaned_uploads();
+
+        assert!(!orphan_a.exists());
+        assert!(!orphan_b.exists());
+        assert!(recording.exists());
+        assert!(nested.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

A crashed server or dropped upload connection leaves a `.upload` temp file behind in the recordings directory. Because the upload handler uses `create_new(true)` for atomicity, the orphan blocks future uploads of the same name with `409 Conflict`.

## Solution

Scan the recordings base directory at startup and remove any `*.upload` files. At boot no upload can be in progress, so all matches are by definition orphaned.

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds startup cleanup of orphaned `.upload` temporary files in the recordings directory to prevent them from blocking subsequent uploads with 409 Conflict errors.

The changes introduce a new public method `cleanup_orphaned_uploads()` to `RecordingManager` that scans the recordings base directory (non-recursively) for any files with the `.upload` extension and deletes them. The method logs successful deletions at info level and any failures at warn level. Because no uploads can be in progress during server startup, any matching files are guaranteed to be orphaned remnants from previous server crashes or dropped client connections.

During server initialization in `main.rs`, `RecordingManager::new().cleanup_orphaned_uploads()` is invoked immediately after logging setup and before any server subsystems start, ensuring orphaned temp files are removed before the upload handler becomes active.

The implementation includes a unit test that verifies the cleanup only operates on files in the base directory (matching `*.upload`) while preserving regular recording files and ignoring `.upload` files in subdirectories, ensuring the operation does not inadvertently delete unrelated content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/192)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->