### PR TITLE
test(replay): gate replay_*.rs on pcap-replay feature

### DIFF
--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Furuno DRS4D-NXT pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Furuno DRS2D pcap fixture.
 //!
 //! Regression for the spoke-alignment overshoot panic on the last spoke of a

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Furuno DRS25A-NXT NND demo recording.
 //!
 //! Verifies that replaying a TZtouch3 `.nnd.gz` demo file through the

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Garmin xHD pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Navico 4G pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Navico BR24 pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Navico HALO20+ pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Navico HALO24 pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Navico HALO3006 pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcap-replay")]
+
 //! Integration test: replay Raymarine Quantum pcap fixture.
 //!
 //! Verifies that replaying the fixture through the full pipeline


### PR DESCRIPTION
The 10 `tests/replay_*.rs` integration tests reference symbols that are gated behind `#[cfg(feature = "pcap-replay")]` in the library:

- `mayara::replay::init`
- `mayara::replay::set_instant_timing`
- `Cli { pcap, repeat, .. }`

Without the feature, those items don't exist and each test crate fails to compile with `E0425` (no such function) and `E0560` (no such struct field). That breaks plain `cargo test` for anyone who doesn't know to add `--features pcap-replay`.

## Fix

Add a crate-level `#![cfg(feature = "pcap-replay")]` to the top of each `replay_*.rs`. When the feature is off, the test crate compiles to empty (0 tests); when it's on, the replay test runs as before.

## Tested

- `cargo test --release` (default features): now compiles cleanly; each replay test crate reports `0 passed; 0 failed`.
- `cargo test --release --features pcap-replay`: all 10 replay tests run and pass (`replay_furuno`, `replay_furuno_drs2d`, `replay_furuno_nnd`, `replay_garmin`, `replay_navico_4g`, `replay_navico_br24`, `replay_navico_halo20plus`, `replay_navico_halo24`, `replay_navico_halo3006`, `replay_raymarine`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR gates ten integration test files behind the `pcap-replay` Cargo feature to resolve compilation errors when the feature is disabled.

## Problem

The integration test crates in `tests/replay_*.rs` reference library items conditionally compiled with `#[cfg(feature = "pcap-replay")]`, including `mayara::replay::init`, `mayara::replay::set_instant_timing`, and `Cli { pcap, repeat, .. }`. Without the `pcap-replay` feature enabled, these symbols are absent, causing compile errors and breaking `cargo test` for users who don't enable the feature.

## Solution

The PR adds a crate-level `#![cfg(feature = "pcap-replay")]` attribute at the top of each of the ten replay test files:
- `tests/replay_furuno.rs`
- `tests/replay_furuno_drs2d.rs`
- `tests/replay_furuno_nnd.rs`
- `tests/replay_garmin.rs`
- `tests/replay_navico_4g.rs`
- `tests/replay_navico_br24.rs`
- `tests/replay_navico_halo20plus.rs`
- `tests/replay_navico_halo24.rs`
- `tests/replay_navico_halo3006.rs`
- `tests/replay_raymarine.rs`

When the `pcap-replay` feature is disabled, each test crate compiles to empty (0 tests). When enabled with `--features pcap-replay`, all replay tests run and pass as before.

## Changes

Each of the ten test files receives a 2-line addition (+2/-0) of the conditional compilation attribute, with no changes to test logic or public entity declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->