### PR TITLE
ci: revert windows test step to cargo test --release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,11 +45,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: swatinem/rust-cache@v2
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: nextest
     - name: Run tests
-      run: cargo nextest run --features pcap-replay
+      run: cargo test --features pcap-replay --release
     - name: Build
       run: cargo build --release
     - name: Upload artifacts


### PR DESCRIPTION
The debug-profile + nextest switch in #223 was a net loss on windows specifically: test step went from ~5:18 to ~10:47, making the whole job 13:24 vs the prior 7:46 baseline.

## Why it backfired on windows

`cargo test --release` and the subsequent `cargo build --release` shared a release-profile artifact cache, so the second step was nearly free. Splitting tests into debug broke that sharing — windows had to recompile every dep in debug *on top of* the release build that still runs after. We doubled compile work instead of halving it.

## Why macOS keeps the change

The macOS job timing tells the opposite story: test step ~30s, total ~3:17 vs the prior 8-10min when it last successfully compiled. The macos-latest runners (M-series) are fast enough that the compile cost doesn't dominate, so nextest's parallel test execution wins outright. Leaving macOS untouched.

## Change

Windows: back to `cargo test --features pcap-replay --release` (also drops `--verbose`, which had no debugging value).
macOS: unchanged.

## Tested

- YAML validates.
- The reverted windows command is byte-for-byte the pre-#223 command minus `--verbose`. CI on this PR is the real verification — expect windows back to ~7-8min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR reverts the Windows CI test step to use `cargo test --features pcap-replay --release`, restoring the previous test execution approach instead of using `cargo nextest run` with debug profile. The macOS CI workflow retains the debug+nextest configuration.

## Rationale

The change addresses significant performance regressions introduced in PR `#223`. The switch to debug profile with nextest on Windows caused the test step to increase from ~5:18 to ~10:47, and the overall job time to grow from ~7:46 to ~13:24. These regressions occurred because `cargo test --release` and the subsequent `cargo build --release` previously shared release-profile artifact cache; splitting tests into debug prevented this cache sharing and forced recompilation of dependencies for both profiles.

The macOS CI workflow retains the debug+nextest configuration, as that change improved performance on M-series runners, reducing the test step to ~30s and improving overall job time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->