### PR TITLE
fix(raymarine): prime command_sender at discovery so Quantum wired wakes without an MFD

### DIFF
--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -225,7 +225,7 @@ impl RaymarineLocator {
         report: &[u8],
         from: &Ipv4Addr,
         radars: &SharedRadars,
-    ) -> Result<Option<RadarInfo>, Error> {
+    ) -> Result<Option<(RadarInfo, BaseModel)>, Error> {
         match deserialize::<RaymarineBeacon36>(report) {
             Ok(data) => {
                 let beacon_type = u32::from_le_bytes(data.beacon_type);
@@ -322,7 +322,7 @@ impl RaymarineLocator {
                         false,
                     );
 
-                    return Ok(Some(location_info));
+                    return Ok(Some((location_info, model)));
                 } else {
                     log::trace!(
                         "{}: Raymarine 36 report: link_id {:08X} not found in ids: {:02X?}",
@@ -454,7 +454,13 @@ impl RaymarineLocator {
         Ok(())
     }
 
-    fn found(&self, info: RadarInfo, radars: &SharedRadars, subsys: &SubsystemHandle) {
+    fn found(
+        &self,
+        info: RadarInfo,
+        base_model: BaseModel,
+        radars: &SharedRadars,
+        subsys: &SubsystemHandle,
+    ) {
         info.controls
             .set_string(&ControlId::UserName, info.key())
             .unwrap();
@@ -486,7 +492,7 @@ impl RaymarineLocator {
             ));
 
             let report_receiver =
-                report::RaymarineReportReceiver::new(&self.args, info, radars.clone());
+                report::RaymarineReportReceiver::new(&self.args, info, radars.clone(), base_model);
 
             subsys.start(SubsystemBuilder::new(
                 report_name,
@@ -520,8 +526,8 @@ impl RadarLocator for RaymarineLocator {
         match report.len() {
             protocol::beacon36::LEN => {
                 match Self::process_beacon_36_report(self, report, nic_addr, radars) {
-                    Ok(Some(info)) => {
-                        self.found(info, radars, subsys);
+                    Ok(Some((info, base_model))) => {
+                        self.found(info, base_model, radars, subsys);
                     }
                     Ok(None) => {}
                     Err(e) => {
@@ -602,7 +608,7 @@ mod tests {
 
     use clap::Parser;
 
-    use super::protocol;
+    use super::{BaseModel, protocol};
     use crate::{Cli, brand::raymarine::RaymarineLocator, radar::SharedRadars};
 
     #[test]
@@ -691,8 +697,9 @@ mod tests {
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
-        let r = r.unwrap();
-        log::debug!("Radar: {:?}", r);
+        let (r, model) = r.unwrap();
+        log::debug!("Radar: {:?} model: {:?}", r, model);
+        assert_eq!(model, BaseModel::Quantum);
         assert_eq!(r.controls.model_name(), Some("Quantum".to_string()));
         assert_eq!(r.serial_no, None);
         assert_eq!(
@@ -719,8 +726,9 @@ mod tests {
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
-        let r = r.unwrap();
-        log::debug!("Radar: {:?}", r);
+        let (r, model) = r.unwrap();
+        log::debug!("Radar: {:?} model: {:?}", r, model);
+        assert_eq!(model, BaseModel::Quantum);
         assert_eq!(r.controls.model_name(), Some("Quantum".to_string()));
         assert_eq!(r.serial_no, None);
         assert_eq!(
@@ -747,8 +755,9 @@ mod tests {
         assert!(r.is_ok());
         let r = r.unwrap();
         assert!(r.is_some());
-        let r = r.unwrap();
-        log::debug!("Radar: {:?}", r);
+        let (r, model) = r.unwrap();
+        log::debug!("Radar: {:?} model: {:?}", r, model);
+        assert_eq!(model, BaseModel::RD);
         assert_eq!(r.controls.model_name(), Some("RD".to_string()));
         assert_eq!(r.serial_no, None);
         assert_eq!(
@@ -830,7 +839,10 @@ mod tests {
                     let _ = locator.process_beacon_56_report(data, src);
                 }
                 protocol::beacon36::LEN => {
-                    if let Ok(Some(info)) = locator.process_beacon_36_report(data, src, radars) {
+                    if let Ok(Some((info, model))) =
+                        locator.process_beacon_36_report(data, src, radars)
+                    {
+                        assert_eq!(model, BaseModel::Quantum);
                         assert_eq!(
                             info.report_addr,
                             SocketAddrV4::new(Ipv4Addr::new(232, 1, 160, 1), 2574),

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -13,6 +13,7 @@ use crate::radar::range::Ranges;
 use crate::radar::{BYTE_LOOKUP_LENGTH, CommonRadar, Legend, RadarError, RadarInfo, SharedRadars};
 
 // use super::command::Command;
+use super::BaseModel;
 use super::command::Command;
 
 mod quantum;
@@ -118,6 +119,7 @@ impl RaymarineReportReceiver {
         args: &Cli,
         info: RadarInfo, // Quick access to our own RadarInfo
         radars: SharedRadars,
+        base_model: BaseModel,
     ) -> RaymarineReportReceiver {
         let key = info.key();
 
@@ -127,7 +129,18 @@ impl RaymarineReportReceiver {
             key,
             args
         );
-        let command_sender = None; // Only known after we receive the model info
+
+        // Quantum wired radars (and some RD variants) won't send the
+        // 0x280001 info-report until they have received a host keep-alive
+        // first — see issue #228. Create the command_sender now with the
+        // base model the locator already determined, so the heartbeat loop
+        // starts priming the radar immediately. process_info_report() will
+        // not overwrite this once the radar replies.
+        let command_sender = if !replay {
+            Some(Command::new(info.clone(), base_model))
+        } else {
+            None
+        };
 
         let control_update_rx = info.control_update_subscribe();
         let blob_tx = radars.get_blob_tx();

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -347,18 +347,16 @@ pub(super) fn process_info_report(receiver: &mut RaymarineReportReceiver, data: 
             receiver.wire_to_legend = wire_to_legend(&receiver.common.info.get_legend());
             receiver.common.update();
 
-            // If we are in replay mode, we don't need a command sender, as we will not send any commands
-            let command_sender = if !receiver.common.replay {
+            // The command_sender was primed at construction with the
+            // BaseModel known from discovery so the heartbeat loop could
+            // start immediately (issue #228). The model-specific BaseModel
+            // (Quantum vs RD) doesn't change between then and now, so we
+            // keep the existing sender rather than recreating it.
+            if receiver.command_sender.is_none() && !receiver.common.replay {
                 log::debug!("{}: Starting command sender", receiver.common.key);
-                Some(Command::new(
-                    receiver.common.info.clone(),
-                    model.model.clone(),
-                ))
-            } else {
-                log::debug!("{}: No command sender, replay mode", receiver.common.key);
-                None
-            };
-            receiver.command_sender = command_sender;
+                receiver.command_sender =
+                    Some(Command::new(receiver.common.info.clone(), model.model.clone()));
+            }
             receiver.model = Some(model);
             receiver.state = ReceiverState::InfoRequestReceived;
         }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -1440,6 +1440,23 @@ impl CommonRadar {
                     } else {
                         self.info.controls.set_refresh(&cv.id);
                     }
+                } else {
+                    // Without this branch a PUT against a radar whose brand
+                    // module has not yet wired up its command channel
+                    // silently disappears with HTTP 200, which has cost
+                    // contributors many hours of misdiagnosis (issue #228).
+                    log::warn!(
+                        "{}: control PUT {:?}={:?} dropped — command channel \
+                         not initialised yet for this radar",
+                        self.key,
+                        cv.id,
+                        cv.value
+                    );
+                    return self
+                        .info
+                        .controls
+                        .send_error_to_client(reply_tx, &cv, &RadarError::NotConnected)
+                        .await;
                 }
             }
         }


### PR DESCRIPTION
Addresses #228 — but only **Fix 1** (chicken-and-egg keep-alive) and **Fix 2** (silent PUT drop). Fix 3 (standby radar invisible in `/radars/` index) is tracked separately in #233 — no `closes` keyword so #228 stays open until the maintainer is ready to close it.

## Why

Olivier (Inspirity) reported that on a direct Quantum 2 → Linux host topology with no Axiom MFD on the LAN, `PUT power=2` never wakes the radar. Three init-ordering bugs combine to make the failure invisible to the operator:

- **Bug 1:** `command_sender` is only created when info-report `0x280001` arrives. But Quantum wired only emits `0x280001` *after* receiving a host keep-alive. Without an MFD to prime the radar, the heartbeat loop never sends because `command_sender` is `None`.
- **Bug 2:** the `ControlDestination::Command` branch in `set_control` silently drops PUTs when `command_sender` is `None`. The client gets HTTP 200; the command vanishes. This hid Bug 1 for a long time.

`radar_pi` solves Bug 1 by sending the priming keep-alive on socket creation. This PR takes the same approach: the locator already knows whether the discovered radar is `BaseModel::Quantum` or `BaseModel::RD`, so plumb that into `RaymarineReportReceiver::new` and create the `command_sender` immediately. `process_info_report` then keeps the existing sender rather than overwriting it.

Bug 2 becomes a `log::warn!` + `RadarError::NotConnected` returned to the client.

## How to test (from the reporter's recipe)

With `RUST_LOG=debug`, within a few seconds of mayara start against a powered Quantum:

```
<key>: sent [00, 00, 28, 00, 52, 61, 64, 61, 72, 00, 00, 00]  # priming keep-alive
<key>: Detected model: Quantum with serial …                  # info-report received
```

Then `PUT power=2` should produce real outbound traffic and `power.value` should transition 0 → 3 (Preparing) → 2 (Transmit). PUTs that arrive before the command channel is ready now return a clear error instead of silently 200-ing.

The standby-index quirk (Bug 3) is unchanged in this PR — a radar that hasn't yet entered transmit will still not appear in `GET /radars/`. Use the per-radar endpoint by key (visible in the discovery log line `Found radar: key 'rayXXXX'`).

## Why Bug 3 is separate

Fix 3 (filter out `ranges.len() > 0` from `SharedRadars::get_active`) has the largest blast radius of the three: `get_active()` is called from the Signal K stream code, the recordings endpoints, target-tracker setup, and the locator's multiple-radar gate. Letting pre-range radars through any of those paths likely needs a `state` field on the wire and downstream handling in each consumer. That wants its own design discussion — see #233. Not on the critical path for waking the radar.

## Tested

- `cargo test` — 218 + brand tests pass
- `cr review --plain` — no findings
- Locator tests updated to assert the `BaseModel` is plumbed through `process_beacon_36_report`