### PR TITLE
feat(gui): show active renderer (webgpu/webgl) in the controls header

### DIFF
--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -614,6 +614,23 @@ div.myr_ppi {
   color: rgb(100, 200, 180);
 }
 
+.myr_renderer_badge {
+  font-size: 10px;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  text-transform: lowercase;
+  color: #88a;
+  border: 1px solid #446;
+  border-radius: 3px;
+  padding: 1px 6px;
+  margin-left: 8px;
+  margin-right: auto; /* push close button to the right */
+  letter-spacing: 0.5px;
+}
+
+.myr_renderer_badge:empty {
+  display: none;
+}
+
 .myr_close_button {
   width: 32px;
   height: 32px;

--- a/web/gui/viewer.html
+++ b/web/gui/viewer.html
@@ -23,6 +23,7 @@
         <div id="myr_controller" class="myr_controller">
             <div class="myr_controls_header">
                 <span class="myr_controls_title">Radar Controls</span>
+                <span id="myr_renderer_badge" class="myr_renderer_badge" title="Active rendering backend"></span>
                 <button type="button" id="myr_close_controls" class="myr_close_button" title="Close controls">
                     <svg viewBox="0 0 24 24"><path d="M6 6 L18 18 M6 18 L18 6"/></svg>
                 </button>

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -104,6 +104,11 @@ window.onload = async function () {
 
   console.log(`Using ${renderMethod} renderer`);
 
+  const badge = document.getElementById("myr_renderer_badge");
+  if (badge) {
+    badge.textContent = renderMethod;
+  }
+
   // Load protobuf definition - must complete before websocket can process messages
   const protobufPromise = new Promise((resolve, reject) => {
     protobuf.load("./proto/RadarMessage.proto", function (err, root) {


### PR DESCRIPTION
## Why

The GUI auto-selects WebGPU when available and falls back to WebGL2, but there was no way to tell which one was active without opening DevTools and reading the console.

## How

Add a small lowercase badge next to the "Radar Controls" title that reads `webgpu` or `webgl`. The `:empty` selector keeps it invisible until `renderMethod` resolves so there's no empty box during init.

## Tested

- `cargo build --release` clean
- `cargo test --release` 222 tests pass
- `cr review --plain` against main — no findings