### PR TITLE
fix(macos): handle Option return from SCDynamicStoreBuilder::build

### DIFF
--- a/src/lib/network/macos/mod.rs
+++ b/src/lib/network/macos/mod.rs
@@ -25,7 +25,9 @@ fn wait_for_ip_addr_change(
     tx_ip_change: Sender<()>,
 ) -> Result<(), RadarError> {
     // Create a dynamic store session
-    let store: SCDynamicStore = SCDynamicStoreBuilder::new("IPChangeMonitor").build();
+    let store: SCDynamicStore = SCDynamicStoreBuilder::new("IPChangeMonitor")
+        .build()
+        .expect("Failed to create SCDynamicStore session for IP change monitor");
 
     // Define the key to monitor for changes (IPv4 addresses)
     let watched_keys = &CFArray::from_CFTypes(&vec![CFString::new("State:/Network/Global/IPv4")]);
@@ -91,11 +93,10 @@ fn wait_for_ip_addr_change(
 pub fn is_wireless_interface(interface_name: &str) -> bool {
     use system_configuration::dynamic_store::*;
 
-    let store = SCDynamicStoreBuilder::new("networkInterfaceInfo").build();
+    let Some(store) = SCDynamicStoreBuilder::new("networkInterfaceInfo").build() else {
+        return false;
+    };
 
     let key = format!("State:/Network/Interface/{}/AirPort", interface_name);
-    if let Some(_) = store.get(key.as_str()) {
-        return true;
-    }
-    false
+    store.get(key.as_str()).is_some()
 }


### PR DESCRIPTION
PR #218 fixed the source-level core-foundation version skew, and PR #219 added `macos-latest` to the PR build matrix. The first macOS CI run on `main` (#219) revealed two pre-existing API mismatches in `src/lib/network/macos/mod.rs` — `system-configuration 0.7`'s `SCDynamicStoreBuilder::build()` returns `Option<SCDynamicStore>`, not `SCDynamicStore` directly. Both callers assumed the older signature:

- Line 28 (`spawn_wait_for_ip_addr_change`): `E0308` mismatched types
- Line 97 (`is_wireless_interface`): `E0599` `.get()` on `Option`

These were hidden until #219 made macOS a PR-blocking job.

## Fix

- `spawn_wait_for_ip_addr_change`: unwrap with a descriptive `expect`, matching the existing panic-on-impossible-setup style already used on line 35 for `set_notification_keys`.
- `is_wireless_interface`: return `false` when the store can't be created — without a working `SCDynamicStore` we cannot determine wireless-ness. Also collapses the `if let Some(_) = ... { return true; } false` pattern to `.is_some()`.

Both call sites are `cfg(target_os = "macos")` and only run when a real macOS network interface is being inspected, so a panic here is no worse than the existing `set_notification_keys` panic. Promoting these to `Result` returns is a larger error-handling refactor — out of scope for a build-break fix.

## Tested

- `cargo build --release` on linux: clean (file is `cfg(target_os = "macos")`, so linux doesn't touch it, but verifying nothing else regressed).
- macOS verification will happen via CI now that #219 runs `cargo build` + tests on `macos-latest`.