### PR TITLE
docs: document --signalk-token / --signalk-token-file

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -81,10 +81,27 @@ Command Line Options
 | `--nmea0183`                      | Use NMEA 0183 instead of Signal K for navigation                            |
 | `--accept-invalid-certs`          | Accept self-signed TLS certificates when connecting to Signal K via         |
 |                                   | HTTPS/WSS. Required for boat-LAN setups that use self-signed certs.         |
+| `--signalk-token <TOKEN>`         | Signal K bearer token for authenticating to a `ws:` or `wss:` upstream.     |
+|                                   | Sent as `?token=...` on the WebSocket and as `Authorization: Bearer ...`    |
+|                                   | on the REST discovery and AIS-store seeding probes. Has no effect on        |
+|                                   | `tcp:` or `udp:` transports.                                                |
+| `--signalk-token-file <PATH>`     | Read the bearer token from a file (single line, trailing whitespace         |
+|                                   | trimmed). Use this instead of `--signalk-token` to keep the token out       |
+|                                   | of the process argv.                                                        |
 
 **Note on authentication:** Authenticated Signal K servers can only be reached
-via `ws:` or `wss:`. The plain `tcp:` transport is anonymous-only. Authentication
-support is tracked as follow-up work.
+via `ws:` or `wss:`. The plain `tcp:` transport is anonymous-only. Pass the
+token via `--signalk-token`, `--signalk-token-file`, or the
+`MAYARA_SIGNALK_TOKEN` environment variable (in that order of precedence).
+Embedded control characters (e.g. `\r`/`\n` in a token read from a file) are
+rejected at startup to prevent HTTP header injection.
+
+The token must grant at least `readonly` on `vessels.*` so Mayara can seed
+its in-memory AIS store from the upstream `/signalk/v1/api/vessels/` snapshot.
+The standard way to obtain such a token is to POST an access request to
+`POST /signalk/v1/access/requests` with your `clientId` and have the Signal K
+administrator approve it under **Security → Access Requests**; the issued
+token then survives Signal K restarts.
 
 **Note on TLS SNI:** `wss:ip:port` and mDNS-discovered HTTPS Signal K servers
 use the server's IP address (not hostname) during the TLS handshake. Some


### PR DESCRIPTION
## Summary

PR #227 shipped bearer-token authentication to the upstream Signal K server but `USAGE.md` still claimed authentication was "tracked as follow-up work" and didn't list the new flags at all. Add the two flags to the Navigation Data table, note the `MAYARA_SIGNALK_TOKEN` env-var fallback, mention the control-char rejection at startup, and point users at Signal K's standard device-access-request flow as the canonical way to obtain a token.

## Tested

- Docs-only change; no source touched
- Verified no other docs still carry the "authentication not implemented" wording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR introduces comprehensive documentation for authentication to upstream Signal K servers via bearer tokens. The new `USAGE.md` file documents two CLI options (`--signalk-token` and `--signalk-token-file`) that allow passing Signal K bearer tokens, along with their environment variable fallback (`MAYARA_SIGNALK_TOKEN`).

The documentation provides guidance on:
- Token transmission mechanisms (WebSocket query parameters and HTTP Authorization headers for REST probes)
- Validation behavior, including startup rejection of control characters to prevent HTTP header injection
- Required token permissions (`readonly` access on `vessels.*` for AIS store seeding)
- The canonical method for obtaining tokens through Signal K's standard device-access-request flow
- Additional TLS SNI considerations for cloud-hosted Signal K instances

The change is documentation-only, with no modifications to source code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->