### PR TITLE
ci: add macos-latest to the PR build matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,3 +54,19 @@ jobs:
       with:
         name: Mayara Windows x86_64
         path: target/release/mayara-server.exe
+
+  macos:
+    name: Build macOS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: swatinem/rust-cache@v2
+    - name: Run tests
+      run: cargo test --features pcap-replay --release --verbose
+    - name: Build
+      run: cargo build --release
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: Mayara macOS
+        path: target/release/mayara-server


### PR DESCRIPTION
The Rust workflow only built linux and windows on `push` / `pull_request`. macOS was only built inside `release.yml` on `v*` tag pushes, so macOS-breaking changes (e.g. the `core-foundation 0.10` bump in #209) could land on `main` and only surface at release time.

## Change

Add a `macos` job alongside the existing `windows` job, mirroring its shape: native `macos-latest` runner, `cargo test --features pcap-replay --release --verbose`, `cargo build --release`, and artifact upload.

## Note on PR #218

This PR is independent of #218, but if both land, the macOS job will be the actual verification that #218's source-level fix works. Without #218, expect this job to fail on master once it merges — which is the point of adding it.

Relates to #216.