### PR TITLE
feat(gui): add VRM/EBL markers with two-color drag interaction

### DIFF
--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -403,6 +403,101 @@ div.myr_ppi {
   stroke: #666;
 }
 
+/* ============================================
+   VRM/EBL Lozenge - VRM/EBL marker toggle (bottom-left, above AIS)
+   ============================================ */
+
+.myr_vrmebl_lozenge {
+  position: absolute;
+  bottom: 62px; /* Above AIS lozenge (20px + 36px height + 6px gap) */
+  left: 20px;
+  display: flex;
+  align-items: stretch;
+  height: 36px;
+  background: rgba(0, 0, 0, 0.7);
+  border: 2px solid #446;
+  border-radius: 18px;
+  z-index: 100;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.myr_vrmebl_lozenge_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  padding: 0;
+  background: #222;
+  border: none;
+  cursor: pointer;
+  color: #888;
+  transition: all 0.2s ease;
+}
+
+.myr_vrmebl_lozenge_button:hover {
+  background: #333;
+}
+
+.myr_vrmebl_lozenge_button:active {
+  transform: scale(0.95);
+}
+
+.myr_vrmebl_lozenge_button:focus-visible {
+  outline: 2px solid #00ffff;
+  outline-offset: 2px;
+}
+
+.myr_vrmebl_icon {
+  width: 22px;
+  height: 22px;
+}
+
+.myr_vrmebl_dot1 {
+  fill: #00ffff;
+}
+
+.myr_vrmebl_dot2 {
+  fill: #ff00ff;
+}
+
+/* Off: both dots dim, crosshair dim */
+.myr_vrmebl_lozenge.myr_vrmebl_off .myr_vrmebl_lozenge_button {
+  color: #666;
+}
+
+.myr_vrmebl_lozenge.myr_vrmebl_off .myr_vrmebl_dot1,
+.myr_vrmebl_lozenge.myr_vrmebl_off .myr_vrmebl_dot2 {
+  fill: #555;
+}
+
+/* Marker 1 only: cyan dot lit, magenta dim */
+.myr_vrmebl_lozenge.myr_vrmebl_m1 .myr_vrmebl_lozenge_button {
+  color: #00ffff;
+  background: #0a3d3d;
+}
+
+.myr_vrmebl_lozenge.myr_vrmebl_m1 .myr_vrmebl_dot2 {
+  fill: #555;
+}
+
+/* Marker 2 only: magenta dot lit, cyan dim */
+.myr_vrmebl_lozenge.myr_vrmebl_m2 .myr_vrmebl_lozenge_button {
+  color: #ff00ff;
+  background: #3d0a3d;
+}
+
+.myr_vrmebl_lozenge.myr_vrmebl_m2 .myr_vrmebl_dot1 {
+  fill: #555;
+}
+
+/* Both markers: crosshair shown in mixed tone, both dots lit */
+.myr_vrmebl_lozenge.myr_vrmebl_both .myr_vrmebl_lozenge_button {
+  color: #ddccff;
+  background: #2a1d3d;
+}
+
 /* Range lozenge - vertical, left side, centered */
 .myr_range_lozenge {
   position: absolute;

--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -159,6 +159,19 @@ class PPI {
     this.acquireTargetMode = false;
     this.onTargetAcquire = null; // Callback: (bearing, distance) => void
 
+    // VRM/EBL markers - two independent markers, each combining a Variable
+    // Range Marker (range ring) and an Electronic Bearing Line. Each marker
+    // defines a point at (bearing, distance) shown with a draggable ring and
+    // line plus a readout of true bearing and distance.
+    // Each entry: { enabled: bool, bearing: rad (relative to bow), distance: meters }
+    // bearing is stored relative to bow so HU/NU mode switches don't relocate it.
+    this.vrmEbl = [
+      { enabled: false, bearing: 0, distance: 0 },
+      { enabled: false, bearing: 0, distance: 0 },
+    ];
+    this.onVrmEblChange = null; // Callback: (markers) => void (for persistence)
+    this._vrmEblDrag = null;    // { index, mode: 'ring'|'line'|'point', startBearing, startDistance }
+
     // Display zoom (1.0 = 100%, range 0.33 to 3.0)
     this.displayZoom = 1.0;
   }
@@ -184,6 +197,50 @@ class PPI {
    */
   getDisplayZoom() {
     return this.displayZoom;
+  }
+
+  // ============================================================
+  // VRM/EBL public API
+  // ============================================================
+
+  setVrmEblEnabled(index, enabled) {
+    const marker = this.vrmEbl[index];
+    if (!marker) return;
+    if (marker.enabled === enabled) return;
+
+    if (enabled && marker.distance <= 0) {
+      // First-time enable: pick a sensible default of half the displayed range
+      // on a north-easterly bearing so it lands in clear space.
+      const rangeMeters = this.range || this.spoke_range || 1852;
+      marker.distance = rangeMeters * 0.5;
+      marker.bearing = index === 0 ? Math.PI / 4 : -Math.PI / 4;
+    }
+    marker.enabled = enabled;
+    this.#installVrmEblHandlersIfNeeded();
+    this.redrawCanvas();
+    if (this.onVrmEblChange) this.onVrmEblChange(this.vrmEbl);
+  }
+
+  // Restore marker positions from external storage. The onVrmEblChange
+  // callback is intentionally not fired here: this is the inverse of
+  // persistence, so notifying the callback would write the just-restored
+  // values straight back to localStorage.
+  setVrmEblMarkers(markers) {
+    if (!Array.isArray(markers)) return;
+    for (let i = 0; i < Math.min(2, markers.length); i++) {
+      const m = markers[i];
+      if (!m) continue;
+      const target = this.vrmEbl[i];
+      if (typeof m.bearing === "number") target.bearing = m.bearing;
+      if (typeof m.distance === "number") target.distance = m.distance;
+      if (typeof m.enabled === "boolean") target.enabled = m.enabled;
+    }
+    this.#installVrmEblHandlersIfNeeded();
+    this.redrawCanvas();
+  }
+
+  getVrmEblMarkers() {
+    return this.vrmEbl.map((m) => ({ ...m }));
   }
 
   /**
@@ -791,6 +848,9 @@ class PPI {
 
     // Draw compass rose
     this.#drawCompassRose(ctx);
+
+    // Draw VRM/EBL markers on top so labels stay readable
+    this.#drawVrmEbl(ctx, range);
   }
 
   #drawStandbyOverlay(ctx) {
@@ -1442,6 +1502,137 @@ class PPI {
   }
 
   // ============================================================
+  // VRM/EBL drawing
+  // ============================================================
+
+  static VRM_EBL_COLORS = ["#00ffff", "#ff00ff"];
+
+  #drawVrmEbl(ctx, range) {
+    if (!range || range <= 0) return;
+    const pixelsPerMeter = this.beam_length / range;
+
+    for (let i = 0; i < this.vrmEbl.length; i++) {
+      const marker = this.vrmEbl[i];
+      if (!marker.enabled) continue;
+      this.#drawVrmEblMarker(ctx, i, marker, pixelsPerMeter, range);
+    }
+  }
+
+  #drawVrmEblMarker(ctx, index, marker, pixelsPerMeter, range) {
+    const color = PPI.VRM_EBL_COLORS[index];
+    const screenAngle = marker.bearing + this.headingRotation;
+    const radius = marker.distance * pixelsPerMeter;
+    // Line extends to the edge of the PPI so it's always visible even when the
+    // VRM is outside the displayed range.
+    const lineLength = Math.max(radius, this.beam_length);
+
+    const dirX = Math.sin(screenAngle);
+    const dirY = -Math.cos(screenAngle);
+    const lineEndX = this.center_x + lineLength * dirX;
+    const lineEndY = this.center_y + lineLength * dirY;
+    const pointX = this.center_x + radius * dirX;
+    const pointY = this.center_y + radius * dirY;
+
+    ctx.save();
+
+    // EBL: dashed bearing line from centre out
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(this.center_x, this.center_y);
+    ctx.lineTo(lineEndX, lineEndY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // VRM: range ring at distance
+    if (radius > 0 && radius < this.beam_length * 3) {
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(this.center_x, this.center_y, radius, 0, 2 * Math.PI);
+      ctx.stroke();
+    }
+
+    // Intersection handle - the point this marker defines
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(pointX, pointY, 6, 0, 2 * Math.PI);
+    ctx.fill();
+    ctx.strokeStyle = "#000";
+    ctx.lineWidth = 1;
+    ctx.stroke();
+
+    // Readout: true bearing + distance, anchored just outside the ring along
+    // the bearing line. Offset perpendicularly so two markers don't overlap.
+    this.#drawVrmEblReadout(ctx, index, marker, screenAngle, radius, color, range);
+
+    ctx.restore();
+  }
+
+  #drawVrmEblReadout(ctx, index, marker, screenAngle, radius, color, range) {
+    // Anchor 24 px beyond the intersection along the bearing line.
+    const anchorRadius = radius + 24;
+    const ax = this.center_x + anchorRadius * Math.sin(screenAngle);
+    const ay = this.center_y - anchorRadius * Math.cos(screenAngle);
+
+    let bearingText;
+    if (this.trueHeading !== null && this.trueHeading !== undefined) {
+      let trueBearing = marker.bearing + this.trueHeading;
+      while (trueBearing < 0) trueBearing += 2 * Math.PI;
+      while (trueBearing >= 2 * Math.PI) trueBearing -= 2 * Math.PI;
+      bearingText = `${((trueBearing * 180) / Math.PI).toFixed(1)}° T`;
+    } else {
+      let rel = marker.bearing;
+      while (rel < 0) rel += 2 * Math.PI;
+      while (rel >= 2 * Math.PI) rel -= 2 * Math.PI;
+      bearingText = `${((rel * 180) / Math.PI).toFixed(1)}° R`;
+    }
+
+    const distanceText = formatRangeValue(is_metric(range), marker.distance);
+
+    const label = `VRM/EBL ${index + 1}`;
+    const lines = [label, bearingText, distanceText];
+
+    ctx.font = "bold 11px/1 Verdana, Geneva, sans-serif";
+    let maxWidth = 0;
+    for (const line of lines) {
+      const w = ctx.measureText(line).width;
+      if (w > maxWidth) maxWidth = w;
+    }
+    const padX = 6;
+    const padY = 4;
+    const lineHeight = 13;
+    const boxW = maxWidth + padX * 2;
+    const boxH = lineHeight * lines.length + padY * 2;
+
+    // Place box so it sits beside (not on top of) the bearing line. Bias to
+    // the side away from screen centre and clamp to viewport.
+    let boxX = ax - boxW / 2;
+    let boxY = ay - boxH / 2;
+    if (Math.sin(screenAngle) > 0) boxX += 12;
+    else boxX -= boxW + 12;
+    if (-Math.cos(screenAngle) > 0) boxY += 12;
+    else boxY -= 12;
+    boxX = Math.max(4, Math.min(this.width - boxW - 4, boxX));
+    boxY = Math.max(4, Math.min(this.height - boxH - 4, boxY));
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.75)";
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.rect(boxX, boxY, boxW, boxH);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = color;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], boxX + padX, boxY + padY + i * lineHeight);
+    }
+  }
+
+  // ============================================================
   // Drag handles for zone/sector editing
   // ============================================================
 
@@ -1450,7 +1641,9 @@ class PPI {
       this.creatingZoneIndex !== null || this.creatingRectIndex !== null;
     const isEditing =
       this.editingZoneIndex !== null || this.editingSectorIndex !== null;
-    const needsPointerEvents = isCreating || isEditing || this.acquireTargetMode;
+    const hasVrmEbl = this.vrmEbl.some((m) => m.enabled);
+    const needsPointerEvents =
+      isCreating || isEditing || this.acquireTargetMode || hasVrmEbl;
 
     if (needsPointerEvents && this.overlay_dom) {
       this.overlay_dom.style.pointerEvents = "auto";
@@ -1463,6 +1656,10 @@ class PPI {
       this.overlay_dom.style.cursor = "default";
       this.#removeDragHandlers();
     }
+  }
+
+  #installVrmEblHandlersIfNeeded() {
+    this.#updatePointerEvents();
   }
 
   #setupDragHandlers() {
@@ -1623,6 +1820,87 @@ class PPI {
     return null;
   }
 
+  #hitTestVrmEbl(x, y) {
+    if (!this.range || this.range <= 0) return null;
+    const pixelsPerMeter = this.beam_length / this.range;
+    const pointRadius = 12;     // intersection handle priority area
+    const ringTolerance = 8;    // px from ring to grab range
+    const lineTolerance = 8;    // px from line to grab bearing
+
+    // Check intersection handles first (highest priority)
+    let best = null;
+    for (let i = 0; i < this.vrmEbl.length; i++) {
+      const m = this.vrmEbl[i];
+      if (!m.enabled) continue;
+      const screenAngle = m.bearing + this.headingRotation;
+      const radius = m.distance * pixelsPerMeter;
+      const px = this.center_x + radius * Math.sin(screenAngle);
+      const py = this.center_y - radius * Math.cos(screenAngle);
+      const dx = x - px;
+      const dy = y - py;
+      const d2 = dx * dx + dy * dy;
+      if (d2 <= pointRadius * pointRadius) {
+        if (!best || d2 < best.d2) {
+          best = { index: i, mode: "point", d2 };
+        }
+      }
+    }
+    if (best) return { index: best.index, mode: best.mode };
+
+    // Then rings: closeness to the ring circumference.
+    for (let i = 0; i < this.vrmEbl.length; i++) {
+      const m = this.vrmEbl[i];
+      if (!m.enabled) continue;
+      const radius = m.distance * pixelsPerMeter;
+      if (radius <= 0) continue;
+      const dx = x - this.center_x;
+      const dy = y - this.center_y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (Math.abs(dist - radius) <= ringTolerance) {
+        return { index: i, mode: "ring" };
+      }
+    }
+
+    // Then bearing lines: perpendicular distance from the line segment.
+    for (let i = 0; i < this.vrmEbl.length; i++) {
+      const m = this.vrmEbl[i];
+      if (!m.enabled) continue;
+      const screenAngle = m.bearing + this.headingRotation;
+      const dirX = Math.sin(screenAngle);
+      const dirY = -Math.cos(screenAngle);
+      const dx = x - this.center_x;
+      const dy = y - this.center_y;
+      // Project onto direction; only count points on the positive ray.
+      const t = dx * dirX + dy * dirY;
+      if (t < 0) continue;
+      const perp = Math.abs(dx * dirY - dy * dirX);
+      if (perp <= lineTolerance && t <= this.beam_length * 1.2) {
+        return { index: i, mode: "line" };
+      }
+    }
+
+    return null;
+  }
+
+  #updateVrmEblFromDrag(x, y) {
+    const drag = this._vrmEblDrag;
+    if (!drag) return;
+    const marker = this.vrmEbl[drag.index];
+    if (!marker) return;
+    const radarCoords = this.#pixelToRadarCoords(x, y);
+
+    if (drag.mode === "ring") {
+      marker.distance = Math.max(0, radarCoords.distance);
+    } else if (drag.mode === "line") {
+      marker.bearing = radarCoords.angle;
+    } else if (drag.mode === "point") {
+      marker.bearing = radarCoords.angle;
+      marker.distance = Math.max(0, radarCoords.distance);
+    }
+    this.redrawCanvas();
+    if (this.onVrmEblChange) this.onVrmEblChange(this.vrmEbl);
+  }
+
   #handleMouseDown(event) {
     const coords = this.#getCanvasCoords(event);
 
@@ -1696,6 +1974,15 @@ class PPI {
       }
       this.overlay_dom.style.cursor = "grabbing";
       event.preventDefault();
+      return;
+    }
+
+    const vrmHit = this.#hitTestVrmEbl(coords.x, coords.y);
+    if (vrmHit) {
+      this._vrmEblDrag = vrmHit;
+      this.dragState = { type: "vrmEbl" };
+      this.overlay_dom.style.cursor = "grabbing";
+      event.preventDefault();
     }
   }
 
@@ -1719,14 +2006,26 @@ class PPI {
       } else if (this.dragState.type === "sector") {
         this.#updateSectorFromDrag(coords.x, coords.y);
         event.preventDefault();
+      } else if (this.dragState.type === "vrmEbl") {
+        this.#updateVrmEblFromDrag(coords.x, coords.y);
+        event.preventDefault();
       }
     } else {
       const hit = this.#hitTestHandles(coords.x, coords.y);
       const newHovered = hit ? hit.handle : null;
+      let cursor = "default";
+      if (hit) {
+        cursor = "grab";
+      } else {
+        const vrmHit = this.#hitTestVrmEbl(coords.x, coords.y);
+        if (vrmHit) cursor = "grab";
+      }
       if (newHovered !== this.hoveredHandle) {
         this.hoveredHandle = newHovered;
-        this.overlay_dom.style.cursor = hit ? "grab" : "default";
+        this.overlay_dom.style.cursor = cursor;
         this.redrawCanvas();
+      } else {
+        this.overlay_dom.style.cursor = cursor;
       }
     }
   }
@@ -1754,9 +2053,22 @@ class PPI {
         if (this.onSectorDragEnd && newSector) {
           this.onSectorDragEnd(sectorIndex, newSector);
         }
+      } else if (this.dragState.type === "vrmEbl") {
+        this._vrmEblDrag = null;
+        if (this.onVrmEblChange) this.onVrmEblChange(this.vrmEbl);
       }
       this.dragState = null;
-      this.overlay_dom.style.cursor = this.hoveredHandle ? "grab" : "default";
+      // Re-hit-test under the released pointer so the cursor reflects the
+      // current target (VRM/EBL or zone/sector handle), not the stale
+      // hoveredHandle that only tracks zone/sector handles.
+      const releaseCoords = this.#getCanvasCoords(event);
+      const stillOverHandle = this.#hitTestHandles(
+        releaseCoords.x,
+        releaseCoords.y,
+      );
+      const stillOverVrm = this.#hitTestVrmEbl(releaseCoords.x, releaseCoords.y);
+      this.overlay_dom.style.cursor =
+        stillOverHandle || stillOverVrm ? "grab" : "default";
     } else if (this.acquireTargetMode && this._clickStart) {
       // Handle click for target acquisition
       const coords = this.#getCanvasCoords(event);
@@ -1830,6 +2142,14 @@ class PPI {
           };
           event.preventDefault();
         }
+        return;
+      }
+
+      const vrmHit = this.#hitTestVrmEbl(x, y);
+      if (vrmHit) {
+        this._vrmEblDrag = vrmHit;
+        this.dragState = { type: "vrmEbl" };
+        event.preventDefault();
       }
     }
   }
@@ -1844,6 +2164,8 @@ class PPI {
         this.#updateZoneFromDrag(x, y);
       } else if (this.dragState.type === "sector") {
         this.#updateSectorFromDrag(x, y);
+      } else if (this.dragState.type === "vrmEbl") {
+        this.#updateVrmEblFromDrag(x, y);
       }
       event.preventDefault();
     }
@@ -1863,6 +2185,9 @@ class PPI {
         if (this.onSectorDragEnd && newSector) {
           this.onSectorDragEnd(sectorIndex, newSector);
         }
+      } else if (this.dragState.type === "vrmEbl") {
+        this._vrmEblDrag = null;
+        if (this.onVrmEblChange) this.onVrmEblChange(this.vrmEbl);
       }
       this.dragState = null;
     }

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -67,6 +67,26 @@ var showAis = (() => {
   }
 })();
 
+// VRM/EBL marker localStorage keys. Hoisted to module scope so the
+// initialization IIFEs below and the persistence helpers further down
+// reference the same constants.
+const VRM_EBL_STATE_KEY = "mayaraVrmEbl";
+const VRM_EBL_VISIBLE_KEY = "mayaraVrmEblVisible";
+
+// VRM/EBL markers - persisted between sessions. Stored as a plain object so the
+// data survives reload; bearing is in radians relative to bow.
+var vrmEblState = (() => {
+  try {
+    const raw = localStorage.getItem(VRM_EBL_STATE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+})();
+
 registerRadarCallback(radarLoaded);
 registerControlCallback(controlUpdate);
 registerStreamMessageCallback(handleStreamMessage);
@@ -166,6 +186,9 @@ window.onload = async function () {
 
   // Create AIS lozenge (bottom-left, toggles vessels.* subscription)
   createAisLozenge();
+
+  // Create VRM/EBL lozenge (above AIS lozenge) - cycles through marker states
+  createVrmEblLozenge();
 
   // Create range lozenge
   createRangeLozenge();
@@ -935,6 +958,111 @@ function updateAisLozenge() {
   if (!lozenge) return;
   lozenge.classList.remove("myr_ais_on", "myr_ais_off");
   lozenge.classList.add(showAis ? "myr_ais_on" : "myr_ais_off");
+}
+
+// VRM/EBL lozenge - cycles through marker visibility states. Click steps
+// forward through {none, #1 only, #2 only, both}; right-click steps backward.
+// Two colored dots on the icon mirror the marker colors so the operator can
+// see at a glance which marker is active.
+// Persisted visible-state bitmask: bit 0 = marker 1, bit 1 = marker 2.
+var vrmEblVisible = (() => {
+  try {
+    const raw = localStorage.getItem(VRM_EBL_VISIBLE_KEY);
+    if (raw === null) return 0;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? n & 0x3 : 0;
+  } catch {
+    return 0;
+  }
+})();
+
+function createVrmEblLozenge() {
+  const container = document.querySelector(".myr_ppi");
+  if (!container) return;
+
+  const lozenge = document.createElement("div");
+  lozenge.id = "myr_vrmebl_lozenge";
+  lozenge.className = "myr_vrmebl_lozenge";
+  lozenge.title =
+    "VRM/EBL — click to cycle markers, right-click to step back. " +
+    "Drag the ring to set range, the line to set bearing, the dot to set both.";
+
+  const btn = document.createElement("button");
+  btn.className = "myr_vrmebl_lozenge_button";
+  // Icon: crosshair + two small color dots for marker 1 and 2
+  btn.innerHTML = `<svg class="myr_vrmebl_icon" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="12" y1="3" x2="12" y2="21" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="1.5"/>
+    <circle class="myr_vrmebl_dot1" cx="6" cy="6" r="2.4"/>
+    <circle class="myr_vrmebl_dot2" cx="18" cy="18" r="2.4"/>
+  </svg>`;
+  btn.addEventListener("click", (e) => {
+    e.preventDefault();
+    cycleVrmEbl(1);
+  });
+  btn.addEventListener("contextmenu", (e) => {
+    e.preventDefault();
+    cycleVrmEbl(-1);
+  });
+
+  lozenge.appendChild(btn);
+  container.appendChild(lozenge);
+
+  // Restore persisted marker positions and visibility into the PPI.
+  if (vrmEblState && ppi) {
+    ppi.setVrmEblMarkers(vrmEblState);
+  }
+  if (ppi) {
+    ppi.setVrmEblEnabled(0, (vrmEblVisible & 0x1) !== 0);
+    ppi.setVrmEblEnabled(1, (vrmEblVisible & 0x2) !== 0);
+    ppi.onVrmEblChange = persistVrmEbl;
+  }
+  updateVrmEblLozenge();
+}
+
+// State sequence: 0b00 -> 0b01 -> 0b10 -> 0b11 -> 0b00
+const VRM_EBL_CYCLE = [0b00, 0b01, 0b10, 0b11];
+
+function cycleVrmEbl(direction) {
+  if (!ppi) return;
+  const idx = VRM_EBL_CYCLE.indexOf(vrmEblVisible);
+  const cur = idx >= 0 ? idx : 0;
+  const next =
+    (cur + (direction >= 0 ? 1 : VRM_EBL_CYCLE.length - 1)) %
+    VRM_EBL_CYCLE.length;
+  vrmEblVisible = VRM_EBL_CYCLE[next];
+  ppi.setVrmEblEnabled(0, (vrmEblVisible & 0x1) !== 0);
+  ppi.setVrmEblEnabled(1, (vrmEblVisible & 0x2) !== 0);
+  try {
+    localStorage.setItem(VRM_EBL_VISIBLE_KEY, String(vrmEblVisible));
+  } catch {
+    // ignore quota errors
+  }
+  updateVrmEblLozenge();
+}
+
+function updateVrmEblLozenge() {
+  const lozenge = document.getElementById("myr_vrmebl_lozenge");
+  if (!lozenge) return;
+  lozenge.classList.remove(
+    "myr_vrmebl_off",
+    "myr_vrmebl_m1",
+    "myr_vrmebl_m2",
+    "myr_vrmebl_both",
+  );
+  if (vrmEblVisible === 0) lozenge.classList.add("myr_vrmebl_off");
+  else if (vrmEblVisible === 0b11) lozenge.classList.add("myr_vrmebl_both");
+  else if (vrmEblVisible & 0b01) lozenge.classList.add("myr_vrmebl_m1");
+  else lozenge.classList.add("myr_vrmebl_m2");
+}
+
+function persistVrmEbl(markers) {
+  try {
+    localStorage.setItem(VRM_EBL_STATE_KEY, JSON.stringify(markers));
+  } catch {
+    // ignore quota errors
+  }
 }
 
 // Play an audio alert

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -73,8 +73,8 @@ var showAis = (() => {
 const VRM_EBL_STATE_KEY = "mayaraVrmEbl";
 const VRM_EBL_VISIBLE_KEY = "mayaraVrmEblVisible";
 
-// VRM/EBL markers - persisted between sessions. Stored as a plain object so the
-// data survives reload; bearing is in radians relative to bow.
+// VRM/EBL markers - persisted between sessions as an array payload consumed
+// by PPI.setVrmEblMarkers; bearing is in radians relative to bow.
 var vrmEblState = (() => {
   try {
     const raw = localStorage.getItem(VRM_EBL_STATE_KEY);
@@ -989,7 +989,6 @@ function createVrmEblLozenge() {
 
   const btn = document.createElement("button");
   btn.className = "myr_vrmebl_lozenge_button";
-  // Icon: crosshair + two small color dots for marker 1 and 2
   btn.innerHTML = `<svg class="myr_vrmebl_icon" viewBox="0 0 24 24">
     <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.5"/>
     <line x1="12" y1="3" x2="12" y2="21" stroke="currentColor" stroke-width="1.5"/>
@@ -1009,7 +1008,6 @@ function createVrmEblLozenge() {
   lozenge.appendChild(btn);
   container.appendChild(lozenge);
 
-  // Restore persisted marker positions and visibility into the PPI.
   if (vrmEblState && ppi) {
     ppi.setVrmEblMarkers(vrmEblState);
   }
@@ -1021,7 +1019,6 @@ function createVrmEblLozenge() {
   updateVrmEblLozenge();
 }
 
-// State sequence: 0b00 -> 0b01 -> 0b10 -> 0b11 -> 0b00
 const VRM_EBL_CYCLE = [0b00, 0b01, 0b10, 0b11];
 
 function cycleVrmEbl(direction) {


### PR DESCRIPTION
## Why

Adds Variable Range Markers and Electronic Bearing Lines, requested for radar_pi feature equivalence (closes #16).

## How

Two independent VRM/EBL pairs — cyan and magenta — each combining a range ring and a dashed bearing line. Their intersection is a draggable handle the operator can move directly to a point of interest. A readout box on each marker shows the true bearing and distance to that point, derived from `navigation.headingTrue` so the value stays correct regardless of Head-Up / North-Up mode.

A new bottom-left lozenge (above the AIS lozenge) cycles visibility through {none, #1, #2, both}; right-click steps back. The lozenge icon mirrors the marker colors. Marker positions and visibility persist in `localStorage`.

All implementation is GUI-only (web/gui), brand-agnostic, no Rust changes.

## Tested

- `cargo build --release` clean
- `cargo test --release` all 218+ tests pass
- `cr review --plain` against main — 4 findings, all addressed before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# VRM/EBL Markers with Two-Color Drag Interaction

This pull request introduces Variable Range Marker (VRM) and Electronic Bearing Line (EBL) functionality to the GUI radar overlay, enabling operators to define and manipulate points of interest with draggable marker pairs.

## Overview

The implementation adds two independent VRM/EBL marker pairs—one cyan and one magenta—to the PPI radar display. Each marker pair combines a range ring (VRM) and a dashed bearing line (EBL) that intersect at a user-defined point of interest. The marker position and visibility state persist across browser sessions via localStorage.

## Changes

### CSS Styling (web/gui/layout.css, +95 lines)
Introduces a new VRM/EBL marker toggle lozenge positioned in the bottom-left corner, positioned 62 pixels above the AIS lozenge. The styling includes:
- Base layout with flexbox container, rounded border, and dark semi-transparent background
- Interactive button states for hover, active, and focus-visible states
- Four visual variants representing marker visibility: off (both dots and crosshair dim), marker-1-only (cyan lit, magenta dim), marker-2-only (magenta lit, cyan dim), and both-markers (mixed purple tone with both dots lit)

### Core Marker Implementation (web/gui/ppi.js, +328 lines)
Adds comprehensive VRM/EBL marker support to the PPI class:
- **State management**: Internal `vrmEbl` array storing two independent markers with bearing (radians relative to bow), distance (meters), and enabled flag; also tracks drag state for interactive updates
- **Public API methods**:
  - `setVrmEblEnabled(index, enabled)` — enables/disables individual markers and auto-selects sensible defaults (half the displayed range at a 45° offset) on first enable
  - `setVrmEblMarkers(markers)` — restores marker positions from external storage without triggering persistence callbacks
  - `getVrmEblMarkers()` — returns current marker state as shallow copies
  - `VRM_EBL_COLORS` static field — defines cyan and magenta color scheme
- **Rendering**: Draws after the compass rose, including dashed bearing lines (extending to edge of display), range rings, 6-pixel intersection handles, and readout boxes showing true bearing (when heading available) or relative bearing plus formatted distance
- **Interaction**: Extended hit-testing and pointer handling to prioritize dragging intersection points first, then rings, then bearing lines; drag state updates bearing and distance during mouse/touch movement; cursor feedback indicates draggable elements
- **Drag modes**: Supports three interaction modes—dragging the ring adjusts distance, dragging the line adjusts bearing, dragging the intersection point adjusts both
- **Pointer events**: VRM/EBL editing works outside zone-edit/create modes; drag state is cleared on pointer release

### UI Controls and Persistence (web/gui/viewer.js, +128 lines)
Implements the user-facing VRM/EBL marker UI with persistence:
- **localStorage persistence**: Two keys (`mayaraVrmEbl` for marker positions, `mayaraVrmEblVisible` for visibility state) with graceful error handling for quota errors or invalid data
- **Lozenge control**: New interactive element supporting:
  - Left-click to cycle visibility through {none, marker-1-only, marker-2-only, both}
  - Right-click to cycle backward
  - SVG icon showing a crosshair with two colored dots (cyan at top-left, magenta at bottom-right)
- **State sync**: On startup, loads persisted marker configuration into the PPI; wires the PPI's `onVrmEblChange` callback to automatically save marker state back to localStorage whenever markers change
- **Visual feedback**: Lozenge CSS class updates dynamically to reflect the active visibility state

## Technical Details

- Marker bearing stored relative to bow (not screen) to remain stable when switching between Head-Up and North-Up modes
- Readout box anchor positioned 24 pixels beyond the intersection along the bearing line and offset perpendicularly to prevent overlap between two active markers
- True bearing calculated using `navigation.headingTrue` when available; falls back to relative bearing if heading is unavailable
- Distance readout formatted using existing `formatRangeValue` function to respect metric/nautical unit preferences
- All functionality isolated to web/gui modules—no Rust backend changes required
- Closes issue `#16`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->