### PR TITLE
fix(gui): keep PPI sized to the visible viewport on mobile

### DIFF
--- a/web/gui/debug.css
+++ b/web/gui/debug.css
@@ -13,6 +13,7 @@
   right: 0;
   width: 450px;
   height: 100vh;
+  height: 100dvh;
   background: #1a1a2e;
   border-left: 1px solid #333;
   display: flex;

--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -2,10 +2,15 @@
    Layout - Container, Panels, PPI, Canvas
    ============================================ */
 
-/* Main container */
+/* Main container.
+ * `100dvh` (dynamic viewport height) tracks the visible area as Chrome
+ * Mobile's URL bar collapses/expands, so the PPI canvas no longer extends
+ * past the visible viewport and the radar circle stays centred.
+ * `100vh` is the fallback for browsers without dvh support. */
 div.myr_container {
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 
@@ -17,7 +22,9 @@ div.myr_controller {
   right: 0;
   top: 0;
   height: 100vh;
+  height: 100dvh;
   max-height: 100vh;
+  max-height: 100dvh;
   overflow-y: auto;
   background-color: #111;
   z-index: 200;
@@ -38,6 +45,7 @@ div.myr_ppi {
   position: relative;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -197,6 +197,21 @@ window.onload = async function () {
     ppi.redrawCanvas();
   };
 
+  // Chrome Mobile collapses/expands its URL bar without firing window.resize,
+  // but does fire visualViewport.resize. Without this, the PPI canvas keeps
+  // the old `100dvh` size from when the bar was in the other state, and the
+  // WebGL/WebGPU backing buffer drifts out of sync with the overlay canvas —
+  // the radar image then floats above or below the range rings. Same story
+  // on orientation change for tablets.
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", () => ppi.redrawCanvas());
+  }
+  if (screen.orientation) {
+    screen.orientation.addEventListener("change", () => ppi.redrawCanvas());
+  } else {
+    window.addEventListener("orientationchange", () => ppi.redrawCanvas());
+  }
+
   // Keyboard shortcuts for display zoom
   document.addEventListener("keydown", (event) => {
     if (event.key === "i" || event.key === "I") {

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -206,7 +206,7 @@ window.onload = async function () {
   if (window.visualViewport) {
     window.visualViewport.addEventListener("resize", () => ppi.redrawCanvas());
   }
-  if (screen.orientation) {
+  if (screen.orientation && typeof screen.orientation.addEventListener === "function") {
     screen.orientation.addEventListener("change", () => ppi.redrawCanvas());
   } else {
     window.addEventListener("orientationchange", () => ppi.redrawCanvas());


### PR DESCRIPTION
## Why

On Chrome Mobile, `height: 100vh` sizes to the "large viewport height" that includes the URL-bar area, so when the URL bar is visible the PPI container extends below the visible viewport and the radar circle appears compressed into the lower half of the screen. The WebGL/WebGPU canvas backing buffer then drifts out of sync with the overlay canvas (which redraws against a fresh `getComputedStyle`), so the radar image floats above the range rings instead of sitting inside them.

Reported on Pixel 6 / Android 16 / Chrome 147 in MarineYachtRadar/mayara-server-signalk-plugin#36.

## How

- **CSS**: use `100dvh` (dynamic viewport height) which tracks the visible area as the URL bar collapses or expands. `100vh` is kept as the fallback for browsers without dvh support.
- **viewer.js**: redraw the canvas on `visualViewport.resize` and `screen.orientation.change` (with `orientationchange` fallback) too — Chrome Mobile fires those for URL-bar transitions without firing `window.resize`.

## Tested

- `cargo build --release` clean
- `cargo test --release` 222 tests pass
- `cr review --plain` against main — findings addressed before push (use `screen.orientation` over deprecated `orientationchange` event; guard for environments where `screen.orientation` exists without a usable `addEventListener`)

Closes #250 (which mirrors MarineYachtRadar/mayara-server-signalk-plugin#36 — the plugin issue will be closed manually after merge).