### PR TITLE
fix(gui): keep guard-zone buttons inside the card on narrow panels

### DIFF
--- a/web/gui/controls.css
+++ b/web/gui/controls.css
@@ -827,6 +827,7 @@ div.myr_range_buttons {
 
 .myr_zone_buttons {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 12px;
   justify-content: flex-end;
@@ -835,7 +836,9 @@ div.myr_range_buttons {
 .myr_zone_draw_btn,
 .myr_zone_cancel_btn,
 .myr_zone_save_btn {
-  padding: 6px 16px;
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 6px 8px;
   font-size: 12px;
   font-weight: bold;
   border: 2px solid #446;


### PR DESCRIPTION
The controller side panel has a narrow content area (~208px wide). With `padding: 6px 16px` on each button, Draw/Cancel/Save totalled ~237px and overflowed the flex row. Combined with `justify-content: flex-end`, the leftmost button (Draw) overflowed to the left and visually escaped the card's border, making the layout look broken.

## Fix

- `.myr_zone_buttons`: add `flex-wrap: wrap` as a safety net for ultra-narrow widths.
- Buttons: `flex: 1 1 0; min-width: 0;` so the three buttons share the row equally, and `padding: 6px 8px` (down from `16px`) so they fit comfortably without truncation.

This also applies to the exclusion-rectangle controls, which reuse the same `myr_zone_buttons` / `myr_zone_*_btn` classes.

## Tested

- Verified with Playwright at the default narrow side-panel width (208px content area): all three buttons render inside the card on one row, equal-width.
- Verified at desktop viewport (1400×900): same single-row layout.

closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes a layout overflow issue in guard-zone controls where buttons escape the card border on narrow side panels.

## Changes

**web/gui/controls.css**

Modifies the `.myr_zone_buttons` container and its child button elements to prevent overflow:
- Adds `flex-wrap: wrap` to `.myr_zone_buttons` to allow buttons to wrap if needed
- Updates `.myr_zone_draw_btn`, `.myr_zone_cancel_btn`, and `.myr_zone_save_btn` to:
  - Use `flex: 1 1 0` and `min-width: 0` to make buttons share the row equally with flexible sizing
  - Reduce horizontal padding from `6px 16px` to `6px 8px` for tighter spacing
- The same styling pattern applies to exclusion-rectangle button controls

These changes keep the three zone action buttons (Draw/Cancel/Save) contained within the ~208px wide controller side panel content area by distributing width equally among buttons and reducing padding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->