### PR TITLE
fix(signalk): skip upstream servers that accept then go silent

### DIFF
--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -454,9 +454,14 @@ impl ConnectionType {
 use crate::signalk::WsStream;
 
 enum Stream {
-    Tcp(TcpStream),
+    /// Plain TCP. For Signal K connections `peer` carries the upstream we
+    /// resolved so the cooldown logic can mark the server silent on close.
+    /// For non-Signal K (e.g. raw NMEA 0183) it is `None`.
+    Tcp(TcpStream, Option<SocketAddr>),
     Udp(UdpSocket),
-    WebSocket(WsStream, String),
+    /// Signal K WebSocket. `peer` carries the discovery-time SocketAddr; the
+    /// url string is the WS endpoint URL for logging.
+    WebSocket(WsStream, String, SocketAddr),
 }
 
 pub(crate) struct NavigationData {
@@ -464,6 +469,21 @@ pub(crate) struct NavigationData {
     nmea0183_mode: bool,
     what: &'static str,
     nmea_parser: Option<NmeaParser>,
+}
+
+/// Set true the first time the current Signal K receive loop sees a real
+/// delta. Reset to false in `run` before each receive loop starts; read
+/// (and reset) after the loop returns so an empty connection can be marked
+/// as a "silent" server and skipped on subsequent reconnects. Process-wide
+/// `AtomicBool` because the only writers are the receive loops on a single
+/// `NavigationData::run` task and the only reader is its caller.
+static SIGNALK_DELIVERED_DATA: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Mark the current Signal K receive loop as having delivered at least one
+/// real delta. Idempotent; safe to call on every message.
+fn mark_signalk_delivered() {
+    SIGNALK_DELIVERED_DATA.store(true, std::sync::atomic::Ordering::SeqCst);
 }
 
 impl NavigationData {
@@ -482,6 +502,31 @@ impl NavigationData {
                 what: "Signal K",
                 nmea_parser: None,
             },
+        }
+    }
+
+    /// Called after a Signal K receive loop returns. If a SocketAddr is
+    /// present (Signal K paths only) and the loop never delivered any
+    /// deltas before closing, mark the server as silent so the next
+    /// discovery cycle skips it for `SILENT_SERVER_COOLDOWN`. Conversely,
+    /// a productive connection clears any prior silent marker so a
+    /// previously-bad server that's been fixed is re-trusted right away.
+    fn update_signalk_silent_state(
+        signalk_peer: Option<SocketAddr>,
+        result: &Result<(), RadarError>,
+    ) {
+        let Some(addr) = signalk_peer else {
+            return;
+        };
+        // Shutdowns don't reflect server health — leave the cooldown alone.
+        if matches!(result, Err(RadarError::Shutdown)) {
+            return;
+        }
+        let delivered = SIGNALK_DELIVERED_DATA.swap(false, std::sync::atomic::Ordering::SeqCst);
+        if delivered {
+            crate::signalk::clear_signalk_server_silent(addr);
+        } else {
+            crate::signalk::mark_signalk_server_silent(addr);
         }
     }
 
@@ -542,7 +587,7 @@ impl NavigationData {
                 .find_service(&subsys, &mut rx_ip_change, &navigation_address)
                 .await
             {
-                Ok(Stream::Tcp(stream)) => {
+                Ok(Stream::Tcp(stream, signalk_peer)) => {
                     log::info!(
                         "Listening to {} data via TCP from {}",
                         self.what,
@@ -551,7 +596,9 @@ impl NavigationData {
                             .map(|a| a.to_string())
                             .unwrap_or_else(|_| "<unknown>".to_string())
                     );
-                    match self.receive_loop(stream, &subsys).await {
+                    let result = self.receive_loop(stream, &subsys).await;
+                    Self::update_signalk_silent_state(signalk_peer, &result);
+                    match result {
                         Err(RadarError::Shutdown) => {
                             log::debug!("{} receive_loop shutdown", self.what);
                             return Ok(());
@@ -580,9 +627,11 @@ impl NavigationData {
                         }
                     }
                 }
-                Ok(Stream::WebSocket(ws, url)) => {
+                Ok(Stream::WebSocket(ws, url, signalk_peer)) => {
                     log::info!("Listening to {} data via WebSocket from {}", self.what, url);
-                    match self.receive_ws_loop(ws, &subsys).await {
+                    let result = self.receive_ws_loop(ws, &subsys).await;
+                    Self::update_signalk_silent_state(Some(signalk_peer), &result);
+                    match result {
                         Err(RadarError::Shutdown) => {
                             log::debug!("{} receive_ws_loop shutdown", self.what);
                             return Ok(());
@@ -713,7 +762,7 @@ impl NavigationData {
 
                     match connect_first(known_addresses.clone()).await {
                         Ok(stream) => {
-                            r = Ok(Stream::Tcp(stream));
+                            r = Ok(Stream::Tcp(stream, None));
                             break;
                         }
                         Err(_e) => {}
@@ -747,7 +796,16 @@ impl NavigationData {
                 stream = connect_to_socket(addr) => {
                     match stream {
                         Ok(stream) => {
-                            return Ok(Stream::Tcp(stream));
+                            // `find_tcp_service` covers both Signal K's
+                            // explicit `tcp://host:port` and explicit
+                            // NMEA0183-over-TCP. NMEA0183 lines don't run
+                            // through `signalk_actions_for_line` so they
+                            // never call `mark_signalk_delivered` — passing
+                            // `Some(addr)` there would falsely mark a busy
+                            // NMEA server as silent. Only Signal K mode
+                            // participates in silent-server tracking.
+                            let peer = if self.nmea0183_mode { None } else { Some(addr) };
+                            return Ok(Stream::Tcp(stream, peer));
                         }
                         Err(e) => {
                             log::trace!("Failed to connect {} to {addr}: {e}", self.what);
@@ -814,6 +872,8 @@ impl NavigationData {
                 .map(|a| a.to_string())
                 .unwrap_or_else(|_| "<unknown>".to_string())
         );
+        // Each new connection starts as "no deltas seen yet".
+        SIGNALK_DELIVERED_DATA.store(false, std::sync::atomic::Ordering::SeqCst);
         let (read_half, mut write_half) = stream.split();
         let mut lines = BufReader::new(read_half).lines();
 
@@ -864,6 +924,12 @@ impl NavigationData {
             return vec![SignalKSubscription::OwnShip];
         }
 
+        // Any non-hello line is a real delta. Marking delivered_data here
+        // means a connection that produced even one update is treated as
+        // healthy; only servers that go silent after handshake get the
+        // silent-server cooldown on close.
+        mark_signalk_delivered();
+
         let had_own_ship = get_own_ship_context().is_some();
 
         if let Err(e) = parse_signalk(line) {
@@ -898,6 +964,8 @@ impl NavigationData {
     ) -> Result<(), RadarError> {
         log::info!("{} WebSocket receive_loop started", self.what);
 
+        // Each new connection starts as "no deltas seen yet".
+        SIGNALK_DELIVERED_DATA.store(false, std::sync::atomic::Ordering::SeqCst);
         let (mut write, mut read) = ws.split();
 
         loop {
@@ -1169,7 +1237,7 @@ where
 fn signalk_connection_to_stream(conn: crate::signalk::Connection) -> Stream {
     use crate::signalk::Connection;
     match conn {
-        Connection::Tcp(s) => Stream::Tcp(s),
-        Connection::WebSocket(ws, url) => Stream::WebSocket(ws, url),
+        Connection::Tcp(s, addr) => Stream::Tcp(s, Some(addr)),
+        Connection::WebSocket(ws, url, addr) => Stream::WebSocket(ws, url, addr),
     }
 }

--- a/src/lib/signalk.rs
+++ b/src/lib/signalk.rs
@@ -19,9 +19,10 @@
 
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::broadcast::Receiver;
@@ -29,6 +30,61 @@ use tokio::time::sleep;
 use tokio_graceful_shutdown::SubsystemHandle;
 
 use crate::radar::RadarError;
+
+/// How long to skip a Signal K server after it accepted a connection but
+/// produced no deltas before closing. Five minutes is short enough that an
+/// admin restarting the server with corrected auth gets picked up quickly,
+/// long enough that mayara doesn't thrash reconnecting to a misconfigured
+/// server every few seconds.
+const SILENT_SERVER_COOLDOWN: Duration = Duration::from_secs(300);
+
+fn silent_servers() -> &'static Mutex<HashMap<SocketAddr, Instant>> {
+    static MAP: OnceLock<Mutex<HashMap<SocketAddr, Instant>>> = OnceLock::new();
+    MAP.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Remember that the Signal K server at `addr` accepted a connection but did
+/// not send any deltas before closing. Cooldown elapses after
+/// `SILENT_SERVER_COOLDOWN`. Logs at info level so the operator sees which
+/// servers are being skipped — most often this means the server requires
+/// authentication and mayara was started without `--signalk-token`.
+pub(crate) fn mark_signalk_server_silent(addr: SocketAddr) {
+    if let Ok(mut map) = silent_servers().lock() {
+        map.insert(addr, Instant::now());
+    }
+    log::info!(
+        "Signal K server at {} closed without sending any deltas — skipping for {:?}. \
+         If this server requires authentication, pass `--signalk-token` or \
+         `--signalk-token-file`.",
+        addr,
+        SILENT_SERVER_COOLDOWN
+    );
+}
+
+/// Forget any prior "silent" marker for `addr`. Called when a connection to
+/// the server starts delivering data, so a previously-bad server that's been
+/// fixed is re-trusted immediately.
+pub(crate) fn clear_signalk_server_silent(addr: SocketAddr) {
+    if let Ok(mut map) = silent_servers().lock() {
+        map.remove(&addr);
+    }
+}
+
+/// Returns true if `addr` is still within the silent-disconnect cooldown.
+/// Expired entries are pruned on lookup.
+fn is_signalk_server_silent(addr: SocketAddr) -> bool {
+    let Ok(mut map) = silent_servers().lock() else {
+        return false;
+    };
+    match map.get(&addr) {
+        Some(&t) if t.elapsed() < SILENT_SERVER_COOLDOWN => true,
+        Some(_) => {
+            map.remove(&addr);
+            false
+        }
+        None => false,
+    }
+}
 
 /// mDNS service names used to locate Signal K servers on the local network.
 /// Once found, we perform Discovery and Connection Establishment per the
@@ -49,10 +105,12 @@ const EXPLICIT_RETRY_DELAY: Duration = Duration::from_secs(5);
 pub(crate) type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
 
-/// Result of a successful Signal K connection.
+/// Result of a successful Signal K connection. The `SocketAddr` is the
+/// concrete upstream we resolved and connected to — surfaced so the receive
+/// loop can mark the server silent if it never delivers any deltas.
 pub(crate) enum Connection {
-    Tcp(TcpStream),
-    WebSocket(WsStream, String),
+    Tcp(TcpStream, SocketAddr),
+    WebSocket(WsStream, String, SocketAddr),
 }
 
 /// Last-resolved upstream Signal K REST base URL (e.g.
@@ -202,6 +260,14 @@ pub(crate) async fn find_mdns_service(
         }
 
         for (addr, transport) in &addresses {
+            if is_signalk_server_silent(*addr) {
+                log::debug!(
+                    "Signal K {:?} from {} skipped (within silent-server cooldown)",
+                    transport,
+                    addr
+                );
+                continue;
+            }
             match connect_transport(*addr, *transport, accept_invalid_certs).await {
                 Ok(conn) => return Ok(conn),
                 Err(e) => {
@@ -259,7 +325,7 @@ async fn connect_transport(
         Transport::Tcp => {
             let stream = TcpStream::connect(addr).await.map_err(RadarError::Io)?;
             log::info!("Connected to Signal K via TCP: {}", addr);
-            Ok(Connection::Tcp(stream))
+            Ok(Connection::Tcp(stream, addr))
         }
         Transport::HttpDiscovery => connect_via_discovery(addr, false, accept_invalid_certs).await,
         Transport::HttpsDiscovery => connect_via_discovery(addr, true, accept_invalid_certs).await,
@@ -290,7 +356,7 @@ async fn connect_via_discovery(
     // authentication, so any future auth work will want to land there.
     if let Some(ref ws_url) = discovery.ws_url {
         match connect_websocket(ws_url, accept_invalid_certs).await {
-            Ok(ws) => return Ok(Connection::WebSocket(ws, ws_url.clone())),
+            Ok(ws) => return Ok(Connection::WebSocket(ws, ws_url.clone(), addr)),
             Err(e) => {
                 log::debug!("WS {} failed: {}, falling back to TCP", ws_url, e);
             }
@@ -302,7 +368,7 @@ async fn connect_via_discovery(
         if let Some(tcp_addr) = parse_tcp_url(tcp_url) {
             let stream = TcpStream::connect(tcp_addr).await.map_err(RadarError::Io)?;
             log::info!("Connected to Signal K via TCP: {}", tcp_url);
-            return Ok(Connection::Tcp(stream));
+            return Ok(Connection::Tcp(stream, tcp_addr));
         }
     }
 
@@ -1100,5 +1166,41 @@ mod tests {
     fn url_encode_token_escapes_reserved_chars() {
         assert_eq!(url_encode_token("a b/c"), "a%20b%2Fc");
         assert_eq!(url_encode_token("="), "%3D");
+    }
+
+    // -- silent server cooldown tests --
+    // Tests share a process-wide static map; each test uses a distinct
+    // SocketAddr (TEST-NET-1 .. TEST-NET-3 reserved per RFC 5737) so
+    // concurrent runs don't interfere.
+
+    #[test]
+    fn silent_server_is_remembered_until_cooldown() {
+        let addr: SocketAddr = "192.0.2.10:3000".parse().unwrap();
+        assert!(!is_signalk_server_silent(addr));
+        mark_signalk_server_silent(addr);
+        assert!(is_signalk_server_silent(addr));
+        clear_signalk_server_silent(addr);
+    }
+
+    #[test]
+    fn silent_server_is_cleared_when_productive_again() {
+        let addr: SocketAddr = "192.0.2.11:3000".parse().unwrap();
+        mark_signalk_server_silent(addr);
+        assert!(is_signalk_server_silent(addr));
+        clear_signalk_server_silent(addr);
+        assert!(!is_signalk_server_silent(addr));
+    }
+
+    #[test]
+    fn silent_server_expires_after_cooldown() {
+        // Insert with an old timestamp so the lookup-time pruning kicks in.
+        let addr: SocketAddr = "192.0.2.12:3000".parse().unwrap();
+        {
+            let mut map = silent_servers().lock().unwrap();
+            map.insert(addr, Instant::now() - SILENT_SERVER_COOLDOWN - Duration::from_secs(1));
+        }
+        assert!(!is_signalk_server_silent(addr));
+        // Stale entry must have been pruned.
+        assert!(silent_servers().lock().unwrap().get(&addr).is_none());
     }
 }


### PR DESCRIPTION
## Why

When several Signal K servers are advertised on the LAN (a common dev / multi-instance setup), mayara would discover them all via mDNS, connect to whichever won the race, get its WebSocket closed ~60s later without ever receiving a delta — most often because the server requires authentication that mayara wasn't started with — and then rotate to another server and repeat. The result: hundreds of nearly-identical "Signal K WebSocket connection closed" log lines and no heading or AIS data.

## How

Track which Signal K `SocketAddr` each connection talked to. If the receive loop returns without ever marking a delta delivered, record the address in a process-wide silent-server map with a 5-minute cooldown. `find_mdns_service` skips cooldowned addresses on the next discovery cycle, so mayara naturally settles on the server that's actually serving data. A productive connection clears any prior silent marker so a server that's been fixed is re-trusted right away.

The cooldown is in-memory only and tied to the running process, matching a dev-setup workflow: restart mayara and all servers get a fresh chance. The first time a server is marked silent the log includes a clear hint to try `--signalk-token` / `--signalk-token-file`. NMEA0183 explicit-`tcp://` connections are excluded from silent-server tracking — they don't run through the Signal K delta path so they'd otherwise always be marked silent.

## Tested

- Three new unit tests in `signalk::tests` covering mark/clear/expire branches of the silent-server cooldown.
- `cargo build --release` clean.
- `cargo test --release` 225 tests pass (was 222 + 3 new).
- `cr review --plain` against main flagged one critical issue (NMEA0183 false-positive on explicit `tcp://`) — fixed before push.