### PR TITLE
chore: remove unused ControlBuilder::set_value

### DIFF
--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -2335,11 +2335,6 @@ impl ControlBuilder {
         self
     }
 
-    pub(crate) fn set_value(mut self, value: f64) -> Self {
-        self.control.value = Some(value);
-        self
-    }
-
     pub(crate) fn build(self, controls: &mut HashMap<ControlId, Control>) {
         controls.insert(self.control.item.control_id, self.control);
     }


### PR DESCRIPTION
Standing `dead_code` warning on `main` — the `pub(crate) fn set_value(value: f64) -> Self` builder helper on `ControlBuilder` has no callers in `src/` or `tests/`. Every brand uses the runtime `Controls::set_value(&ControlId, f64)` instead; this builder method was orphaned.

## Tested

- `cargo check --all-targets`: clean, warning gone
- `cargo test --all-targets`: 216 passed, 0 failed