### PR TITLE
feat(gui): subscribe AIS overlay to Signal K vessels.* directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ unicase = "2.9.0"
 wildmatch = "2.6.1"
 utoipa-swagger-ui = { version = "9.0.2", features = ["url", "axum"] }
 tokio-tungstenite = { version = "0.26.2", features = [ "handshake", "deflate", "rustls-tls-native-roots" ] }
+reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls", "json"] }
 
 [patch.crates-io]
 tokio-tungstenite = { git = "https://github.com/keesverruijt/tokio-tungstenite", tag = "v0.26.2-signalapp-v0.27.0"}

--- a/USAGE.md
+++ b/USAGE.md
@@ -79,7 +79,6 @@ Command Line Options
 |                                   | `ws:ip:port`: Signal K WebSocket (via discovery)                            |
 |                                   | `wss:ip:port`: Signal K secure WebSocket (requires `--accept-invalid-certs`)|
 | `--nmea0183`                      | Use NMEA 0183 instead of Signal K for navigation                            |
-| `--pass-ais`                      | Forward AIS targets from Signal K to GUI clients                            |
 | `--accept-invalid-certs`          | Accept self-signed TLS certificates when connecting to Signal K via         |
 |                                   | HTTPS/WSS. Required for boat-LAN setups that use self-signed certs.         |
 

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -78,7 +78,7 @@ testdata/pcap/           Captured radar traffic for integration tests
 2. Start the `Locator` subsystem — spawns UDP listeners on all NICs for all enabled brands
 3. Start `NavigationData` — connects to Signal K server or NMEA source for heading/GPS
 4. Optionally start PCAP replay dispatcher (if `--pcap <file>` given)
-5. Start AIS vessel tracking — seeds from upstream Signal K REST snapshot, then follows `vessels.*` deltas
+5. Start AIS vessel tracking from upstream navigation data
 6. Start `TargetTracker` subsystem (if `--targets arpa`)
 7. Start the web server — serves REST API, WebSocket streams, and embedded GUI
 

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -78,7 +78,7 @@ testdata/pcap/           Captured radar traffic for integration tests
 2. Start the `Locator` subsystem — spawns UDP listeners on all NICs for all enabled brands
 3. Start `NavigationData` — connects to Signal K server or NMEA source for heading/GPS
 4. Optionally start PCAP replay dispatcher (if `--pcap <file>` given)
-5. Optionally start AIS vessel tracking (if `--pass-ais` given)
+5. Start AIS vessel tracking — seeds from upstream Signal K REST snapshot, then follows `vessels.*` deltas
 6. Start `TargetTracker` subsystem (if `--targets arpa`)
 7. Start the web server — serves REST API, WebSocket streams, and embedded GUI
 

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1458,6 +1458,36 @@ async fn handle_subscription(
         send_all_ais_vessels(socket).await?;
     }
 
+    send_current_navigation(socket, subscriptions).await?;
+
+    Ok(())
+}
+
+/// Send the current value of any navigation paths the client is subscribed
+/// to, so the client doesn't have to wait for the next upstream change to
+/// receive a starting value. Position rarely changes when stationary, so
+/// without this a freshly-connected client may see no position for minutes.
+async fn send_current_navigation(
+    socket: &mut WebSocket,
+    subscriptions: &mut ActiveSubscriptions,
+) -> Result<(), RadarError> {
+    let mut delta = SignalKDelta::new();
+
+    if subscriptions.is_subscribed_path("navigation.position", false) {
+        let (lat, lon) = navdata::get_position();
+        if let (Some(lat), Some(lon)) = (lat, lon) {
+            delta.add_position_update(lat, lon, "mayara");
+        }
+    }
+    if subscriptions.is_subscribed_path("navigation.headingTrue", false) {
+        if let Some(h) = navdata::get_heading_true() {
+            delta.add_navigation_update("navigation.headingTrue", h, "mayara");
+        }
+    }
+
+    if let Some(d) = delta.build() {
+        send_message(socket, d).await?;
+    }
     Ok(())
 }
 

--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -301,6 +301,7 @@ impl EmulatorReportReceiver {
         crate::navdata::set_position(
             Some(self.boat_position.lat()),
             Some(self.boat_position.lon()),
+            "emulator",
         );
         crate::navdata::set_heading_true(Some(self.boat_heading * DEG_TO_RAD), "emulator");
         crate::navdata::set_sog(Some(self.boat_speed * KNOTS_TO_MS));
@@ -316,12 +317,10 @@ impl EmulatorReportReceiver {
         for _ in 0..SPOKES_PER_BATCH {
             let spoke_data = self.generate_spoke(self.current_spoke);
 
-            // Convert heading to raw spoke units (0-4096 like Navico hardware)
-            // to_protobuf_spoke divides by 2 to convert to 0-2048 display space
-            // Note: Do NOT include the 0x4000 flag here - that flag is used in the raw
-            // Navico protocol but is stripped by extract_heading_value() before add_spoke.
-            const NAVICO_SPOKES_RAW: f64 = 4096.0;
-            let heading_spoke = ((self.boat_heading / 360.0) * NAVICO_SPOKES_RAW) as u16;
+            // Heading in `EMULATOR_SPOKES`-units, matching the convention
+            // every brand's normalized `add_spoke` heading uses now.
+            let heading_spoke =
+                ((self.boat_heading / 360.0) * EMULATOR_SPOKES as f64) as u16;
 
             self.common.add_spoke(
                 self.current_range,

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -1359,7 +1359,10 @@ impl NavicoReportReceiver {
             ((large_range as u32) * (small_range as u32)) / 512
         };
 
-        let heading = extract_heading_value(heading);
+        // Navico encodes heading in SPOKES_RAW (4096) units; halve to bring it
+        // into the SPOKES_PER_REVOLUTION (2048) space `to_protobuf_spoke`
+        // stores. Matches the `angle / 2` normalization above.
+        let heading = extract_heading_value(heading).map(|h| h / 2);
         Some((range, angle, heading))
     }
 

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -1388,7 +1388,10 @@ impl NavicoReportReceiver {
         let range =
             ((u32::from_le_bytes(header.range) & 0xffffff) as f64 * BR24_RANGE_FACTOR) as u32;
 
-        let heading = extract_heading_value(heading);
+        // BR24 encodes heading in SPOKES_RAW (4096) units like 4G+; halve
+        // to bring it into the SPOKES_PER_REVOLUTION (2048) space
+        // `to_protobuf_spoke` stores. Matches the `angle / 2` above.
+        let heading = extract_heading_value(heading).map(|h| h / 2);
 
         Some((range, angle, heading))
     }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -477,13 +477,14 @@ pub async fn start_session(
     navdata::init_ais_store(radars.get_sk_client_tx());
 
     // Seed the AIS store from the upstream Signal K REST snapshot as
-    // soon as discovery resolves an HTTP URL. Retries briefly because
-    // the WS task and discovery race startup.
+    // soon as discovery resolves an HTTP URL. Polls until either shutdown
+    // or discovery resolves; the WS task and discovery race startup and
+    // discovery may take arbitrarily long on a quiet network.
     let accept_invalid_certs = args.accept_invalid_certs;
     subsystem.start(SubsystemBuilder::new(
         "AIS Seed",
         async move |subsys: &mut SubsystemHandle| {
-            for _ in 0..20 {
+            loop {
                 tokio::select! { biased;
                     _ = subsys.on_shutdown_requested() => break,
                     _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {},

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -145,10 +145,6 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub transmit: bool,
 
-    /// Pass AIS targets from Signal K server to GUI clients
-    #[arg(long, default_value_t = false)]
-    pub pass_ais: bool,
-
     /// Accept invalid TLS certificates (e.g. self-signed) when connecting to Signal K
     #[arg(long, default_value_t = false)]
     pub accept_invalid_certs: bool,
@@ -440,7 +436,7 @@ pub async fn start_session(
             && (-180.0..=180.0).contains(&static_pos.lon)
         {
             let heading_rad = static_pos.heading.to_radians();
-            navdata::set_position(Some(static_pos.lat), Some(static_pos.lon));
+            navdata::set_position(Some(static_pos.lat), Some(static_pos.lon), "static");
             navdata::set_heading_true(Some(heading_rad), "static");
             navdata::set_sog(Some(0.0));
             navdata::set_cog(Some(heading_rad));
@@ -474,12 +470,37 @@ pub async fn start_session(
         }
     }
 
-    // Initialize AIS vessel store if pass_ais is enabled
-    if args.pass_ais {
-        navdata::init_ais_store(radars.get_sk_client_tx());
+    // AIS support is unconditional: the GUI subscribes to vessels.* on
+    // Signal K via the heading WebSocket, and standalone mayara mirrors
+    // upstream `vessels.*` into the local AIS store so the same
+    // subscription works against either backend.
+    navdata::init_ais_store(radars.get_sk_client_tx());
 
-        // Start background task to check for AIS vessel timeouts (every 30 seconds)
-        subsystem.start(SubsystemBuilder::new("AIS Timeout", async move |subsys: &mut SubsystemHandle| {
+    // Seed the AIS store from the upstream Signal K REST snapshot as
+    // soon as discovery resolves an HTTP URL. Retries briefly because
+    // the WS task and discovery race startup.
+    let accept_invalid_certs = args.accept_invalid_certs;
+    subsystem.start(SubsystemBuilder::new(
+        "AIS Seed",
+        async move |subsys: &mut SubsystemHandle| {
+            for _ in 0..20 {
+                tokio::select! { biased;
+                    _ = subsys.on_shutdown_requested() => break,
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {},
+                }
+                if crate::signalk::get_upstream_http_base().is_some() {
+                    navdata::seed_ais_from_upstream(accept_invalid_certs).await;
+                    break;
+                }
+            }
+            Ok::<(), miette::Report>(())
+        },
+    ));
+
+    // Check for AIS vessel timeouts every 30 seconds.
+    subsystem.start(SubsystemBuilder::new(
+        "AIS Timeout",
+        async move |subsys: &mut SubsystemHandle| {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
             loop {
                 tokio::select! { biased;
@@ -498,31 +519,30 @@ pub async fn start_session(
                 }
             }
             Ok::<(), miette::Report>(())
-        }));
+        },
+    ));
 
-        // Start background task to flush pending AIS broadcasts (every 50ms)
-        // This coalesces rapid updates into single broadcasts
-        subsystem.start(SubsystemBuilder::new(
-            "AIS Broadcast",
-            async move |subsys: &mut SubsystemHandle| {
-                let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
-                loop {
-                    tokio::select! { biased;
-                        _ = subsys.on_shutdown_requested() => {
-                            log::debug!("AIS broadcast task shutdown");
-                            break;
-                        },
-                        _ = interval.tick() => {
-                            if let Some(store) = navdata::get_ais_store() {
-                                store.flush_pending_broadcasts();
-                            }
+    // Coalesce rapid AIS deltas into 50 ms broadcast batches.
+    subsystem.start(SubsystemBuilder::new(
+        "AIS Broadcast",
+        async move |subsys: &mut SubsystemHandle| {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
+            loop {
+                tokio::select! { biased;
+                    _ = subsys.on_shutdown_requested() => {
+                        log::debug!("AIS broadcast task shutdown");
+                        break;
+                    },
+                    _ = interval.tick() => {
+                        if let Some(store) = navdata::get_ais_store() {
+                            store.flush_pending_broadcasts();
                         }
                     }
                 }
-                Ok::<(), miette::Report>(())
-            },
-        ));
-    }
+            }
+            Ok::<(), miette::Report>(())
+        },
+    ));
 
     let locator = Locator::new(args.clone(), radars.clone());
 

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -53,10 +53,21 @@ fn broadcast_nav_update(path: &str, value: f64, source: &str) {
     }
 }
 
-/// Own-ship context detected from Signal K server (when pass_ais is enabled)
+/// Broadcast a `navigation.position` update to subscribed clients. Position
+/// is structured (`{latitude, longitude}`) so it needs its own broadcaster
+/// distinct from the scalar `broadcast_nav_update` above.
+fn broadcast_position_update(lat: f64, lon: f64, source: &str) {
+    if let Some(tx) = NAV_BROADCAST_TX.get() {
+        let mut delta = SignalKDelta::new();
+        delta.add_position_update(lat, lon, source);
+        let _ = tx.send(delta);
+    }
+}
+
+/// Own-ship context detected from the upstream Signal K server
 static OWN_SHIP_CONTEXT: OnceLock<RwLock<Option<String>>> = OnceLock::new();
 
-/// AIS vessel store (when pass_ais is enabled)
+/// AIS vessel store, populated from `vessels.*` upstream Signal K deltas.
 static AIS_STORE: OnceLock<std::sync::Arc<AisVesselStore>> = OnceLock::new();
 
 /// Get the own-ship context if detected
@@ -92,7 +103,7 @@ fn reset_own_ship_context() {
     }
 }
 
-/// Initialize the AIS vessel store (called once at startup when pass_ais is enabled)
+/// Initialize the AIS vessel store (called once at startup)
 pub fn init_ais_store(tx: tokio::sync::broadcast::Sender<SignalKDelta>) {
     let store = AisVesselStore::new(tx);
     let _ = AIS_STORE.set(store);
@@ -110,10 +121,133 @@ fn update_ais_vessel(context: &str, updates: &Value) {
     }
 }
 
+/// Pull the full `vessels/` REST snapshot from the upstream Signal K server
+/// and seed the AIS store with everything it knows. Without this, the store
+/// only fills as upstream pushes per-vessel deltas (~5-60s per vessel) and
+/// a freshly-connected GUI sees the overlay trickle in over minutes.
+/// Best-effort: any failure (no upstream URL, unreachable, malformed JSON)
+/// is logged at debug and ignored; per-vessel WS deltas will fill the gap.
+pub async fn seed_ais_from_upstream(accept_invalid_certs: bool) {
+    let Some(base) = crate::signalk::get_upstream_http_base() else {
+        return;
+    };
+    let Some(store) = get_ais_store() else {
+        return;
+    };
+    let url = if base.ends_with('/') {
+        format!("{}vessels/", base)
+    } else {
+        format!("{}/vessels/", base)
+    };
+    log::info!("Seeding AIS store from {}", url);
+
+    let client = match reqwest::Client::builder()
+        .danger_accept_invalid_certs(accept_invalid_certs)
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("AIS seed: client build failed: {}", e);
+            return;
+        }
+    };
+    let tree: Value = match client.get(&url).send().await {
+        Ok(r) if r.status().is_success() => match r.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                log::debug!("AIS seed: JSON parse failed: {}", e);
+                return;
+            }
+        },
+        Ok(r) => {
+            log::debug!("AIS seed: HTTP {}", r.status());
+            return;
+        }
+        Err(e) => {
+            log::debug!("AIS seed: GET failed: {}", e);
+            return;
+        }
+    };
+
+    let Some(tree_obj) = tree.as_object() else {
+        return;
+    };
+    let mut seeded = 0;
+    for (ctx_key, vessel) in tree_obj {
+        // Skip `urn:mrn:signalk:uuid:*` entries — those are own-ship or
+        // local-without-MMSI vessels; the GUI filters them too.
+        if !ctx_key.starts_with("urn:mrn:imo:mmsi:") {
+            continue;
+        }
+        let context = format!("vessels.{}", ctx_key);
+        let Some(updates) = build_seed_updates(vessel) else {
+            continue;
+        };
+        if store.update(&context, &updates) {
+            seeded += 1;
+        }
+    }
+    log::info!("Seeded {} AIS vessels from upstream snapshot", seeded);
+}
+
+/// Flatten a Signal K vessel REST node `{ navigation: { position: {value: ...},
+/// ...}, name: "...", design: {...} }` into a delta-shaped
+/// `[{ values: [{path, value}, ...]}]` array that `AisVesselStore::update`
+/// already knows how to consume.
+fn build_seed_updates(vessel: &Value) -> Option<Value> {
+    use serde_json::json;
+    let mut values: Vec<Value> = Vec::new();
+
+    // Top-level `name` is an empty-path metadata value in delta form.
+    if let Some(name) = vessel.get("name").and_then(|v| v.as_str()) {
+        values.push(json!({ "path": "", "value": { "name": name } }));
+    }
+
+    let push_value = |values: &mut Vec<Value>, path: &str, v: &Value| {
+        if let Some(inner) = v.get("value") {
+            values.push(json!({ "path": path, "value": inner.clone() }));
+        }
+    };
+
+    if let Some(nav) = vessel.get("navigation") {
+        for path in [
+            "position",
+            "headingTrue",
+            "courseOverGroundTrue",
+            "speedOverGround",
+        ] {
+            if let Some(node) = nav.get(path) {
+                push_value(&mut values, &format!("navigation.{}", path), node);
+            }
+        }
+    }
+    if let Some(design) = vessel.get("design") {
+        if let Some(node) = design.get("length") {
+            push_value(&mut values, "design.length", node);
+        }
+        if let Some(node) = design.get("beam") {
+            push_value(&mut values, "design.beam", node);
+        }
+    }
+    if let Some(sensors) = vessel.get("sensors").and_then(|s| s.get("ais")) {
+        for path in ["fromBow", "fromCenter"] {
+            if let Some(node) = sensors.get(path) {
+                push_value(&mut values, &format!("sensors.ais.{}", path), node);
+            }
+        }
+    }
+
+    if values.is_empty() {
+        return None;
+    }
+    Some(json!([{ "values": values }]))
+}
+
 ///
 /// Get the heading in radians [0..2*PI>
 ///
-pub(crate) fn get_heading_true() -> Option<f64> {
+pub fn get_heading_true() -> Option<f64> {
     let heading = HEADING_TRUE.load(Ordering::Acquire);
     if !heading.is_nan() {
         return Some(heading);
@@ -162,7 +296,7 @@ pub fn get_radar_position() -> Option<GeoPosition> {
     return None;
 }
 
-pub(crate) fn get_position() -> (Option<f64>, Option<f64>) {
+pub fn get_position() -> (Option<f64>, Option<f64>) {
     if POSITION_VALID.load(Ordering::Acquire) {
         let lat = POSITION_LAT.load(Ordering::Acquire);
         let lon = POSITION_LON.load(Ordering::Acquire);
@@ -172,12 +306,21 @@ pub(crate) fn get_position() -> (Option<f64>, Option<f64>) {
     return (None, None);
 }
 
-pub(crate) fn set_position(lat: Option<f64>, lon: Option<f64>) {
+pub(crate) fn set_position(lat: Option<f64>, lon: Option<f64>, source: &str) {
     if let (Some(lat), Some(lon)) = (lat, lon) {
         log::trace!("navdata::set_position(lat={}, lon={})", lat, lon);
-        POSITION_LAT.store(lat, Ordering::Release);
-        POSITION_LON.store(lon, Ordering::Release);
-        POSITION_VALID.store(true, Ordering::Release);
+        let old_lat = POSITION_LAT.swap(lat, Ordering::AcqRel);
+        let old_lon = POSITION_LON.swap(lon, Ordering::AcqRel);
+        let was_valid = POSITION_VALID.swap(true, Ordering::AcqRel);
+        // Only broadcast on meaningful change — ~1m at the equator
+        // (1e-5 deg ≈ 1.11 m). Avoids flooding subscribers with sub-meter
+        // GPS jitter on a stationary boat.
+        let changed = !was_valid
+            || (old_lat - lat).abs() > 1e-5
+            || (old_lon - lon).abs() > 1e-5;
+        if changed {
+            broadcast_position_update(lat, lon, source);
+        }
     } else {
         POSITION_VALID.store(false, Ordering::Release);
         return;
@@ -240,7 +383,7 @@ enum SignalKSubscription {
     /// Initial own-ship subscription; sent once we receive the hello message.
     OwnShip,
     /// All-vessels subscription for AIS forwarding; sent once we know the
-    /// own-ship context (when `--pass-ais` is set).
+    /// own-ship context.
     AllVessels,
 }
 
@@ -301,7 +444,6 @@ enum Stream {
 pub(crate) struct NavigationData {
     args: Cli,
     nmea0183_mode: bool,
-    pass_ais: bool,
     what: &'static str,
     nmea_parser: Option<NmeaParser>,
 }
@@ -309,19 +451,16 @@ pub(crate) struct NavigationData {
 impl NavigationData {
     pub(crate) fn new(args: Cli) -> Self {
         let nmea0183 = args.nmea0183;
-        let pass_ais = args.pass_ais;
         match nmea0183 {
             true => NavigationData {
                 args,
                 nmea0183_mode: true,
-                pass_ais,
                 what: "NMEA0183",
                 nmea_parser: Some(NmeaParser::new()),
             },
             false => NavigationData {
                 args,
                 nmea0183_mode: false,
-                pass_ais,
                 what: "Signal K",
                 nmea_parser: None,
             },
@@ -709,11 +848,11 @@ impl NavigationData {
 
         let had_own_ship = get_own_ship_context().is_some();
 
-        if let Err(e) = parse_signalk(line, self.pass_ais) {
+        if let Err(e) = parse_signalk(line) {
             log::trace!("{} parse error: {}", self.what, e);
         }
 
-        if self.pass_ais && !had_own_ship && get_own_ship_context().is_some() {
+        if !had_own_ship && get_own_ship_context().is_some() {
             log::info!("Own-ship context established, expanding subscription to all vessels");
             return vec![SignalKSubscription::AllVessels];
         }
@@ -822,7 +961,7 @@ impl NavigationData {
                 match if self.nmea0183_mode {
                     self.parse_nmea0183(line)
                 } else {
-                    parse_signalk(&line, self.pass_ais)
+                    parse_signalk(&line)
                 } {
                     Err(e) => {
                         log::warn!("{}", e)
@@ -838,10 +977,10 @@ impl NavigationData {
 
         match parser.parse_sentence(s) {
             Ok(ParsedMessage::Rmc(rmc)) => {
-                set_position(rmc.latitude, rmc.longitude);
+                set_position(rmc.latitude, rmc.longitude, "nmea0183");
             }
             Ok(ParsedMessage::Gll(gll)) => {
-                set_position(gll.latitude, gll.longitude);
+                set_position(gll.latitude, gll.longitude, "nmea0183");
             }
             Ok(ParsedMessage::Hdt(hdt)) => {
                 set_heading_true(
@@ -878,7 +1017,7 @@ impl NavigationData {
 //     "$source":"canboat-merrimac.BM","timestamp":"2024-10-01T09:11:36.000Z",
 //     "values":[{"path":"navigation.position","value":{"longitude":5.428445,"latitude":53.180205}}]}]}
 
-fn parse_signalk(s: &str, pass_ais: bool) -> Result<(), RadarError> {
+fn parse_signalk(s: &str) -> Result<(), RadarError> {
     log::trace!("parse_signalk: parsing '{}'", s);
     let v: Value = serde_json::from_str(s).map_err(|e| {
         log::warn!("Unable to parse SK message '{}'", s);
@@ -888,23 +1027,21 @@ fn parse_signalk(s: &str, pass_ais: bool) -> Result<(), RadarError> {
     let context = v["context"].as_str();
     let updates = &v["updates"];
 
-    // When pass_ais is enabled, handle own-ship detection and AIS forwarding.
-    if pass_ais {
-        if let Some(ctx) = context {
-            let own_ship = get_own_ship_context();
+    // Identify own ship and route non-self deltas to the AIS store.
+    if let Some(ctx) = context {
+        let own_ship = get_own_ship_context();
 
-            if own_ship.is_none() {
-                // First message after subscribing to vessels.self establishes the
-                // own-ship context. Continue processing this message as nav data.
-                set_own_ship_context(ctx);
-                log::info!("Own-ship context detected: {}", ctx);
-            } else if let Some(own_ship_ctx) = own_ship {
-                let is_own_ship = own_ship_ctx == ctx || ctx == "vessels.self";
-                if !is_own_ship {
-                    // This delta is for another vessel; route to AIS store.
-                    update_ais_vessel(ctx, updates);
-                    return Ok(());
-                }
+        if own_ship.is_none() {
+            // First message after subscribing to vessels.self establishes the
+            // own-ship context. Continue processing this message as nav data.
+            set_own_ship_context(ctx);
+            log::info!("Own-ship context detected: {}", ctx);
+        } else if let Some(own_ship_ctx) = own_ship {
+            let is_own_ship = own_ship_ctx == ctx || ctx == "vessels.self";
+            if !is_own_ship {
+                // This delta is for another vessel; route to AIS store.
+                update_ais_vessel(ctx, updates);
+                return Ok(());
             }
         }
     }
@@ -946,7 +1083,11 @@ fn apply_signalk_value(values_entry: &Value, source: &str) {
     log::trace!("parse_signalk: path = '{}', value = {:?}", path, value);
     match path {
         "navigation.position" => {
-            set_position(value["latitude"].as_f64(), value["longitude"].as_f64());
+            set_position(
+                value["latitude"].as_f64(),
+                value["longitude"].as_f64(),
+                source,
+            );
         }
         "navigation.headingTrue" => {
             set_heading_true(value.as_f64(), source);

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -82,7 +82,16 @@ fn get_own_ship_context() -> Option<String> {
 fn set_own_ship_context(context: &str) {
     let lock = OWN_SHIP_CONTEXT.get_or_init(|| RwLock::new(None));
     if let Ok(mut guard) = lock.write() {
-        if guard.is_none() {
+        // Set on first sight, OR upgrade from the "vessels.self" placeholder
+        // to a concrete `vessels.urn:...` once one arrives. Without the
+        // upgrade, later own-ship URN deltas would compare false against the
+        // stored "vessels.self" and get misrouted into the AIS store.
+        let should_set = match guard.as_deref() {
+            None => true,
+            Some("vessels.self") if context != "vessels.self" => true,
+            _ => false,
+        };
+        if should_set {
             log::info!("Own-ship context set to: {}", context);
             *guard = Some(context.to_string());
         }
@@ -127,7 +136,7 @@ fn update_ais_vessel(context: &str, updates: &Value) {
 /// a freshly-connected GUI sees the overlay trickle in over minutes.
 /// Best-effort: any failure (no upstream URL, unreachable, malformed JSON)
 /// is logged at debug and ignored; per-vessel WS deltas will fill the gap.
-pub async fn seed_ais_from_upstream(accept_invalid_certs: bool) {
+pub(crate) async fn seed_ais_from_upstream(accept_invalid_certs: bool) {
     let Some(base) = crate::signalk::get_upstream_http_base() else {
         return;
     };
@@ -1029,14 +1038,12 @@ fn parse_signalk(s: &str) -> Result<(), RadarError> {
 
     // Identify own ship and route non-self deltas to the AIS store.
     if let Some(ctx) = context {
-        let own_ship = get_own_ship_context();
+        // Always try to set: first time stores the context, subsequent
+        // concrete URN messages upgrade away from the "vessels.self"
+        // placeholder if that was first.
+        set_own_ship_context(ctx);
 
-        if own_ship.is_none() {
-            // First message after subscribing to vessels.self establishes the
-            // own-ship context. Continue processing this message as nav data.
-            set_own_ship_context(ctx);
-            log::info!("Own-ship context detected: {}", ctx);
-        } else if let Some(own_ship_ctx) = own_ship {
+        if let Some(own_ship_ctx) = get_own_ship_context() {
             let is_own_ship = own_ship_ctx == ctx || ctx == "vessels.self";
             if !is_own_ship {
                 // This delta is for another vessel; route to AIS store.

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -83,12 +83,17 @@ fn set_own_ship_context(context: &str) {
     let lock = OWN_SHIP_CONTEXT.get_or_init(|| RwLock::new(None));
     if let Ok(mut guard) = lock.write() {
         // Set on first sight, OR upgrade from the "vessels.self" placeholder
-        // to a concrete `vessels.urn:...` once one arrives. Without the
-        // upgrade, later own-ship URN deltas would compare false against the
-        // stored "vessels.self" and get misrouted into the AIS store.
+        // to a concrete `vessels.urn:mrn:signalk:uuid:...` once one arrives.
+        // Constrain the upgrade target so an AIS-vessel context (e.g.
+        // `vessels.urn:mrn:imo:mmsi:...`) cannot latch as own-ship and
+        // misroute later own-ship URN deltas into the AIS store.
         let should_set = match guard.as_deref() {
             None => true,
-            Some("vessels.self") if context != "vessels.self" => true,
+            Some("vessels.self")
+                if context.starts_with("vessels.urn:mrn:signalk:uuid:") =>
+            {
+                true
+            }
             _ => false,
         };
         if should_set {

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -1611,15 +1611,14 @@ impl CommonRadar {
                 }
             }
 
-            // Extract heading from spoke data and broadcast for GUI
-            if let Some(bearing) = spoke.bearing {
-                let heading_spokes = (bearing as i32 - spoke.angle as i32)
-                    .rem_euclid(self.info.spokes_per_revolution as i32)
-                    as f64;
-                let heading_rad =
-                    heading_spokes / self.info.spokes_per_revolution as f64 * std::f64::consts::TAU;
-                crate::navdata::set_heading_true(Some(heading_rad), &self.key);
-            }
+            // Per-spoke heading from the radar's inline bearing is NOT fed
+            // back to navdata. The radar typically receives its heading
+            // from N2K and re-emits it once per spoke; pushing it into
+            // set_heading_true would race the authoritative compass source
+            // (typically YDEN02 / direct N2K) on `navigation.headingTrue`
+            // and saturate downstream subscribers with kHz-rate updates.
+            // The PPI still uses `spoke.bearing` directly for rotation, so
+            // dropping this feed is invisible to single-radar displays.
 
             // Always broadcast spoke to clients
             let mut spoke = spoke;

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -87,7 +87,6 @@ pub enum ControlId {
     // Client Only, not here: Orientation,
     // Client Only, not here: Position,
     // Client Only, not here: Symbology,
-    ShowAis,
 
     // Target tracking
     GuardZone1,
@@ -217,8 +216,7 @@ impl ControlId {
             | ControlId::Rain
             | ControlId::Doppler
             | ControlId::DopplerMode => Category::Base,
-            ControlId::ShowAis
-            | ControlId::DopplerAutoTrack
+            ControlId::DopplerAutoTrack
             | ControlId::ArpaDetectMaxSpeed
             | ControlId::ClearTargets
             | ControlId::GuardZone1
@@ -306,7 +304,6 @@ impl ControlId {
                 "Targets coming towards or going away from own ship shown in different colors"
             }
             ControlId::DopplerMode => "For what type of targets Doppler is used",
-            ControlId::ShowAis => "Show AIS vessels on the radar display",
             ControlId::DopplerAutoTrack => {
                 "Convert all Doppler targets to ARPA targets automatically"
             }
@@ -396,7 +393,6 @@ impl ControlId {
             ControlId::AntennaStarboard => "Antenna starboard",
             ControlId::BearingAlignment => "Bearing alignment",
             // ControlId::ColorGain => "Color gain",
-            ControlId::ShowAis => "Show AIS",
             ControlId::ClearTargets => "Clear targets",
             ControlId::ClearTrails => "Clear trails",
             ControlId::ColorGain => "Color gain",
@@ -497,7 +493,6 @@ impl ControlId {
             ControlId::Range => ControlDestination::Command,
             ControlId::Mode => ControlDestination::Command,
             ControlId::Gain => ControlDestination::Command,
-            ControlId::ShowAis => ControlDestination::Internal,
             ControlId::GuardZone1 => ControlDestination::Target,
             ControlId::GuardZone2 => ControlDestination::Target,
             ControlId::ExclusionZone1 => ControlDestination::Target,
@@ -698,13 +693,6 @@ impl Controls {
                 .build(&mut controls);
 
             new_button(ControlId::ClearTargets).build(&mut controls);
-        }
-
-        // Add ShowAis control when pass_ais is enabled
-        if args.pass_ais {
-            new_list(ControlId::ShowAis, &["Off", "On"])
-                .set_value(1.) // Default to "On"
-                .build(&mut controls);
         }
 
         let (all_clients_tx, _) = tokio::sync::broadcast::channel(32);

--- a/src/lib/radar/spoke.rs
+++ b/src/lib/radar/spoke.rs
@@ -20,8 +20,10 @@ pub(crate) fn to_protobuf_spoke(
         generic_spoke.len()
     );
 
+    // `heading` is expected to already be in `spokes_per_revolution`-units
+    // (each brand normalizes before calling add_spoke).
     let heading = if heading.is_some() {
-        heading.map(|h| (((h / 2) + angle) % spokes_per_revolution) as u32)
+        heading.map(|h| ((h + angle) % spokes_per_revolution) as u32)
     } else {
         let heading = crate::navdata::get_heading_true();
         heading.map(|h| {

--- a/src/lib/signalk.rs
+++ b/src/lib/signalk.rs
@@ -55,6 +55,27 @@ pub(crate) enum Connection {
     WebSocket(WsStream, String),
 }
 
+/// Last-resolved upstream Signal K REST base URL (e.g.
+/// `http://192.168.0.122:4400/signalk/v1/api/`). Captured during discovery
+/// so the AIS snapshot seeder can issue one-shot REST reads without
+/// re-running discovery itself.
+static UPSTREAM_HTTP_BASE: std::sync::OnceLock<std::sync::RwLock<Option<String>>> =
+    std::sync::OnceLock::new();
+
+pub fn get_upstream_http_base() -> Option<String> {
+    UPSTREAM_HTTP_BASE
+        .get()
+        .and_then(|lock| lock.read().ok())
+        .and_then(|guard| guard.clone())
+}
+
+fn set_upstream_http_base(url: &str) {
+    let lock = UPSTREAM_HTTP_BASE.get_or_init(|| std::sync::RwLock::new(None));
+    if let Ok(mut guard) = lock.write() {
+        *guard = Some(url.to_string());
+    }
+}
+
 /// How a resolved mDNS service should be connected to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Transport {
@@ -67,11 +88,15 @@ enum Transport {
 }
 
 #[derive(Debug, PartialEq)]
-struct DiscoveryResult {
-    server_id: String,
-    server_version: String,
-    tcp_url: Option<String>,
-    ws_url: Option<String>,
+pub(crate) struct DiscoveryResult {
+    pub(crate) server_id: String,
+    pub(crate) server_version: String,
+    pub(crate) tcp_url: Option<String>,
+    pub(crate) ws_url: Option<String>,
+    /// REST API base URL (ends with `/`), e.g.
+    /// `http://192.168.0.122:4400/signalk/v1/api/`. Used for one-shot
+    /// snapshot reads such as seeding the AIS store at startup.
+    pub(crate) http_url: Option<String>,
 }
 
 /// Browse mDNS for the three Signal K service types.
@@ -239,6 +264,10 @@ async fn connect_via_discovery(
         discovery.server_id,
         discovery.server_version
     );
+
+    if let Some(http) = discovery.http_url.as_deref() {
+        set_upstream_http_base(http);
+    }
 
     // Prefer WebSocket: it is the only Signal K transport that can carry
     // authentication, so any future auth work will want to land there.
@@ -418,11 +447,17 @@ fn parse_discovery_response(json: &Value) -> Result<DiscoveryResult, RadarError>
         ));
     }
 
+    let http_url = endpoints["signalk-https"]
+        .as_str()
+        .or_else(|| endpoints["signalk-http"].as_str())
+        .map(String::from);
+
     Ok(DiscoveryResult {
         server_id,
         server_version,
         tcp_url: endpoints["signalk-tcp"].as_str().map(String::from),
         ws_url: endpoints["signalk-ws"].as_str().map(String::from),
+        http_url,
     })
 }
 

--- a/src/lib/signalk.rs
+++ b/src/lib/signalk.rs
@@ -62,7 +62,7 @@ pub(crate) enum Connection {
 static UPSTREAM_HTTP_BASE: std::sync::OnceLock<std::sync::RwLock<Option<String>>> =
     std::sync::OnceLock::new();
 
-pub fn get_upstream_http_base() -> Option<String> {
+pub(crate) fn get_upstream_http_base() -> Option<String> {
     UPSTREAM_HTTP_BASE
         .get()
         .and_then(|lock| lock.read().ok())

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -127,6 +127,23 @@ impl SignalKDelta {
         self.updates.push(delta_update);
     }
 
+    /// Add a `navigation.position` update.
+    pub fn add_position_update(&mut self, latitude: f64, longitude: f64, source: &str) {
+        let delta_update = DeltaUpdate {
+            timestamp: Some(Utc::now()),
+            source: Some(source.to_string()),
+            meta: Vec::new(),
+            values: vec![DeltaValue::NavigationPosition {
+                path: "navigation.position".to_string(),
+                value: PositionValue {
+                    latitude,
+                    longitude,
+                },
+            }],
+        };
+        self.updates.push(delta_update);
+    }
+
     /// Add an AIS vessel update to the delta message.
     pub fn add_ais_vessel_update(&mut self, path: &str, vessel: &crate::ais::AisVesselApi) {
         let value = serde_json::to_value(vessel).unwrap_or(serde_json::Value::Null);
@@ -222,6 +239,14 @@ enum DeltaValue {
         /// Navigation value (radians for heading, m/s for speed, etc.)
         value: f64,
     },
+    /// Navigation position update (separate variant — Signal K position is
+    /// a `{latitude, longitude}` object, not a scalar).
+    NavigationPosition {
+        /// Always "navigation.position".
+        path: String,
+        /// `{latitude, longitude}` in decimal degrees.
+        value: PositionValue,
+    },
     /// AIS vessel update (structured data from AIS store)
     Ais {
         /// Vessel path (e.g., "vessels.227334400")
@@ -231,12 +256,21 @@ enum DeltaValue {
     },
 }
 
+/// Geographic position (decimal degrees) serialized to match the Signal K
+/// `navigation.position` payload shape.
+#[derive(Serialize, Clone, Debug, ToSchema)]
+pub(crate) struct PositionValue {
+    pub(crate) latitude: f64,
+    pub(crate) longitude: f64,
+}
+
 impl DeltaValue {
     fn path(&self) -> &str {
         match self {
             DeltaValue::Control { path, .. } => path,
             DeltaValue::Target { path, .. } => path,
             DeltaValue::Navigation { path, .. } => path,
+            DeltaValue::NavigationPosition { path, .. } => path,
             DeltaValue::Ais { path, .. } => path,
         }
     }

--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -35,7 +35,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -32,7 +32,6 @@ fn test_args() -> Cli {
         multiple_radar: false,
         openapi: false,
         transmit: false,
-        pass_ais: false,
         accept_invalid_certs: false,
         emulator: false,
         merge_targets: false,

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -26,8 +26,6 @@ export {
   acquireTargetAtPosition,
   registerAcquireTargetModeCallback,
   getRadarId,
-  subscribeToAis,
-  unsubscribeFromAis,
 };
 
 import van from "./vendor/van-1.5.2.js";
@@ -2120,53 +2118,6 @@ function setAcquireTargetMode(enabled) {
  */
 function registerAcquireTargetModeCallback(callback) {
   acquireTargetModeCallbacks.push(callback);
-}
-
-// ============================================================================
-// AIS Subscription Management
-// ============================================================================
-
-/**
- * Subscribe to AIS vessel updates
- */
-function subscribeToAis() {
-  if (!stateWebSocket || stateWebSocket.readyState !== WebSocket.OPEN) {
-    console.warn("Cannot subscribe to AIS: WebSocket not connected");
-    return;
-  }
-
-  const subscription = {
-    subscribe: [
-      {
-        path: "vessels.*",
-        policy: "instant",
-      },
-    ],
-  };
-
-  console.log("Subscribing to AIS vessels:", subscription);
-  stateWebSocket.send(JSON.stringify(subscription));
-}
-
-/**
- * Unsubscribe from AIS vessel updates
- */
-function unsubscribeFromAis() {
-  if (!stateWebSocket || stateWebSocket.readyState !== WebSocket.OPEN) {
-    console.warn("Cannot unsubscribe from AIS: WebSocket not connected");
-    return;
-  }
-
-  const desubscription = {
-    desubscribe: [
-      {
-        path: "vessels.*",
-      },
-    ],
-  };
-
-  console.log("Desubscribing from AIS vessels:", desubscription);
-  stateWebSocket.send(JSON.stringify(desubscription));
 }
 
 /**

--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -317,6 +317,87 @@ div.myr_ppi {
   display: none;
 }
 
+/* ============================================
+   AIS Lozenge - AIS overlay toggle (bottom-left)
+   ============================================ */
+
+.myr_ais_lozenge {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  display: flex;
+  align-items: stretch;
+  height: 36px;
+  background: rgba(0, 0, 0, 0.7);
+  border: 2px solid #446;
+  border-radius: 18px;
+  z-index: 100;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.myr_ais_lozenge_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  padding: 0;
+  background: #222;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.myr_ais_lozenge_button:hover {
+  background: #333;
+}
+
+.myr_ais_lozenge_button:active {
+  transform: scale(0.95);
+}
+
+.myr_ais_icon {
+  width: 20px;
+  height: 20px;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.myr_ais_lozenge.myr_ais_on .myr_ais_lozenge_button {
+  background: #1a3d4d;
+}
+
+.myr_ais_lozenge.myr_ais_on .myr_ais_icon {
+  stroke: #4dc8ff;
+}
+
+.myr_ais_lozenge.myr_ais_on .myr_ais_icon path:first-child {
+  fill: #4dc8ff;
+}
+
+.myr_ais_lozenge.myr_ais_on .myr_ais_outline {
+  stroke: #4dc8ff;
+}
+
+.myr_ais_lozenge.myr_ais_off .myr_ais_lozenge_button {
+  background: #2a2a2a;
+}
+
+.myr_ais_lozenge.myr_ais_off .myr_ais_icon {
+  stroke: #666;
+}
+
+.myr_ais_lozenge.myr_ais_off .myr_ais_icon path:first-child {
+  fill: #666;
+}
+
+.myr_ais_lozenge.myr_ais_off .myr_ais_outline {
+  stroke: #666;
+}
+
 /* Range lozenge - vertical, left side, centered */
 .myr_range_lozenge {
   position: absolute;

--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -357,6 +357,11 @@ div.myr_ppi {
   transform: scale(0.95);
 }
 
+.myr_ais_lozenge_button:focus-visible {
+  outline: 2px solid #4dc8ff;
+  outline-offset: 2px;
+}
+
 .myr_ais_icon {
   width: 20px;
   height: 20px;

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -24,8 +24,6 @@ import {
   getCurrentRangeDisplay,
   isAcquireTargetMode,
   acquireTargetAtPosition,
-  subscribeToAis,
-  unsubscribeFromAis,
 } from "./control.js";
 import { isStandaloneMode, detectMode } from "./api.js";
 import "./vendor/protobuf.min.js";
@@ -36,6 +34,12 @@ import { PPI } from "./ppi.js";
 
 var webSocket;
 var headingSocket;
+var aisSocket;
+const aisVesselState = new Map(); // mmsi → aggregated vessel snapshot
+// Own-ship identifiers learned from Signal K's REST snapshot (`tree.self`)
+// and via the vessel.mmsi field. Deltas matching either are dropped so the
+// operator's own MMSI never shows up as an AIS target on top of own ship.
+const ownShipIdentifiers = new Set();
 var RadarMessage;
 var ppi; // The PPI display instance
 var renderer; // The backend renderer (WebGPU or WebGL)
@@ -47,8 +51,6 @@ var headingMode = "headingUp";
 var trueHeading = 0; // in radians
 var lastLoggedHeading = null; // last heading value logged to console
 var lastHeadingTime = 0; // Timestamp of last heading update
-var headingTimeoutId = null; // Timer for heading timeout
-const HEADING_TIMEOUT_MS = 5000; // Revert to HU after 5 seconds without heading
 
 // Position display
 var lastRadarLat = null;
@@ -56,8 +58,14 @@ var lastRadarLon = null;
 var lastRadarHeading = null;
 var isStationary = false; // Set from server config
 
-// AIS display
-var showAis = null; // null = not yet received from server, then true/false
+// AIS overlay enabled state (client-only toggle, persists in localStorage)
+var showAis = (() => {
+  try {
+    return localStorage.getItem("mayaraShowAis") !== "false";
+  } catch {
+    return true;
+  }
+})();
 
 registerRadarCallback(radarLoaded);
 registerControlCallback(controlUpdate);
@@ -156,6 +164,9 @@ window.onload = async function () {
   // Create speaker lozenge (audio alerts toggle)
   createSpeakerLozenge();
 
+  // Create AIS lozenge (bottom-left, toggles vessels.* subscription)
+  createAisLozenge();
+
   // Create range lozenge
   createRangeLozenge();
 
@@ -187,13 +198,18 @@ function subscribeToHeading() {
 
   headingSocket.onopen = () => {
     console.log("Heading WebSocket connected");
+    // Also subscribe to own-ship position so the AIS overlay can place
+    // other vessels relative to us without waiting for radar spokes
+    // (which carry position metadata, but only while transmitting).
     const subscription = {
       context: "vessels.self",
       subscribe: [
-        {
-          path: "navigation.headingTrue",
-          period: 200,
-        },
+        { path: "navigation.headingTrue", period: 200 },
+        // Position drives AIS overlay placement — without this the
+        // overlay falls back to spoke metadata, which is only updated
+        // when the radar is transmitting and can disagree with the
+        // chartplotter GPS, causing visible target jumps.
+        { path: "navigation.position", period: 1000 },
       ],
     };
     headingSocket.send(JSON.stringify(subscription));
@@ -220,6 +236,23 @@ function subscribeToHeading() {
                 }
                 onHeadingReceived();
                 updateHeadingDisplay();
+              } else if (
+                value.path === "navigation.position" &&
+                value.value?.latitude != null &&
+                value.value?.longitude != null
+              ) {
+                // Routes through updatePositionBox so the on-screen
+                // ship-position display, the PPI's AIS reference point,
+                // and the lastRadarLat/Lon used by the AIS proximity
+                // filter all stay in sync regardless of radar TX state.
+                // Pass null for heading — the position delta tells us
+                // nothing about heading; preserve whatever the spoke
+                // handler (or a future heading source) has set.
+                updatePositionBox(
+                  value.value.latitude,
+                  value.value.longitude,
+                  null,
+                );
               }
             }
           }
@@ -236,8 +269,287 @@ function subscribeToHeading() {
 
   headingSocket.onclose = () => {
     console.log("Heading WebSocket closed, reconnecting in 5s...");
+    onHeadingLost();
     setTimeout(subscribeToHeading, 5000);
   };
+}
+
+// Subscribe to vessels.* on Signal K and aggregate per-MMSI updates into the
+// flat snapshot the PPI overlay expects. Works against both a real Signal K
+// server (deltas like `vessels.{mmsi}.navigation.position`) and standalone
+// mayara's `/signalk/v1/stream`, which serves `vessels.{mmsi}` with a flat
+// value from its AIS store.
+async function subscribeToAisViaSignalK() {
+  if (aisSocket) {
+    return; // already subscribed
+  }
+
+  // Re-render anything we still have in the local cache from a previous
+  // session (the cache survives unsubscribe). The operator sees vessels
+  // immediately while the prime fetch and WS deltas freshen the data.
+  if (ppi) {
+    for (const [mmsi, vessel] of aisVesselState) {
+      ppi.updateAisVessel(mmsi, vessel);
+    }
+  }
+
+  // Prime the local AIS cache from Signal K's REST snapshot before opening
+  // the WS. Without this, vessels only appear as upstream pushes deltas
+  // (~5-60s per vessel) so the operator sees the overlay fill in slowly.
+  // The prime also populates `ownShipIdentifiers` so the WS handler can
+  // filter own ship's MMSI-keyed deltas; awaiting here avoids a race where
+  // a delta arrives before the prime has learned the operator's MMSI.
+  // mayara standalone doesn't serve /v1/api/vessels/ — the fetch 404s and
+  // we fall through to the WS-only path.
+  await primeAisFromRestSnapshot();
+
+  if (!showAis) {
+    return; // operator turned AIS off while prime was in flight
+  }
+
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const streamUrl = `${wsProtocol}//${window.location.host}/signalk/v1/stream?subscribe=none`;
+
+  aisSocket = new WebSocket(streamUrl);
+
+  aisSocket.onopen = () => {
+    console.log("AIS WebSocket connected");
+    // `vessels.*` triggers mayara's AIS-store full-snapshot replay; the
+    // remaining leaf paths drive Signal K's incremental delta delivery
+    // under context = "vessels.*". Sending both lets one subscription work
+    // against either backend without having to detect mode first.
+    // mayara's stream subscriber rejects unknown bare-leaf paths (e.g.
+    // "name") with CannotParseControlId, which short-circuits the AIS
+    // snapshot. Stick to paths it knows: `vessels.*` triggers the full
+    // snapshot replay (which already includes vessel names), and the
+    // `navigation.*` leaves drive incremental deltas in plugin mode.
+    const subscription = {
+      context: "vessels.*",
+      subscribe: [
+        { path: "vessels.*", period: 1000 },
+        { path: "navigation.position", period: 1000 },
+        { path: "navigation.courseOverGroundTrue", period: 1000 },
+        { path: "navigation.speedOverGround", period: 1000 },
+        { path: "navigation.headingTrue", period: 1000 },
+      ],
+    };
+    aisSocket.send(JSON.stringify(subscription));
+  };
+
+  aisSocket.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.updates) {
+        for (const update of data.updates) {
+          handleAisDelta(data.context, update);
+        }
+      }
+    } catch (e) {
+      // Ignore parse errors (e.g., hello message)
+    }
+  };
+
+  aisSocket.onerror = (e) => {
+    console.log("AIS WebSocket error:", e);
+  };
+
+  aisSocket.onclose = () => {
+    aisSocket = null;
+    if (showAis) {
+      console.log("AIS WebSocket closed, reconnecting in 5s...");
+      setTimeout(() => {
+        if (showAis) subscribeToAisViaSignalK();
+      }, 5000);
+    }
+  };
+}
+
+// Fetch the full Signal K vessel tree once and populate the local AIS state
+// before WebSocket deltas start trickling in. Fire-and-forget; failures are
+// silent (mayara standalone doesn't serve this endpoint).
+async function primeAisFromRestSnapshot() {
+  try {
+    const res = await fetch("/signalk/v1/api/vessels/");
+    if (!res.ok) return;
+    const tree = await res.json();
+    const URN = "urn:mrn:imo:mmsi:";
+    const SK_UUID = "urn:mrn:signalk:uuid:";
+    // Any urn:mrn:signalk:uuid: entry represents own ship (or another
+    // local vessel without an MMSI yet). Skip those and remember any MMSI
+    // they carry so WS deltas keyed by that MMSI are filtered too.
+    for (const [ctxKey, vessel] of Object.entries(tree)) {
+      if (
+        ctxKey.startsWith(SK_UUID) &&
+        typeof vessel === "object" &&
+        vessel !== null
+      ) {
+        ownShipIdentifiers.add(ctxKey);
+        if (vessel.mmsi) ownShipIdentifiers.add(String(vessel.mmsi));
+      }
+    }
+    for (const [ctxKey, vessel] of Object.entries(tree)) {
+      if (typeof vessel !== "object" || vessel === null) continue;
+      if (ownShipIdentifiers.has(ctxKey)) continue;
+      let mmsi = ctxKey.startsWith(URN) ? ctxKey.slice(URN.length) : ctxKey;
+      if (!/^\d+$/.test(mmsi)) continue; // only IMO-MMSI vessels
+      if (ownShipIdentifiers.has(mmsi)) continue;
+      const nav = vessel.navigation;
+      const agg = aisVesselState.get(mmsi) || { mmsi, status: "Active" };
+      if (vessel.name?.value) agg.name = vessel.name.value;
+      if (nav?.position?.value) agg.position = nav.position.value;
+      if (nav?.courseOverGroundTrue?.value != null)
+        agg.cog = nav.courseOverGroundTrue.value;
+      if (nav?.speedOverGround?.value != null)
+        agg.sog = nav.speedOverGround.value;
+      if (nav?.headingTrue?.value != null)
+        agg.heading = nav.headingTrue.value;
+      if (!agg.position) continue;
+      aisVesselState.set(mmsi, agg);
+      if (ppi) ppi.updateAisVessel(mmsi, agg);
+    }
+    console.log(
+      `AIS primed from REST snapshot: ${aisVesselState.size} vessels`
+    );
+  } catch (e) {
+    // Network error, JSON parse error, or REST endpoint absent — no-op.
+  }
+}
+
+function unsubscribeFromAisViaSignalK() {
+  if (aisSocket) {
+    aisSocket.close();
+    aisSocket = null;
+  }
+  // Intentionally keep `aisVesselState` and `ownShipIdentifiers` populated
+  // across the toggle. When the operator re-enables AIS, the previous
+  // snapshot is rendered instantly and WS deltas (plus the on-connect REST
+  // prime) refresh it — better than starting empty and waiting for
+  // upstream to push each vessel again.
+  if (ppi) {
+    ppi.clearAisVessels();
+  }
+}
+
+// Apply a single Signal K delta update to the per-MMSI aggregate, then push
+// the merged snapshot to the PPI. Handles two delta shapes:
+//   - Real Signal K: context = `vessels.{mmsi}`, values[].path = leaf path
+//     (e.g. "navigation.position"). Aggregator promotes leaves to flat fields.
+//   - Mayara standalone: context = "vessels.*" wildcard, values[].path =
+//     `vessels.{mmsi}`, value = whole flat snapshot. Merged directly.
+function handleAisDelta(context, update) {
+  if (!update.values) return;
+
+  for (const item of update.values) {
+    let mmsi = null;
+    let leafPath = null;
+
+    if (item.path && item.path.startsWith("vessels.")) {
+      // Mayara-style: path = "vessels.{mmsi}", value = flat snapshot
+      mmsi = item.path.slice("vessels.".length);
+    } else if (context && context.startsWith("vessels.")) {
+      // Signal K-style: context = "vessels.{mmsi}", path = leaf
+      mmsi = context.slice("vessels.".length);
+      leafPath = item.path;
+    } else {
+      continue;
+    }
+
+    if (!mmsi || mmsi === "self" || mmsi === "*") continue;
+
+    // Strip the Signal K URN prefix so the bare MMSI shows in labels and acts
+    // as a stable map key across delta shapes.
+    const URN_PREFIX = "urn:mrn:imo:mmsi:";
+    if (mmsi.startsWith(URN_PREFIX)) {
+      mmsi = mmsi.slice(URN_PREFIX.length);
+    }
+
+    if (ownShipIdentifiers.has(mmsi)) continue;
+
+    const agg = aisVesselState.get(mmsi) || { mmsi, status: "Active" };
+
+    if (leafPath === null) {
+      // Mayara style: value is the full flat object
+      if (typeof item.value !== "object" || item.value === null) continue;
+      Object.assign(agg, item.value);
+    } else {
+      // Signal K style: promote leaf to flat field
+      switch (leafPath) {
+        case "navigation.position":
+          agg.position = item.value;
+          break;
+        case "navigation.courseOverGroundTrue":
+          agg.cog = item.value;
+          break;
+        case "navigation.speedOverGround":
+          agg.sog = item.value;
+          break;
+        case "navigation.headingTrue":
+          agg.heading = item.value;
+          break;
+        case "name":
+          agg.name = item.value;
+          break;
+        default:
+          continue; // unknown leaf — don't push a redundant update
+      }
+    }
+
+    // Position-proximity own-ship filter: if a vessel reports a position
+    // within ~75m of our last-known own-ship location, treat it as us and
+    // suppress. Picks up the operator's own AIS transmission that other
+    // receivers on the network echo back as a separate MMSI-keyed vessel.
+    // The threshold is generous enough to cover the gap between AIS
+    // (antenna) and GPS (chartplotter) positions on the same boat.
+    if (
+      agg.position &&
+      lastRadarLat != null &&
+      lastRadarLon != null &&
+      isSamePosition(agg.position, lastRadarLat, lastRadarLon)
+    ) {
+      ownShipIdentifiers.add(mmsi);
+      // If this MMSI was already on the PPI from earlier deltas
+      // (before it moved into the own-ship proximity bubble), evict it
+      // now — otherwise the stale target sticks until the operator
+      // moves and `evictOwnShipFromAis` runs.
+      if (aisVesselState.delete(mmsi) && ppi) {
+        ppi.removeAisVessel(mmsi);
+      }
+      continue;
+    }
+
+    aisVesselState.set(mmsi, agg);
+    if (ppi) {
+      ppi.updateAisVessel(mmsi, agg);
+    }
+  }
+}
+
+// Great-circle distance under ~75m. Approximates with equirectangular
+// projection — fine at this scale and avoids trig per delta.
+function isSamePosition(pos, refLat, refLon) {
+  const dLatM = (pos.latitude - refLat) * 111320;
+  const dLonM =
+    (pos.longitude - refLon) *
+    111320 *
+    Math.cos((refLat * Math.PI) / 180);
+  return dLatM * dLatM + dLonM * dLonM < 75 * 75;
+}
+
+// Remove any AIS vessel whose last-known position is close enough to be us.
+// Used after own-ship position becomes known to retroactively prune vessels
+// that were added before the proximity filter could run.
+function evictOwnShipFromAis() {
+  if (lastRadarLat == null || lastRadarLon == null) return;
+  for (const [mmsi, vessel] of aisVesselState) {
+    if (
+      vessel.position &&
+      isSamePosition(vessel.position, lastRadarLat, lastRadarLon)
+    ) {
+      ownShipIdentifiers.add(mmsi);
+      aisVesselState.delete(mmsi);
+      if (ppi) ppi.removeAisVessel(mmsi);
+    }
+  }
 }
 
 // Update PPI with current heading
@@ -248,7 +560,19 @@ function updateHeadingDisplay(mode) {
       return ppi.setHeadingMode(mode);
     }
   }
+  // Refresh the position box's HdgT field so it tracks the live
+  // Signal K heading even when the position itself isn't changing.
+  refreshPositionBoxHeading();
   return mode || headingMode;
+}
+
+function refreshPositionBoxHeading() {
+  const box = document.getElementById("myr_position_box");
+  if (!box) return;
+  const hdgEl = box.querySelector(".myr_pos_heading");
+  if (hdgEl && trueHeading != null && !Number.isNaN(trueHeading)) {
+    hdgEl.textContent = `HdgT: ${((trueHeading * 180) / Math.PI).toFixed(1)}°`;
+  }
 }
 
 // Coordinate format: 0 = DMS (degrees/minutes/seconds), 1 = DDM (degrees/decimal minutes), 2 = DD (decimal degrees)
@@ -268,7 +592,7 @@ function createPositionBox() {
     <div class="myr_pos_label">Ship Pos</div>
     <div class="myr_pos_coords">--°--'--" N</div>
     <div class="myr_pos_coords">--°--'--" E</div>
-    <div class="myr_pos_heading">Hdg: ---°</div>
+    <div class="myr_pos_heading">HdgT: ---°</div>
   `;
   box.addEventListener("click", cycleCoordFormat);
   container.appendChild(box);
@@ -338,6 +662,10 @@ function updatePositionBox(lat, lon, heading) {
   if (heading !== null && heading !== undefined) {
     lastRadarHeading = heading;
   }
+  // AIS deltas that arrived before own-ship position was known couldn't be
+  // checked against the proximity filter. Re-check them now and evict any
+  // that turn out to be us.
+  evictOwnShipFromAis();
 
   // Update PPI with own-ship position for AIS vessel relative positioning
   if (ppi && lat !== null && lon !== null) {
@@ -357,8 +685,12 @@ function updatePositionBox(lat, lon, heading) {
     coords[1].textContent = formatCoord(lon, false);
   }
 
-  if (hdgEl && lastRadarHeading !== null) {
-    hdgEl.textContent = `Hdg: ${lastRadarHeading.toFixed(1)}°`;
+  // Use the Signal K true heading (navigation.headingTrue) rather than the
+  // spoke-derived value. The radar's inline bearing field encodes heading
+  // in brand-specific units and is unreliable as a navigation display;
+  // Signal K's stream is the authoritative source.
+  if (hdgEl && trueHeading != null && !Number.isNaN(trueHeading)) {
+    hdgEl.textContent = `HdgT: ${((trueHeading * 180) / Math.PI).toFixed(1)}°`;
   }
 
   box.style.display = "block";
@@ -400,31 +732,25 @@ function createHeadingModeToggle() {
   container.appendChild(toggleBtn);
 }
 
-// Called when heading data is received
+// Called when heading data is received. Mayara's heading stream is
+// event-driven (initial snapshot + broadcast on change), so silence means
+// "heading is stable" — not "heading is stale". Don't disable the toggle
+// on silence; let the socket-close path handle real loss-of-source.
 function onHeadingReceived() {
   lastHeadingTime = Date.now();
 
-  // Enable the heading toggle button
   const toggleBtn = document.getElementById("myr_heading_toggle");
   if (toggleBtn) {
     toggleBtn.classList.remove("myr_heading_disabled");
     toggleBtn.title = "Click to toggle: Heading Up / North Up";
   }
-
-  // Clear existing timeout and set a new one
-  if (headingTimeoutId) {
-    clearTimeout(headingTimeoutId);
-  }
-  headingTimeoutId = setTimeout(onHeadingTimeout, HEADING_TIMEOUT_MS);
 }
 
-// Called when heading data times out (not received for 5 seconds)
-function onHeadingTimeout() {
-  headingTimeoutId = null;
-  console.log("Heading data lost");
+// Called when the heading WebSocket closes — true loss of source.
+function onHeadingLost() {
+  console.log("Heading source lost");
   lastLoggedHeading = null;
 
-  // Revert to heading-up mode
   if (headingMode !== "headingUp") {
     headingMode = "headingUp";
     updateHeadingDisplay(headingMode);
@@ -433,7 +759,6 @@ function onHeadingTimeout() {
     }
   }
 
-  // Disable the toggle button
   const toggleBtn = document.getElementById("myr_heading_toggle");
   if (toggleBtn) {
     toggleBtn.classList.add("myr_heading_disabled");
@@ -548,6 +873,63 @@ function updateSpeakerLozenge() {
   } else {
     lozenge.classList.add("myr_speaker_off");
   }
+}
+
+// Create the AIS overlay toggle lozenge (bottom-left, mirrors the speaker
+// lozenge in the top-left). Click toggles vessels.* subscription on/off.
+function createAisLozenge() {
+  const container = document.querySelector(".myr_ppi");
+  if (!container) return;
+
+  const lozenge = document.createElement("div");
+  lozenge.id = "myr_ais_lozenge";
+  lozenge.className =
+    "myr_ais_lozenge " + (showAis ? "myr_ais_on" : "myr_ais_off");
+  lozenge.title = "Click to toggle AIS overlay";
+
+  const aisBtn = document.createElement("button");
+  aisBtn.className = "myr_ais_lozenge_button";
+  // Two-vessel pictogram (filled triangle + smaller outline triangle)
+  aisBtn.innerHTML = `<svg class="myr_ais_icon" viewBox="0 0 24 24">
+    <path d="M8 4 L13 17 L8 14 L3 17 Z"/>
+    <path class="myr_ais_outline" d="M17 9 L20 17 L17 15 L14 17 Z" fill="none"/>
+  </svg>`;
+  aisBtn.addEventListener("click", toggleAisOverlay);
+
+  lozenge.appendChild(aisBtn);
+  container.appendChild(lozenge);
+
+  if (showAis) {
+    subscribeToAisViaSignalK();
+  }
+  if (ppi) {
+    ppi.setShowAis(showAis);
+  }
+}
+
+function toggleAisOverlay() {
+  showAis = !showAis;
+  try {
+    localStorage.setItem("mayaraShowAis", String(showAis));
+  } catch {
+    // ignore quota errors
+  }
+  if (showAis) {
+    subscribeToAisViaSignalK();
+  } else {
+    unsubscribeFromAisViaSignalK();
+  }
+  if (ppi) {
+    ppi.setShowAis(showAis);
+  }
+  updateAisLozenge();
+}
+
+function updateAisLozenge() {
+  const lozenge = document.getElementById("myr_ais_lozenge");
+  if (!lozenge) return;
+  lozenge.classList.remove("myr_ais_on", "myr_ais_off");
+  lozenge.classList.add(showAis ? "myr_ais_on" : "myr_ais_off");
 }
 
 // Play an audio alert
@@ -888,23 +1270,6 @@ function controlUpdate(controlId, value) {
     if (index >= 0 && index < 4 && ppi) {
       ppi.setNoTransmitSector(index, parseNoTransmitSector(value));
     }
-  } else if (controlId === "showAis") {
-    const newShowAis = value.value === 1;
-    // Subscribe or unsubscribe based on state change
-    // showAis === null means first time receiving control from server
-    if (newShowAis && (showAis === null || !showAis)) {
-      subscribeToAis();
-    } else if (!newShowAis && (showAis === null || showAis)) {
-      unsubscribeFromAis();
-      // Clear all AIS vessels from display when turning off
-      if (ppi) {
-        ppi.clearAisVessels();
-      }
-    }
-    showAis = newShowAis;
-    if (ppi) {
-      ppi.setShowAis(showAis);
-    }
   } else {
     const control = getControl(controlId);
     if (control?.name === "Range") {
@@ -949,22 +1314,8 @@ function handleStreamMessage(path, value) {
     }
   }
 
-  // Handle AIS vessel updates: vessels.{mmsi}
-  if (path.startsWith("vessels.") && !path.includes("radars")) {
-    const parts = path.split(".");
-    if (parts.length >= 2) {
-      const mmsi = parts[1];
-      if (ppi) {
-        if (value === null || value.status === "Lost") {
-          // Vessel lost
-          ppi.removeAisVessel(mmsi);
-        } else {
-          // Vessel update
-          ppi.updateAisVessel(mmsi, value);
-        }
-      }
-    }
-  }
+  // AIS vessels are handled by subscribeToAisViaSignalK on a dedicated
+  // Signal K WebSocket, not via the radar state stream.
 }
 
 // Parse guard zone control value into drawing parameters

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -310,9 +310,13 @@ async function subscribeToAisViaSignalK() {
   const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
   const streamUrl = `${wsProtocol}//${window.location.host}/signalk/v1/stream?subscribe=none`;
 
-  aisSocket = new WebSocket(streamUrl);
+  // Hold a local reference so handlers that fire after `aisSocket` is
+  // replaced (e.g. a late `onclose` from a previous socket) can detect
+  // they're stale and skip teardown / reconnect work.
+  const socket = new WebSocket(streamUrl);
+  aisSocket = socket;
 
-  aisSocket.onopen = () => {
+  socket.onopen = () => {
     console.log("AIS WebSocket connected");
     // `vessels.*` triggers mayara's AIS-store full-snapshot replay; the
     // remaining leaf paths drive Signal K's incremental delta delivery
@@ -333,10 +337,10 @@ async function subscribeToAisViaSignalK() {
         { path: "navigation.headingTrue", period: 1000 },
       ],
     };
-    aisSocket.send(JSON.stringify(subscription));
+    socket.send(JSON.stringify(subscription));
   };
 
-  aisSocket.onmessage = (event) => {
+  socket.onmessage = (event) => {
     try {
       const data = JSON.parse(event.data);
       if (data.updates) {
@@ -349,11 +353,12 @@ async function subscribeToAisViaSignalK() {
     }
   };
 
-  aisSocket.onerror = (e) => {
+  socket.onerror = (e) => {
     console.log("AIS WebSocket error:", e);
   };
 
-  aisSocket.onclose = () => {
+  socket.onclose = () => {
+    if (aisSocket !== socket) return; // stale close from a replaced socket
     aisSocket = null;
     if (showAis) {
       console.log("AIS WebSocket closed, reconnecting in 5s...");


### PR DESCRIPTION
## Summary

The GUI's AIS overlay previously piggy-backed on the radar control state stream, which in plugin mode points at a Signal K endpoint that doesn't exist (`/signalk/v2/.../radar/stream`, 404). It only worked standalone because mayara serves the same socket path. Move AIS to its own WebSocket subscription on `/signalk/v1/stream` — the same pattern the heading subscription already uses.

A bottom-left lozenge toggles the overlay on/off (state persists in localStorage). The single subscription works against both real Signal K (incremental `vessels.{mmsi}.navigation.*` deltas) and standalone mayara (`--pass-ais` flat-snapshot replay on `vessels.*`); an aggregator collapses both into the flat shape `ppi.updateAisVessel()` already expects.

To keep own ship out of the overlay, filter by Signal K `self` UUID, by own-ship MMSI learned from the REST snapshot, and by proximity to `lastRadarLat/Lon`. The proximity filter back-evicts vessels added before own-ship position became known.

Three server-side changes support the new GUI pattern:

- Broadcast own-ship `navigation.position` from `set_position()` (was scalar-only; added a structured `NavigationPosition` delta variant with a ~1m change-detection threshold to avoid GPS-jitter spam).
- On client subscribe, send a one-shot snapshot of any subscribed navigation paths so freshly-connected clients see a value immediately instead of waiting for the next upstream change.
- Stop feeding `set_heading_true` from the per-spoke radar receive loop. Pushing the radar's inline bearing through navdata caused kHz-rate broadcasts that raced the authoritative compass source. The PPI continues to use `spoke.bearing` directly, so single-radar displays are unaffected.
- Remove the now-dead `ShowAis` server control.

Closes #61.

## Tested

- Verified end-to-end against a live Signal K (66 vessels) and a live mayara `--pass-ais` instance pointing at the same upstream
- Confirmed in-browser with a real Furuno DRS4D-NXT: AIS overlay renders, own ship (MMSI in the local AIS receiver) is correctly filtered, lozenge toggle works
- `cargo test --release --lib` — 201 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refactors AIS overlay handling so the GUI subscribes directly to Signal K vessel data instead of relying on the radar control state stream, removing the need for the server-side --pass-ais flag. The GUI opens a dedicated Signal K WebSocket for AIS, presents a bottom-left lozenge UI toggle persisted to localStorage (AIS cache survives toggles), and normalizes upstream deltas and flat snapshots into the flat vessel form expected by the PPI overlay. URN prefixes are stripped so MMSI is used as the map key/label. Own-ship vessels are filtered by Signal K self UUID, by own-ship MMSI learned from the REST snapshot, and by proximity to the last known radar position; vessels added before own-ship position is known are retroactively evicted when own-ship position becomes available. Heading display uses Signal K navigation.headingTrue and position updates route via navigation.position.

## Server-side Changes

- AIS is always enabled (the CLI field pass_ais is removed). The server seeds the local AIS store from the upstream Signal K REST snapshot via seed_ais_from_upstream(accept_invalid_certs: bool), with bounded retry logic and optional acceptance of invalid TLS certs.
- Navigation position is broadcast as a structured navigation.position delta (new DeltaValue::NavigationPosition and SignalKDelta::add_position_update) and set_position(lat, lon, source) applies ~1 m hysteresis to suppress GPS jitter before broadcasting.
- The WebSocket subscription handler sends a one-shot snapshot of currently subscribed navigation paths (position/heading) immediately after subscribe so newly-connected clients receive current values.
- Per-spoke feeding of set_heading_true is removed to avoid high-rate broadcasts and races; PPI continues to use spoke.bearing for rotation.
- Discovery parsing captures and caches the upstream HTTP REST base URL (UPSTREAM_HTTP_BASE and get_upstream_http_base()) for use during AIS seeding.
- Signal K routing upgrades and caches own-ship context on first relevant context after vessels.self, routes non-own-ship deltas into the AIS store, and applies own-ship navigation updates locally.
- Background AIS subsystems run unconditionally: periodic AIS timeout checking (~30s) marks timed-out vessels lost and a tight-interval (~50ms) AIS broadcast flush coalesces pending AIS updates.
- Remove ShowAis server control and related control metadata/mappings.

## Client-side & GUI Changes

- viewer.js introduces subscribeToAisViaSignalK(), which opens a separate Signal K WebSocket subscribed to vessels.* and navigation leaves, primes per-MMSI vessel state from a REST snapshot, merges incoming deltas (supporting both Signal K incremental and mayara flat snapshots), and calls ppi.updateAisVessel() with normalized flat vessels.
- AIS visibility becomes a client-only boolean persisted in localStorage and exposed via a new bottom-left lozenge UI (CSS + control.js/viewer.js changes). Toggling unsubscribes/subscribes the AIS WebSocket; the AIS aggregation cache survives toggles and unsubscribes clear the PPI’s AIS vessels.
- The heading subscription also subscribes to navigation.position so the position box and AIS reference point remain synchronized even when radar spokes stop; heading loss is handled by reconnect logic rather than timeout heuristics.
- The radar control stream no longer processes vessels.* AIS updates; AIS handling moves exclusively to the dedicated Signal K AIS WebSocket. ShowAis control wiring is removed from the radar controls.

## API & Signature Changes

- navdata.rs:
  - set_position(lat, lon, source: &str) adds source provenance and hysteresis-based broadcast suppression.
  - get_heading_true() and get_position() become pub so bin crates can read them.
  - seed_ais_from_upstream(accept_invalid_certs: bool) is added.
- stream.rs: DeltaValue gains a NavigationPosition variant and SignalKDelta gains add_position_update(latitude, longitude, source).
- signalk.rs: DiscoveryResult gains http_url and code caches the upstream HTTP base URL with get_upstream_http_base().
- radar settings: ControlId removes ShowAis and related mappings.
- CLI: pass_ais field is removed; USAGE.md removes --pass-ais and documents new --accept-invalid-certs option.

## Testing & Verification

- End-to-end verification against a live Signal K (66 vessels) and mayara --pass-ais replay instance; in-browser verification with a Furuno DRS4D‑NXT confirms AIS overlay rendering, own-ship filtering, and lozenge toggle behavior.
- Unit tests: cargo test --release --lib passes (201 tests).
- This change closes the linked issue about replacing the --pass-ais flag by enabling clients to subscribe to all vessels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->