### PR TITLE
fix(deps): migrate to tokio-graceful-shutdown 0.19 closure API

### DIFF
--- a/src/bin/mayara-server/main.rs
+++ b/src/bin/mayara-server/main.rs
@@ -7,7 +7,7 @@ use log::{info, warn};
 use miette::IntoDiagnostic;
 use miette::Result;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 use web::Web;
 
 mod web;
@@ -73,9 +73,12 @@ async fn main() -> Result<()> {
 
     RecordingManager::new().cleanup_orphaned_uploads();
 
-    Toplevel::new(|s| async move {
-        let web = Web::new(&s, args).await;
-        s.start(SubsystemBuilder::new("Webserver", move |a| web.run(a)));
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
+        let web = Web::new(&*s, args).await;
+        s.start(SubsystemBuilder::new(
+            "Webserver",
+            async move |a: &mut SubsystemHandle| web.run(a).await,
+        ));
     })
     .catch_signals()
     .handle_shutdown_requests(Duration::from_millis(5000))

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -137,7 +137,7 @@ impl Web {
         }
     }
 
-    pub async fn run(self, subsys: SubsystemHandle) -> Result<(), WebError> {
+    pub async fn run(self, subsys: &mut SubsystemHandle) -> Result<(), WebError> {
         let port = self.args.port;
         let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port);
         let socket = socket2::Socket::new(

--- a/src/lib/brand/emulator/mod.rs
+++ b/src/lib/brand/emulator/mod.rs
@@ -141,8 +141,9 @@ pub(crate) fn create_emulator_radar(args: &Cli, radars: &SharedRadars, subsys: &
         let report_name = info.key() + " reports";
         let report_receiver = report::EmulatorReportReceiver::new(args, info, radars.clone());
 
-        subsys.start(SubsystemBuilder::new(report_name, |s| {
-            report_receiver.run(s)
-        }));
+        subsys.start(SubsystemBuilder::new(
+            report_name,
+            async move |s: &mut SubsystemHandle| report_receiver.run(s).await,
+        ));
     }
 }

--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -82,7 +82,7 @@ impl EmulatorReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+    pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         // Set initial status to Transmit in emulator mode
         self.common
             .set_value(&ControlId::Power, Power::Transmit as i32 as f64);

--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -82,7 +82,7 @@ impl EmulatorReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         // Set initial status to Transmit in emulator mode
         self.common
             .set_value(&ControlId::Power, Power::Transmit as i32 as f64);

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -157,9 +157,10 @@ impl FurunoLocator {
             if let Some(ib) = info_b {
                 report_receiver.set_range_b(&self.args, radars, ib);
             }
-            subsys.start(SubsystemBuilder::new(report_name, |s| {
-                report_receiver.run(s)
-            }));
+            subsys.start(SubsystemBuilder::new(
+                report_name,
+                async move |s: &mut SubsystemHandle| report_receiver.run(s).await,
+            ));
         }
     }
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -350,7 +350,7 @@ impl FurunoReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+    pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         loop {
             // Each time we start the loop, there is no stream
             // and none of the data sockets are open.

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -350,7 +350,7 @@ impl FurunoReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         loop {
             // Each time we start the loop, there is no stream
             // and none of the data sockets are open.

--- a/src/lib/brand/garmin/mod.rs
+++ b/src/lib/brand/garmin/mod.rs
@@ -191,9 +191,10 @@ impl GarminLocator {
                 }
             }
 
-            subsys.start(SubsystemBuilder::new(report_name, |s| {
-                report_receiver.run(s)
-            }));
+            subsys.start(SubsystemBuilder::new(
+                report_name,
+                async move |s: &mut SubsystemHandle| report_receiver.run(s).await,
+            ));
         }
     }
 

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -391,7 +391,7 @@ impl GarminReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         loop {
             if let Err(e) = self.start_sockets().await {
                 log::warn!("{}: Failed to start sockets: {}", self.common.key, e);

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -391,7 +391,7 @@ impl GarminReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+    pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         loop {
             if let Err(e) = self.start_sockets().await {
                 log::warn!("{}: Failed to start sockets: {}", self.common.key, e);

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -130,9 +130,10 @@ impl KodenLocator {
 
             let report_receiver =
                 report::KodenReportReceiver::new(&self.args, radars.clone(), info);
-            subsys.start(SubsystemBuilder::new(report_name, |s| {
-                report_receiver.run(s)
-            }));
+            subsys.start(SubsystemBuilder::new(
+                report_name,
+                async move |s: &mut SubsystemHandle| report_receiver.run(s).await,
+            ));
         }
     }
 }

--- a/src/lib/brand/koden/report.rs
+++ b/src/lib/brand/koden/report.rs
@@ -46,7 +46,7 @@ impl KodenReportReceiver {
         }
     }
 
-    pub(crate) async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    pub(crate) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         loop {
             if let Err(e) = self.data_loop(&subsys).await {
                 log::error!("{}: Data loop error: {}, restarting", self.common.key, e);

--- a/src/lib/brand/navico/mod.rs
+++ b/src/lib/brand/navico/mod.rs
@@ -391,9 +391,10 @@ impl NavicoLocator {
             let report_receiver =
                 report::NavicoReportReceiver::new(&self.args, info, radars.clone());
 
-            subsys.start(SubsystemBuilder::new(report_name, |s| {
-                report_receiver.run(s)
-            }));
+            subsys.start(SubsystemBuilder::new(
+                report_name,
+                async move |s: &mut SubsystemHandle| report_receiver.run(s).await,
+            ));
         }
     }
 }

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -442,7 +442,7 @@ impl NavicoReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+    pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         self.start_report_socket()?;
         loop {
             match self.socket_loop(&subsys).await {

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -442,7 +442,7 @@ impl NavicoReportReceiver {
         }
     }
 
-    pub async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         self.start_report_socket()?;
         loop {
             match self.socket_loop(&subsys).await {

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -471,22 +471,27 @@ impl RaymarineLocator {
             let send_addr = info.send_command_addr;
             let nic_addr = info.nic_addr;
             let navdata_name = format!("{}-navdata", report_name);
-            subsys.start(SubsystemBuilder::new(navdata_name, move |s| async move {
-                match crate::network::create_multicast_send(&send_addr, &nic_addr) {
+            subsys.start(SubsystemBuilder::new(
+                navdata_name,
+                async move |s: &mut SubsystemHandle| match crate::network::create_multicast_send(
+                    &send_addr,
+                    &nic_addr,
+                ) {
                     Ok(sock) => navdata::run(s, sock).await.map_err(|e| e.into()),
                     Err(e) => {
                         log::warn!("Failed to create NavData socket: {}", e);
                         Ok::<(), anyhow::Error>(())
                     }
-                }
-            }));
+                },
+            ));
 
             let report_receiver =
                 report::RaymarineReportReceiver::new(&self.args, info, radars.clone());
 
-            subsys.start(SubsystemBuilder::new(report_name, |s| {
-                report_receiver.run(s)
-            }));
+            subsys.start(SubsystemBuilder::new(
+                report_name,
+                async move |s: &mut SubsystemHandle| report_receiver.run(s).await,
+            ));
         }
     }
 }

--- a/src/lib/brand/raymarine/navdata.rs
+++ b/src/lib/brand/raymarine/navdata.rs
@@ -41,7 +41,7 @@ fn radians_to_fixed(rad: f64) -> i32 {
 
 /// Run the NavData sender loop. Sends position/heading to the radar
 /// every 100ms for as long as the subsystem is alive.
-pub async fn run(subsys: SubsystemHandle, socket: UdpSocket) -> Result<(), RadarError> {
+pub async fn run(subsys: &mut SubsystemHandle, socket: UdpSocket) -> Result<(), RadarError> {
     let mut deadline = Instant::now() + NAVDATA_INTERVAL;
 
     loop {

--- a/src/lib/brand/raymarine/navdata.rs
+++ b/src/lib/brand/raymarine/navdata.rs
@@ -41,7 +41,7 @@ fn radians_to_fixed(rad: f64) -> i32 {
 
 /// Run the NavData sender loop. Sends position/heading to the radar
 /// every 100ms for as long as the subsystem is alive.
-pub async fn run(subsys: &mut SubsystemHandle, socket: UdpSocket) -> Result<(), RadarError> {
+pub(super) async fn run(subsys: &mut SubsystemHandle, socket: UdpSocket) -> Result<(), RadarError> {
     let mut deadline = Instant::now() + NAVDATA_INTERVAL;
 
     loop {

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -251,7 +251,7 @@ impl RaymarineReportReceiver {
         Ok(())
     }
 
-    pub async fn run(mut self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         self.start_report_socket().await?;
         loop {
             if self.report_socket.is_some() {

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -251,7 +251,7 @@ impl RaymarineReportReceiver {
         Ok(())
     }
 
-    pub async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+    pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         self.start_report_socket().await?;
         loop {
             if self.report_socket.is_some() {

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -85,7 +85,7 @@ impl Locator {
 
     pub async fn run(
         self,
-        subsys: SubsystemHandle,
+        subsys: &mut SubsystemHandle,
         tx_ip_change: broadcast::Sender<()>,
         tx_interface_request: broadcast::Sender<Option<mpsc::Sender<InterfaceApi>>>,
     ) -> Result<(), RadarError> {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -413,7 +413,7 @@ pub async fn start_session(
 
         subsystem.start(SubsystemBuilder::new(
             "TrackerManager",
-            |subsys| async move {
+            async move |subsys: &mut SubsystemHandle| {
                 tokio::select! { biased;
                     _ = subsys.on_shutdown_requested() => {
                         log::debug!("TrackerManager shutdown requested");
@@ -447,7 +447,7 @@ pub async fn start_session(
 
             subsystem.start(SubsystemBuilder::new(
                 "Static Navigation",
-                |subsys| async move {
+                async move |subsys: &mut SubsystemHandle| {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
                         STATIC_NAV_REBROADCAST_INTERVAL_SECS,
                     ));
@@ -479,7 +479,7 @@ pub async fn start_session(
         navdata::init_ais_store(radars.get_sk_client_tx());
 
         // Start background task to check for AIS vessel timeouts (every 30 seconds)
-        subsystem.start(SubsystemBuilder::new("AIS Timeout", |subsys| async move {
+        subsystem.start(SubsystemBuilder::new("AIS Timeout", async move |subsys: &mut SubsystemHandle| {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
             loop {
                 tokio::select! { biased;
@@ -504,7 +504,7 @@ pub async fn start_session(
         // This coalesces rapid updates into single broadcasts
         subsystem.start(SubsystemBuilder::new(
             "AIS Broadcast",
-            |subsys| async move {
+            async move |subsys: &mut SubsystemHandle| {
                 let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
                 loop {
                     tokio::select! { biased;
@@ -530,19 +530,25 @@ pub async fn start_session(
     let mut navdata = navdata::NavigationData::new(args.clone());
 
     let rx_ip_change_clone = tx_ip_change.subscribe();
-    subsystem.start(SubsystemBuilder::new("NavData", |subsys| async move {
-        navdata.run(subsys, rx_ip_change_clone).await
-    }));
+    subsystem.start(SubsystemBuilder::new(
+        "NavData",
+        async move |subsys: &mut SubsystemHandle| {
+            navdata.run(subsys, rx_ip_change_clone).await
+        },
+    ));
     let tx_interface_request_clone = tx_interface_request.clone();
-    subsystem.start(SubsystemBuilder::new("Locator", |subsys| {
-        locator.run(subsys, tx_ip_change, tx_interface_request_clone)
-    }));
+    subsystem.start(SubsystemBuilder::new(
+        "Locator",
+        async move |subsys: &mut SubsystemHandle| {
+            locator.run(subsys, tx_ip_change, tx_interface_request_clone).await
+        },
+    ));
 
     // Start pcap replay dispatcher after the locator (which registers listeners)
     #[cfg(feature = "pcap-replay")]
     if replay::is_active() {
         let repeat = args.repeat;
-        subsystem.start(SubsystemBuilder::new("PcapReplay", move |subsys| async move {
+        subsystem.start(SubsystemBuilder::new("PcapReplay", async move |subsys: &mut SubsystemHandle| {
             tokio::select! { biased;
                 _ = subsys.on_shutdown_requested() => {
                     log::debug!("PcapReplay shutdown requested");

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -330,7 +330,7 @@ impl NavigationData {
 
     pub(crate) async fn run(
         &mut self,
-        subsys: SubsystemHandle,
+        subsys: &mut SubsystemHandle,
         rx_ip_change: Receiver<()>,
     ) -> Result<(), Error> {
         // In NND replay mode, consume NMEA sentences from the replay channel

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -564,13 +564,14 @@ impl RadarInfo {
         if self.output {
             let info_clone2 = self.clone();
 
-            subsys.start(SubsystemBuilder::new("stdout", move |s| {
-                info_clone2.forward_output(s)
-            }));
+            subsys.start(SubsystemBuilder::new(
+                "stdout",
+                async move |s: &mut SubsystemHandle| info_clone2.forward_output(s).await,
+            ));
         }
     }
 
-    async fn forward_output(self, subsys: SubsystemHandle) -> Result<(), RadarError> {
+    async fn forward_output(self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         use std::io::Write;
 
         let mut rx = self.message_tx.subscribe();

--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -8,7 +8,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -56,10 +56,10 @@ async fn replay_furuno_drs4dnxt() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -11,7 +11,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -60,10 +60,10 @@ async fn replay_furuno_drs2d() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -8,7 +8,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -56,10 +56,10 @@ async fn replay_furuno_nnd() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -8,7 +8,7 @@
 use mayara::{replay, Cli};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -56,10 +56,10 @@ async fn replay_garmin_xhd() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -8,7 +8,7 @@
 use mayara::{replay, Cli};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -57,10 +57,10 @@ async fn replay_navico_4g() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -8,7 +8,7 @@
 use mayara::{replay, Cli};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -57,10 +57,10 @@ async fn replay_navico_br24() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -8,7 +8,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -57,10 +57,10 @@ async fn replay_navico_halo20plus() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -8,7 +8,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -57,10 +57,10 @@ async fn replay_navico_halo24() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -8,7 +8,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -56,10 +56,10 @@ async fn replay_navico_halo3006() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -8,7 +8,7 @@
 use mayara::{Cli, replay};
 use std::path::Path;
 use std::time::Duration;
-use tokio_graceful_shutdown::{SubsystemBuilder, Toplevel};
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 fn test_args() -> Cli {
     Cli {
@@ -56,10 +56,10 @@ async fn replay_raymarine_quantum() {
     replay::set_instant_timing();
     let args = test_args();
 
-    Toplevel::new(move |s| async move {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         let (radars, _) = mayara::start_session(&s, args).await;
 
-        s.start(SubsystemBuilder::new("test", move |subsys| async move {
+        s.start(SubsystemBuilder::new("test", async move |subsys: &mut SubsystemHandle| {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let keys = radars.get_keys();


### PR DESCRIPTION
PR #208 bumped `tokio-graceful-shutdown` from 0.15 to 0.19, which broke the build on `main`. 0.19 changed the `SubsystemBuilder::new` closure signature from `FnOnce(SubsystemHandle) -> Future` to `for<'a> AsyncSubsysFn<&'a mut SubsystemHandle, _>`, so every call site failed with `E0631` / "FnOnce not general enough".

## Fix

- All `SubsystemBuilder::new` and `Toplevel::new` closures converted to the edition-2024 async-closure form used by upstream's examples: `async move |s: &mut SubsystemHandle| ...`.
- Run-method signatures that previously took `SubsystemHandle` by value now take `&mut SubsystemHandle`:
  - per-brand `ReportReceiver::run` (emulator, furuno, garmin, koden, navico, raymarine)
  - `raymarine::navdata::run`
  - `Web::run`, `NavigationData::run`, `Locator::run`, `RadarInfo::forward_output`
- Replay integration tests updated to match.

## Tested

- `cargo build --release`: clean.
- `cargo test --release` (default features): 15 + 210 + 1 lib/integration tests pass.
- `cargo test --release --features pcap-replay`: all 10 replay tests run and pass (furuno, furuno-drs2d, furuno-nnd, garmin, navico-4g, navico-br24, navico-halo20+, navico-halo24, navico-halo3006, raymarine).

## Not addressed in this PR

- macOS build verification for #209's `core-foundation 0.9 → 0.10` bump: `system-configuration 0.7.0` still pulls `core-foundation 0.9.4` transitively, so the macOS code path (`src/lib/network/macos/mod.rs`) now mixes two CF type families. CI doesn't build macOS on PRs (only release tags do). This needs follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR migrates the codebase to tokio-graceful-shutdown 0.19 by adopting the new async-closure subsystem API. It converts all subsystem closures from the previous FnOnce(SubsystemHandle) -> Future form to the new Rust 2024 async-closure form: async move |s: &mut SubsystemHandle| { ... } and adjusts callers to the new borrowing model.

## Changes

- Closure API migration: All Toplevel::new() and SubsystemBuilder::new() closures are written as typed async closures receiving &mut SubsystemHandle and await subsystem futures explicitly.
- Method signature updates: run() entrypoints and internal subsystem functions that previously take SubsystemHandle by value now take &mut SubsystemHandle. Affected items include per-brand ReportReceiver::run (emulator, furuno, garmin, koden, navico, raymarine), raymarine::navdata::run, Web::run, NavigationData::run, Locator::run, and RadarInfo::forward_output. Several of these run functions have their visibility narrowed to pub(super) when they are internal.
- Subsystem startup refactoring: Brand-specific Locator/found wiring and subsystem startup logic switch to async move closures that await report_receiver.run(s).await (emulator, furuno, garmin, koden, navico, raymarine).
- Core session startup: start_session and other background subsystems (TrackerManager, Static Navigation, AIS Timeout, AIS Broadcast, NavData, Locator, PcapReplay) use typed async closures with &mut SubsystemHandle.
- Tests: All pcap replay integration tests update imports and closure signatures to use SubsystemHandle and async move |s: &mut SubsystemHandle| forms.

## Validation

- cargo build --release completes cleanly.
- cargo test --release (default features) passes all tests reported.
- cargo test --release --features pcap-replay passes all 10 replay tests across supported radar models.

## Not addressed

- macOS build verification for the core-foundation 0.9 → 0.10 bump remains unresolved due to a transitive dependency (system-configuration 0.7.0 → core-foundation 0.9.4) and requires follow-up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->