### PR TITLE
ci: speed up tests with debug profile and cargo-nextest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,11 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
     - name: Run tests
-      run: cargo test --features pcap-replay --release --verbose
+      run: cargo nextest run --features pcap-replay
     - name: Build
       run: cargo build --release
     - name: Upload artifacts
@@ -61,8 +64,11 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
     - name: Run tests
-      run: cargo test --features pcap-replay --release --verbose
+      run: cargo nextest run --features pcap-replay
     - name: Build
       run: cargo build --release
     - name: Upload artifacts


### PR DESCRIPTION
The `windows` and `macos` jobs previously ran `cargo test --features pcap-replay --release --verbose` and then `cargo build --release`. The release-mode test step did a full release build of test artifacts that the subsequent release-mode binary build couldn't fully reuse, so we paid the heavy compile cost twice. On windows this typically took ~8 minutes; on cold caches it crept past 15.

## Changes

- Drop `--release` from the test step. Tests verify functional behavior; release-mode validation still happens via the subsequent `cargo build --release`. Debug compile is much faster.
- Switch from `cargo test` to `cargo nextest run` via `taiki-e/install-action`. nextest parallelises test execution across binaries and gives faster, more readable output.
- Drop `--verbose` (no debugging value in CI logs).

## Tested

- Locally: `cargo nextest run --features pcap-replay` runs the full suite — 235 passed, 30 skipped, runtime 1.3s after compile.
- The release binary is still built and uploaded via the unchanged `cargo build --release` step, so the release-mode validation path is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR accelerates CI test execution for the Windows and macOS jobs by replacing `cargo test` with `cargo nextest run` and running tests in debug profile instead of release mode.

## Changes

The workflow modifies the `windows` and `macos` jobs to:

1. **Install cargo-nextest**: Adds a `taiki-e/install-action@v2` step configured to install `nextest` in both jobs
2. **Switch test runner**: Replaces `cargo test --features pcap-replay --release --verbose` with `cargo nextest run --features pcap-replay`
3. **Remove test build artifacts overhead**: Eliminates the `--release` flag from the test step so tests compile in debug profile rather than performing a full release build

The subsequent `cargo build --release` step remains unchanged, ensuring release-mode validation continues while avoiding the previous double compile overhead where test artifacts built in release mode could not be fully reused by the release binary build.

## Rationale

Previously, the test step performed a full release build that could not be reused by the subsequent release build, effectively doubling compile time (typically ~8 minutes on Windows, extending beyond 15 minutes on cold caches). This change reduces test compilation time by running in debug profile while maintaining release validation via the existing build step. The switch to nextest provides faster, more readable test execution through parallelization across test binaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->