### PR TITLE
fix(web): send Cache-Control: no-cache on embedded GUI assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 tokio-graceful-shutdown = "0.19.3"
 tokio-util = "0.7.18"
 tower = "0.5.3"
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.6", features = ["set-header", "trace"] }
 utoipa = { version = "5", features = ["macros", "axum_extras", "chrono", "time", "url", "repr" ] }
 serde_string_enum = "0.2.1"
 unicase = "2.9.0"

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -1,6 +1,7 @@
 use axum::{
     Json, Router, debug_handler,
     extract::{Path, State},
+    http::{HeaderValue, header},
     response::{IntoResponse, Redirect, Response},
     routing::get,
 };
@@ -24,6 +25,8 @@ use tokio::{
 };
 use tokio_graceful_shutdown::SubsystemHandle;
 use tokio_rustls::{TlsAcceptor, server::TlsStream};
+use tower::ServiceBuilder;
+use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
 use utoipa::ToSchema;
 
@@ -167,7 +170,18 @@ impl Web {
             _ => None,
         };
 
-        let serve_assets = ServeEmbed::<Assets>::new();
+        // Wrap the embedded GUI in `Cache-Control: no-cache` so a fresh
+        // mayara image's `web/gui/*` is picked up on the next normal F5
+        // (browser revalidates via the ETags axum-embed already emits).
+        // Without this header, the browser's heuristic cache holds onto
+        // viewer.js/layout.css across mayara updates and the user has
+        // to hard-refresh (Ctrl+Shift+R) to see new GUI features.
+        let serve_assets = ServiceBuilder::new()
+            .layer(SetResponseHeaderLayer::overriding(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("no-cache"),
+            ))
+            .service(ServeEmbed::<Assets>::new());
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let shutdown_tx = self.shutdown_tx.clone();
 


### PR DESCRIPTION
## Summary

When a user updates mayara to a newer image, the browser's heuristic cache holds onto the previous `viewer.js` / `layout.css` / `viewer.html` until a hard reload (Ctrl+Shift+R). Reported when an AIS-overlay lozenge from #211 wasn't visible after an update; mayara's logs showed the new code was running, but the browser was still serving the pre-#211 GUI.

Wrap `ServeEmbed` with `tower-http`'s `SetResponseHeaderLayer` so every fallback asset response carries `Cache-Control: no-cache`. The browser keeps the cached copy but revalidates with the server on every request via `If-None-Match`. `axum-embed` already emits `ETag`s, so the revalidation is one round-trip with a `304 Not Modified` body when the asset is unchanged — negligible on a boat LAN.

## Tested

- `cargo check` + `cargo test --all-targets`: clean (233 tests pass)
- Manual `curl -I` against `cargo run -- --emulator -p 9999`:
  - First request to `/gui/viewer.html` → `200 OK` + `cache-control: no-cache` + `etag: <hash>`
  - Second request with `If-None-Match: <hash>` → `304 Not Modified`
  - Same shape confirmed for `/gui/viewer.js` and `/gui/layout.css`
- `cr review --plain --base origin/main`: no findings