### PR TITLE
fix(signalk): require own-ship navigation before trusting an upstream

### DIFF
--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -1242,19 +1242,24 @@ fn apply_signalk_value(values_entry: &Value, source: &str) {
     log::trace!("parse_signalk: path = '{}', value = {:?}", path, value);
     match path {
         "navigation.position" => {
-            set_position(
-                value["latitude"].as_f64(),
-                value["longitude"].as_f64(),
-                source,
-            );
-            // First own-ship position turns the probe deadline off for the
-            // life of this connection — even a single delta tells us the
-            // upstream is publishing what the radar overlay needs.
-            mark_signalk_own_ship_nav_seen();
+            let lat = value["latitude"].as_f64();
+            let lon = value["longitude"].as_f64();
+            set_position(lat, lon, source);
+            // Only arm the probe-satisfied flag for a delta that carries a
+            // real fix. Signal K servers do publish `value: null` (or a
+            // partial position) when the upstream loses GPS — counting
+            // those would keep mayara stuck on a server that isn't
+            // actually providing nav.
+            if lat.is_some() && lon.is_some() {
+                mark_signalk_own_ship_nav_seen();
+            }
         }
         "navigation.headingTrue" => {
-            set_heading_true(value.as_f64(), source);
-            mark_signalk_own_ship_nav_seen();
+            let heading = value.as_f64();
+            set_heading_true(heading, source);
+            if heading.is_some() {
+                mark_signalk_own_ship_nav_seen();
+            }
         }
         "navigation.speedOverGround" => {
             set_sog(value.as_f64());

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -493,9 +493,10 @@ static SIGNALK_OWN_SHIP_NAV_SEEN: std::sync::atomic::AtomicBool =
 /// own-ship `navigation.position` or `navigation.headingTrue` delta
 /// before we consider the server unproductive and cool it down. Healthy
 /// Signal K servers publish nav at multi-Hz once a vessel.self GPS is
-/// configured, so 30s is generous; misconfigured servers (no GPS, no
-/// auth on a secured stream) will reliably miss this window.
-const OWN_SHIP_NAV_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+/// configured, so 5s is plenty; misconfigured servers (no GPS, no auth
+/// on a secured stream) miss this window with margin to spare, and
+/// the operator gets useful diagnostics in seconds rather than minutes.
+const OWN_SHIP_NAV_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Mark the current Signal K receive loop as having delivered at least one
 /// real delta. Idempotent; safe to call on every message.

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -472,18 +472,47 @@ pub(crate) struct NavigationData {
 }
 
 /// Set true the first time the current Signal K receive loop sees a real
-/// delta. Reset to false in `run` before each receive loop starts; read
-/// (and reset) after the loop returns so an empty connection can be marked
-/// as a "silent" server and skipped on subsequent reconnects. Process-wide
-/// `AtomicBool` because the only writers are the receive loops on a single
-/// `NavigationData::run` task and the only reader is its caller.
+/// delta. Reset to false in the receive loop's preamble. After the loop
+/// returns, the caller uses this to mark an entirely-silent server in the
+/// cooldown map.
 static SIGNALK_DELIVERED_DATA: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+
+/// Set true the first time the current Signal K receive loop sees an
+/// own-ship `navigation.position` or `navigation.headingTrue` delta. This
+/// is the tighter "useful" criterion: a server that holds the connection
+/// open and even emits some chatter but never publishes own-ship nav
+/// data is no good to a radar app, because we can't place AIS targets
+/// or rotate the overlay without it. The 30-second probe in each receive
+/// loop watches this flag and tears the connection down if it stays
+/// false past the deadline.
+static SIGNALK_OWN_SHIP_NAV_SEEN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// How long a Signal K connection is given to publish at least one
+/// own-ship `navigation.position` or `navigation.headingTrue` delta
+/// before we consider the server unproductive and cool it down. Healthy
+/// Signal K servers publish nav at multi-Hz once a vessel.self GPS is
+/// configured, so 30s is generous; misconfigured servers (no GPS, no
+/// auth on a secured stream) will reliably miss this window.
+const OWN_SHIP_NAV_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Mark the current Signal K receive loop as having delivered at least one
 /// real delta. Idempotent; safe to call on every message.
 fn mark_signalk_delivered() {
     SIGNALK_DELIVERED_DATA.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Mark that the current Signal K receive loop has seen own-ship
+/// position or heading. Called from `apply_signalk_value` when a
+/// `navigation.position` / `navigation.headingTrue` delta lands on an
+/// own-ship context.
+fn mark_signalk_own_ship_nav_seen() {
+    SIGNALK_OWN_SHIP_NAV_SEEN.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn own_ship_nav_seen() -> bool {
+    SIGNALK_OWN_SHIP_NAV_SEEN.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 impl NavigationData {
@@ -506,11 +535,16 @@ impl NavigationData {
     }
 
     /// Called after a Signal K receive loop returns. If a SocketAddr is
-    /// present (Signal K paths only) and the loop never delivered any
-    /// deltas before closing, mark the server as silent so the next
-    /// discovery cycle skips it for `SILENT_SERVER_COOLDOWN`. Conversely,
-    /// a productive connection clears any prior silent marker so a
-    /// previously-bad server that's been fixed is re-trusted right away.
+    /// present (Signal K paths only), decide which cooldown action to take
+    /// based on what arrived during the connection:
+    ///
+    /// - Own-ship navigation seen → server is fully working; clear any
+    ///   prior silent marker so a recovered server is trusted again.
+    /// - Some deltas but no own-ship nav → server holds the connection
+    ///   open but isn't publishing what mayara needs (no GPS, no auth on
+    ///   a secured stream). Mark silent with the no-nav reason.
+    /// - No deltas at all → server is completely silent. Mark silent with
+    ///   the no-deltas reason.
     fn update_signalk_silent_state(
         signalk_peer: Option<SocketAddr>,
         result: &Result<(), RadarError>,
@@ -523,8 +557,11 @@ impl NavigationData {
             return;
         }
         let delivered = SIGNALK_DELIVERED_DATA.swap(false, std::sync::atomic::Ordering::SeqCst);
-        if delivered {
+        let own_ship = SIGNALK_OWN_SHIP_NAV_SEEN.swap(false, std::sync::atomic::Ordering::SeqCst);
+        if own_ship {
             crate::signalk::clear_signalk_server_silent(addr);
+        } else if delivered {
+            crate::signalk::mark_signalk_server_silent_no_nav(addr);
         } else {
             crate::signalk::mark_signalk_server_silent(addr);
         }
@@ -872,15 +909,34 @@ impl NavigationData {
                 .map(|a| a.to_string())
                 .unwrap_or_else(|_| "<unknown>".to_string())
         );
-        // Each new connection starts as "no deltas seen yet".
+        // Each new connection starts fresh: no deltas seen yet, no own-ship
+        // nav seen yet. The own-ship-nav flag is also reset so a previous
+        // healthy connection's state doesn't make a new unhealthy one look
+        // OK on close.
         SIGNALK_DELIVERED_DATA.store(false, std::sync::atomic::Ordering::SeqCst);
+        SIGNALK_OWN_SHIP_NAV_SEEN.store(false, std::sync::atomic::Ordering::SeqCst);
         let (read_half, mut write_half) = stream.split();
         let mut lines = BufReader::new(read_half).lines();
+
+        // The own-ship-nav probe only applies to Signal K connections;
+        // NMEA0183-over-TCP carries its own sentences and isn't expected
+        // to produce Signal K navigation deltas.
+        let probe_active = !self.nmea0183_mode;
+        let probe_deadline = tokio::time::sleep(OWN_SHIP_NAV_PROBE_TIMEOUT);
+        tokio::pin!(probe_deadline);
 
         loop {
             tokio::select! { biased;
                 _ = subsys.on_shutdown_requested() => {
                     log::debug!("{} receive_loop shutdown", self.what);
+                    return Ok(());
+                },
+                _ = &mut probe_deadline, if probe_active && !own_ship_nav_seen() => {
+                    log::warn!(
+                        "{} no own-ship navigation within {:?}; dropping connection",
+                        self.what,
+                        OWN_SHIP_NAV_PROBE_TIMEOUT,
+                    );
                     return Ok(());
                 },
                 r = lines.next_line() => {
@@ -964,14 +1020,33 @@ impl NavigationData {
     ) -> Result<(), RadarError> {
         log::info!("{} WebSocket receive_loop started", self.what);
 
-        // Each new connection starts as "no deltas seen yet".
+        // Each new connection starts fresh; see receive_loop preamble for
+        // the rationale on resetting both flags.
         SIGNALK_DELIVERED_DATA.store(false, std::sync::atomic::Ordering::SeqCst);
+        SIGNALK_OWN_SHIP_NAV_SEEN.store(false, std::sync::atomic::Ordering::SeqCst);
         let (mut write, mut read) = ws.split();
+
+        // Probe deadline: if no own-ship navigation arrives within
+        // OWN_SHIP_NAV_PROBE_TIMEOUT, return Ok so the caller's
+        // update_signalk_silent_state cools the server down with the
+        // no-nav reason. The select arm is guarded by `if !own_ship_nav_seen()`
+        // so it stops firing as soon as we get the data we wanted.
+        let probe_deadline = tokio::time::sleep(OWN_SHIP_NAV_PROBE_TIMEOUT);
+        tokio::pin!(probe_deadline);
 
         loop {
             tokio::select! { biased;
                 _ = subsys.on_shutdown_requested() => {
                     log::debug!("{} receive_ws_loop shutdown", self.what);
+                    let _ = write.close().await;
+                    return Ok(());
+                },
+                _ = &mut probe_deadline, if !own_ship_nav_seen() => {
+                    log::warn!(
+                        "{} no own-ship navigation within {:?}; dropping connection",
+                        self.what,
+                        OWN_SHIP_NAV_PROBE_TIMEOUT,
+                    );
                     let _ = write.close().await;
                     return Ok(());
                 },
@@ -1172,9 +1247,14 @@ fn apply_signalk_value(values_entry: &Value, source: &str) {
                 value["longitude"].as_f64(),
                 source,
             );
+            // First own-ship position turns the probe deadline off for the
+            // life of this connection — even a single delta tells us the
+            // upstream is publishing what the radar overlay needs.
+            mark_signalk_own_ship_nav_seen();
         }
         "navigation.headingTrue" => {
             set_heading_true(value.as_f64(), source);
+            mark_signalk_own_ship_nav_seen();
         }
         "navigation.speedOverGround" => {
             set_sog(value.as_f64());

--- a/src/lib/signalk.rs
+++ b/src/lib/signalk.rs
@@ -61,6 +61,26 @@ pub(crate) fn mark_signalk_server_silent(addr: SocketAddr) {
     );
 }
 
+/// Remember that the Signal K server at `addr` accepted a connection and
+/// even sent some deltas, but never published own-ship navigation
+/// (`navigation.position` / `navigation.headingTrue`). Same cooldown as
+/// `mark_signalk_server_silent` but with a more specific log message —
+/// this case typically means the upstream has no GPS configured or its
+/// security settings hide `vessels.self` from anonymous readers.
+pub(crate) fn mark_signalk_server_silent_no_nav(addr: SocketAddr) {
+    if let Ok(mut map) = silent_servers().lock() {
+        map.insert(addr, Instant::now());
+    }
+    log::info!(
+        "Signal K server at {} did not publish own-ship navigation — skipping for {:?}. \
+         Check that the upstream is producing `navigation.position` or \
+         `navigation.headingTrue` for `vessels.self` (anonymous-read security \
+         policies or a missing GPS source are the usual culprits).",
+        addr,
+        SILENT_SERVER_COOLDOWN
+    );
+}
+
 /// Forget any prior "silent" marker for `addr`. Called when a connection to
 /// the server starts delivering data, so a previously-bad server that's been
 /// fixed is re-trusted immediately.
@@ -231,6 +251,14 @@ pub(crate) async fn find_mdns_service(
 
     log::debug!("Signal K find_mdns_service (re)start");
 
+    // Every Signal K SocketAddr we've ever resolved during this discovery
+    // cycle. Used purely to produce the one-shot "all known servers in
+    // cooldown" WARN below; cleared on successful connect (in the caller's
+    // next iteration this function starts fresh).
+    let mut seen_addresses: std::collections::HashSet<SocketAddr> =
+        std::collections::HashSet::new();
+    let mut all_failed_warned = false;
+
     loop {
         // `biased` gives HTTPS precedence over HTTP, and both over plain TCP,
         // so when a server advertises multiple transports we naturally pick
@@ -259,6 +287,10 @@ pub(crate) async fn find_mdns_service(
             continue;
         }
 
+        for (addr, _) in &addresses {
+            seen_addresses.insert(*addr);
+        }
+
         for (addr, transport) in &addresses {
             if is_signalk_server_silent(*addr) {
                 log::debug!(
@@ -274,6 +306,33 @@ pub(crate) async fn find_mdns_service(
                     log::debug!("Signal K {:?} from {} failed: {}", transport, addr, e);
                 }
             }
+        }
+
+        // After working through this batch, check whether every Signal K
+        // server we've ever seen this cycle is now in cooldown. If so,
+        // tell the operator once — mDNS may still surface re-resolution
+        // events for the same servers, so without this gate the operator
+        // sees nothing while mayara silently waits for the cooldowns to
+        // expire (5 min). The warning is reset as soon as we succeed in
+        // connecting to anything (return path above).
+        if !all_failed_warned
+            && !seen_addresses.is_empty()
+            && seen_addresses.iter().all(|a| is_signalk_server_silent(*a))
+        {
+            let list = seen_addresses
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            log::warn!(
+                "All discovered Signal K servers are in cooldown: {}. \
+                 mayara will keep retrying as cooldowns expire ({:?} each). \
+                 Configure `--signalk-token`/`--signalk-token-file` or fix the \
+                 upstream nav data source to recover.",
+                list,
+                SILENT_SERVER_COOLDOWN
+            );
+            all_failed_warned = true;
         }
     }
 }
@@ -1202,5 +1261,17 @@ mod tests {
         assert!(!is_signalk_server_silent(addr));
         // Stale entry must have been pruned.
         assert!(silent_servers().lock().unwrap().get(&addr).is_none());
+    }
+
+    #[test]
+    fn silent_server_no_nav_marker_uses_same_cooldown_map() {
+        // The no-nav variant has a different log message but feeds the
+        // same cooldown set, so the discovery loop skips both equally.
+        let addr: SocketAddr = "192.0.2.13:3000".parse().unwrap();
+        assert!(!is_signalk_server_silent(addr));
+        mark_signalk_server_silent_no_nav(addr);
+        assert!(is_signalk_server_silent(addr));
+        clear_signalk_server_silent(addr);
+        assert!(!is_signalk_server_silent(addr));
     }
 }


### PR DESCRIPTION
## Why

PR #256 cooled down servers that closed without sending any deltas at all, which made mayara settle on the first server that kept its WebSocket open. That's not strong enough: a server can keep the WS open indefinitely while publishing AIS or other vessel data but never producing the own-ship `navigation.position` / `navigation.headingTrue` mayara needs to place AIS targets and rotate the overlay. The result looked like "AIS targets not appearing" even though mayara was happily connected.

## How

- Each receive loop now races a 30-second probe against the message read. If no own-ship nav delta arrives within the window, the loop drops the connection and the caller cools the server down with a distinct "did not publish own-ship navigation" log explaining what to check (security policy / GPS source).
- A first nav delta cancels the probe for the life of the connection.
- One-shot WARN when every Signal K server we've discovered this cycle is in cooldown, so the operator sees mayara isn't silently spinning while waiting for cooldowns to expire. Reset on successful connect so a recovered network produces the warning afresh next time.
- NMEA0183-over-TCP connections skip the probe — they don't go through the Signal K delta path.

## Tested

- New unit test for the no-nav cooldown marker.
- `cargo build --release` clean.
- `cargo test --release` 226 tests pass (was 225 + 1 new).
- `cr review --plain` against main — no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Signal K connections now require receipt of own-ship navigation data (`navigation.position` or `navigation.headingTrue`) within 30 seconds to be considered successfully connected.

**src/lib/navdata.rs**: Introduces `SIGNALK_OWN_SHIP_NAV_SEEN` flag to track when own-ship navigation deltas have been applied, separate from the existing `SIGNALK_DELIVERED_DATA` flag. Both TCP and WebSocket Signal K receive loops enforce a 30-second probe deadline that closes the connection if own-ship navigation is not received within the window. Receipt of the first own-ship navigation delta disables the probe for the connection's lifetime. NMEA0183-over-TCP connections bypass the probe entirely. Connection health state is updated to distinguish between servers with no deltas, servers with deltas but no own-ship navigation, and servers providing own-ship navigation.

**src/lib/signalk.rs**: Adds `mark_signalk_server_silent_no_nav()` to cool down servers that connect successfully but don't publish own-ship navigation, using the same cooldown mechanism as the existing silent marker. The mDNS discovery loop now tracks all Signal K socket addresses seen in the current discovery cycle and emits a single warning when every discovered server is in cooldown, listing the affected addresses and providing guidance about configuration (`--signalk-token`) and upstream navigation data sources. This warning resets on successful connection.

## Testing

Adds unit test verifying that the no-nav silent marker shares cooldown tracking with the existing silent marker. All 226 tests pass (225 existing + 1 new).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->