### PR TITLE
docs(furuno): correct DRS to DRS2D in supported radars list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Fully supported and tested with real hardware:
 Implemented but awaiting real-hardware validation:
 
 - [**Garmin**](docs/garmin-setup.md) — HD, xHD, xHD2, xHD3, Fantom, Fantom Pro (all models including dual range and MotionScope/Doppler)
-- [**Furuno**](docs/furuno-setup.md) — DRS, DRS4DL, DRS6A X-Class, FAR-15x3, FAR-3000
+- [**Furuno**](docs/furuno-setup.md) — DRS2D, DRS4DL, DRS6A X-Class, FAR-15x3, FAR-3000
 - [**Koden**](docs/koden-setup.md) — MDS-xxR control boxes with any antenna unit (RADARpc series)
 - [**Raymarine**](docs/raymarine-setup.md) — HD, Magnum, Cyclone
 


### PR DESCRIPTION
Fix typo in README: the awaiting-validation Furuno entry listed `DRS` but the actual model designation is `DRS2D`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR corrects a typo in the README's "Radar support" section by updating the Furuno model designation from `DRS` to `DRS2D` in the awaiting-hardware-validation list.

## Changes

The PR updates the Furuno entry under the "Implemented but awaiting real-hardware validation" section to list the correct model names: DRS2D, DRS4DL, DRS6A X-Class, FAR-15x3, and FAR-3000.

**Files changed:** README.md (+1/-1)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->