### PR TITLE
fix(gui): inscribe PPI in canvas so full range is visible

### DIFF
--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -2,7 +2,9 @@ export { PPI };
 
 import { SpokeProcessorFactory } from "./spoke_processor.js";
 
-// Factor by which we fill the (w,h) canvas with the outer radar range ring
+// Fraction of the shorter canvas axis used as the outer radar range ring radius.
+// The PPI is a circle inscribed in the canvas so the full set range is visible
+// in every direction; the remaining margin leaves room for range labels.
 const RANGE_SCALE = 0.9;
 
 const NAUTICAL_MILE = 1852.0;
@@ -713,7 +715,7 @@ class PPI {
     this.height = h;
     this.center_x = w / 2;
     this.center_y = h / 2;
-    this.beam_length = Math.trunc(Math.max(this.center_x, this.center_y) * RANGE_SCALE * this.displayZoom);
+    this.beam_length = Math.trunc(Math.min(this.center_x, this.center_y) * RANGE_SCALE * this.displayZoom);
 
     // Update heading rotation
     let trueHeadingDeg = this.lastHeading;


### PR DESCRIPTION
The PPI radius was scaled to the longer canvas axis, so on widescreens the top and bottom of the range disc were clipped: at 24 nm range only ~14 nm was visible ahead in head-up mode. Inscribing the circle in the shorter axis instead makes the full set range visible in every direction. The 0.9 margin still leaves room for range labels, and `displayZoom` (0.33–3.0) still lets users push the disc past the canvas edges if they prefer to fill more pixels.

closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR modifies the PPI (Plan Position Indicator) circle radius calculation to ensure the full configured radar range is visible in all directions, addressing the issue of distance rings being clipped on widescreen displays.

## Changes

### web/gui/ppi.js

**Header Comment Update:** Updates the documentation to clarify that the PPI circle is inscribed in the shorter canvas axis (rather than the longer axis), with a 0.9 scale factor that reserves margin for range label rendering.

**`redrawCanvas()` Method:** Changes the `beam_length` calculation from using `Math.max(center_x, center_y)` to `Math.min(center_x, center_y)`. This alteration inscribes the radar circle within the shorter canvas dimension, ensuring the full set range is visible in every direction regardless of the canvas aspect ratio.

The `displayZoom` setting (ranging from 0.33 to 3.0) continues to allow users to scale the radar disc beyond the canvas edges if desired.

## Impact

- Fixes the issue where radar range rings were clipped on widescreen canvases in head-up mode (e.g., only ~14-16 nm visible when 24 nm range was set)
- Ensures consistent radar circle visibility across all display orientations and aspect ratios
- Preserves user control through the `displayZoom` setting for custom scaling preferences
- Affects all downstream UI elements that derive from `beam_length`, including range rings, range labels, and renderer resizing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->