### PR TITLE
fix(deps): use system-configuration's core-foundation re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,7 +1699,6 @@ dependencies = [
  "chrono",
  "clap",
  "clap-verbosity-flag",
- "core-foundation 0.10.1",
  "crossbeam",
  "directories",
  "enum-primitive-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,6 @@ tokio-tungstenite = { version = "0.26.2", features = [ "handshake", "deflate", "
 tokio-tungstenite = { git = "https://github.com/keesverruijt/tokio-tungstenite", tag = "v0.26.2-signalapp-v0.27.0"}
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.10.1"
 system-configuration = "0.7.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/lib/network/macos/mod.rs
+++ b/src/lib/network/macos/mod.rs
@@ -1,10 +1,10 @@
 use std::ptr;
 
-use core_foundation::runloop::{
-    CFRunLoop, CFRunLoopAddSource, CFRunLoopStop, kCFRunLoopDefaultMode,
-};
 use system_configuration::core_foundation::array::CFArray;
 use system_configuration::core_foundation::base::TCFType;
+use system_configuration::core_foundation::runloop::{
+    CFRunLoop, CFRunLoopAddSource, CFRunLoopRunResult, CFRunLoopStop, kCFRunLoopDefaultMode,
+};
 use system_configuration::core_foundation::string::CFString;
 use system_configuration::dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder};
 use system_configuration::sys::dynamic_store::SCDynamicStoreCreateRunLoopSource;
@@ -61,15 +61,15 @@ fn wait_for_ip_addr_change(
             std::time::Duration::from_secs(2),
             true,
         ) {
-            core_foundation::runloop::CFRunLoopRunResult::Finished => {
+            CFRunLoopRunResult::Finished => {
                 log::trace!("CFRunLoop finished.");
             }
-            core_foundation::runloop::CFRunLoopRunResult::Stopped => {
+            CFRunLoopRunResult::Stopped => {
                 log::trace!("CFRunLoop stopped.");
                 break;
             }
-            core_foundation::runloop::CFRunLoopRunResult::TimedOut => {}
-            core_foundation::runloop::CFRunLoopRunResult::HandledSource => {
+            CFRunLoopRunResult::TimedOut => {}
+            CFRunLoopRunResult::HandledSource => {
                 log::trace!("CFRunLoop handled source.");
                 log::debug!("IP address changed.");
                 let _ = tx_ip_change.send(());


### PR DESCRIPTION
`src/lib/network/macos/mod.rs` mixed `core-foundation 0.10` (our direct dep, bumped in #209) with `core-foundation 0.9` re-exported through `system-configuration 0.7`. The two are distinct type families in Rust, so the macOS build broke after #209 — but linux/windows CI stayed green because the macOS job only runs on `v*` tag pushes (see #216).

## Fix

- Drop direct `core-foundation` dep from `Cargo.toml`.
- Import every CF type (including the previously-needed `runloop::*`) through `system_configuration::core_foundation::*`. Single source of truth.
- Add `CFRunLoopRunResult` to the `use` list to keep the match arms readable.

`core-foundation 0.10` still appears in `Cargo.lock` via `security-framework` → `native-tls` / `rustls-native-certs` → `tokio-tungstenite`, but those are independent of our macOS code paths and don't share types with `system-configuration`'s CF wrappers, so no skew.

## Tested

- `cargo build --release` and `cargo test --release --features pcap-replay` on linux: clean.
- macOS source-level reasoning: all CF types now come from `system_configuration::core_foundation`, matching the version `system_configuration` uses internally.
- Couldn't fully cross-compile to macOS here (no macOS SDK / `ring` build-script needs `cc`). Real verification will happen when CI builds macOS — which is why PR #(next) adds `macos-latest` to the PR matrix.

closes #216