### PR TITLE
feat(arpa): emit Signal K notifications for guard-zone target acquisition

### DIFF
--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -109,6 +109,14 @@ pub struct TrackerManager {
     sk_client_tx: broadcast::Sender<SignalKDelta>,
     /// Command receiver for MARPA requests and control changes
     command_rx: mpsc::Receiver<TrackerCommand>,
+    /// Active target count per (radar_key, guard_zone_index). Indexes 0
+    /// and 1 correspond to guard zones 1 and 2 (manual MARPA acquisitions
+    /// use GuardZone(0), which we skip). The counter is incremented when
+    /// a target is first acquired (Acquiring) inside the zone and
+    /// decremented when it goes Lost. A 0->1 transition emits an `alert`
+    /// `notifications.radar.<key>.guardZone.<n>`; a non-zero->0
+    /// transition emits the matching `normal` clear.
+    guard_zone_active: HashMap<String, [u32; 2]>,
 }
 
 impl TrackerManager {
@@ -131,9 +139,88 @@ impl TrackerManager {
             next_radar_index: 1,
             sk_client_tx,
             command_rx,
+            guard_zone_active: HashMap::new(),
         };
 
         (manager, command_tx)
+    }
+
+    /// Record a new guard-zone target acquisition and emit the SK
+    /// `notifications.radar.<key>.guardZone.<zone>` alert on the
+    /// 0 -> 1 transition. Idempotent on higher counts so a flurry of
+    /// blob hits inside the same zone produces a single alarm.
+    fn enter_guard_zone(&mut self, radar_key: &str, zone: u8) {
+        if zone == 0 || zone > 2 {
+            return;
+        }
+        let counts = self
+            .guard_zone_active
+            .entry(radar_key.to_string())
+            .or_insert([0; 2]);
+        let idx = (zone - 1) as usize;
+        let prev = counts[idx];
+        counts[idx] = prev.saturating_add(1);
+        if prev == 0 {
+            self.emit_guard_zone_notification(
+                radar_key,
+                zone,
+                crate::stream::NotificationState::Alert,
+                format!("Radar {} guard zone {}: target acquired", radar_key, zone),
+            );
+        }
+    }
+
+    /// Record a guard-zone target transitioning to Lost and emit the
+    /// matching `normal` clear when the last target in the zone leaves.
+    fn leave_guard_zone(&mut self, radar_key: &str, zone: u8) {
+        if zone == 0 || zone > 2 {
+            return;
+        }
+        let Some(counts) = self.guard_zone_active.get_mut(radar_key) else {
+            return;
+        };
+        let idx = (zone - 1) as usize;
+        let prev = counts[idx];
+        if prev == 0 {
+            return;
+        }
+        counts[idx] = prev - 1;
+        if counts[idx] == 0 {
+            self.emit_guard_zone_notification(
+                radar_key,
+                zone,
+                crate::stream::NotificationState::Normal,
+                format!("Radar {} guard zone {}: clear", radar_key, zone),
+            );
+        }
+    }
+
+    fn emit_guard_zone_notification(
+        &self,
+        radar_key: &str,
+        zone: u8,
+        state: crate::stream::NotificationState,
+        message: String,
+    ) {
+        use crate::stream::{NotificationMethod, NotificationValue};
+        let path = format!(
+            "notifications.radar.{}.guardZone.{}",
+            radar_key, zone
+        );
+        let method = match state {
+            crate::stream::NotificationState::Normal => Vec::new(),
+            _ => vec![NotificationMethod::Visual, NotificationMethod::Sound],
+        };
+        let value = NotificationValue {
+            state,
+            method,
+            message,
+        };
+        let mut delta = SignalKDelta::new();
+        delta.add_notification_update(&path, value, "mayara");
+        if let Err(e) = self.sk_client_tx.send(delta) {
+            log::trace!("Failed to broadcast guard-zone notification: {}", e);
+        }
     }
 
     /// Get or create tracker for a radar
@@ -240,6 +327,15 @@ impl TrackerManager {
                 if let Err(e) = self.sk_client_tx.send(delta) {
                     log::trace!("Failed to broadcast promoted target: {}", e);
                 }
+            }
+        }
+
+        // Fire the guard-zone alarm on the first acquisition of a target
+        // inside the zone. Subsequent matches against the same target go
+        // through ProcessResult::Updated and don't touch the counter.
+        if let ProcessResult::NewAcquiring(_) = result {
+            if let CandidateSource::GuardZone(zone) = source {
+                self.enter_guard_zone(&msg.radar_key, zone);
             }
         }
 
@@ -445,6 +541,10 @@ impl TrackerManager {
         // Format: (target_id, radar_key, api)
         let mut lost_updates: Vec<(u64, String, ArpaTargetApi)> = Vec::new();
         let mut deletions: Vec<(u64, String)> = Vec::new(); // (target_id, radar_key)
+        // (radar_key, zone) pairs to decrement the guard-zone counter for.
+        // Collected here so the SK notification emission happens outside
+        // the tracker borrow below.
+        let mut guard_zone_exits: Vec<(String, u8)> = Vec::new();
 
         if self.merge_mode {
             if let Some(ref mut tracker) = self.shared_tracker {
@@ -454,6 +554,9 @@ impl TrackerManager {
                 for id in &lost_ids {
                     if let Some(target) = tracker.get_target(*id) {
                         let radar_key = target.last_radar_key.clone();
+                        if let Some(zone) = target.source_zone {
+                            guard_zone_exits.push((radar_key.clone(), zone));
+                        }
                         let api = active_target_to_api(target, target.last_radar_position.as_ref());
                         lost_updates.push((*id, radar_key, api));
                     }
@@ -478,6 +581,9 @@ impl TrackerManager {
                     // Collect lost status updates
                     for id in &lost_ids {
                         if let Some(target) = tracker.get_target(*id) {
+                            if let Some(zone) = target.source_zone {
+                                guard_zone_exits.push((radar_key.clone(), zone));
+                            }
                             let api =
                                 active_target_to_api(target, target.last_radar_position.as_ref());
                             lost_updates.push((*id, radar_key.clone(), api));
@@ -490,6 +596,12 @@ impl TrackerManager {
                     }
                 }
             }
+        }
+
+        // Drive the guard-zone counter and emit any 0-transition `normal`
+        // notifications now that the tracker borrow has ended.
+        for (radar_key, zone) in guard_zone_exits {
+            self.leave_guard_zone(&radar_key, zone);
         }
 
         // Now broadcast outside the tracker borrow
@@ -951,5 +1063,75 @@ mod tests {
         let radar_pos = GeoPosition::new(52.0, 4.0);
         let targets = manager.get_targets_api(Some(radar_pos));
         assert!(targets.is_empty()); // No blobs processed yet
+    }
+
+    /// Sink that drains the broadcast channel into a Vec so tests can
+    /// assert on the deltas the manager emits.
+    fn drain_sk_deltas(
+        mut rx: tokio::sync::broadcast::Receiver<SignalKDelta>,
+    ) -> Vec<SignalKDelta> {
+        let mut out = Vec::new();
+        while let Ok(delta) = rx.try_recv() {
+            out.push(delta);
+        }
+        out
+    }
+
+    fn make_test_manager_with_rx() -> (TrackerManager, tokio::sync::broadcast::Receiver<SignalKDelta>) {
+        let (sk_tx, sk_rx) = broadcast::channel(16);
+        let (manager, _command_tx) = TrackerManager::new(false, sk_tx);
+        (manager, sk_rx)
+    }
+
+    #[test]
+    fn guard_zone_alert_fires_on_first_acquisition_only() {
+        let (mut manager, rx) = make_test_manager_with_rx();
+        manager.enter_guard_zone("nav1", 1);
+        manager.enter_guard_zone("nav1", 1);
+        manager.enter_guard_zone("nav1", 1);
+        let deltas = drain_sk_deltas(rx);
+        // 0->1 fires alert; the next two are 1->2 and 2->3 so stay quiet.
+        assert_eq!(deltas.len(), 1);
+    }
+
+    #[test]
+    fn guard_zone_normal_fires_on_last_target_leaving() {
+        let (mut manager, rx) = make_test_manager_with_rx();
+        manager.enter_guard_zone("nav1", 1);
+        manager.enter_guard_zone("nav1", 1);
+        manager.leave_guard_zone("nav1", 1); // 2 -> 1, still alarming
+        manager.leave_guard_zone("nav1", 1); // 1 -> 0, clear
+        let deltas = drain_sk_deltas(rx);
+        // First alert + final normal.
+        assert_eq!(deltas.len(), 2);
+    }
+
+    #[test]
+    fn guard_zone_counters_are_per_radar_and_per_zone() {
+        let (mut manager, rx) = make_test_manager_with_rx();
+        manager.enter_guard_zone("nav1", 1);
+        manager.enter_guard_zone("nav1", 2);
+        manager.enter_guard_zone("nav2", 1);
+        // Three independent 0->1 transitions, three alerts.
+        assert_eq!(drain_sk_deltas(rx).len(), 3);
+    }
+
+    #[test]
+    fn guard_zone_skips_marpa_zone_zero() {
+        let (mut manager, rx) = make_test_manager_with_rx();
+        manager.enter_guard_zone("nav1", 0);
+        manager.leave_guard_zone("nav1", 0);
+        // Zone 0 is MARPA / manual acquisition and shouldn't produce
+        // guard-zone notifications.
+        assert!(drain_sk_deltas(rx).is_empty());
+    }
+
+    #[test]
+    fn guard_zone_leave_below_zero_is_noop() {
+        let (mut manager, rx) = make_test_manager_with_rx();
+        manager.leave_guard_zone("nav1", 1);
+        manager.leave_guard_zone("nav1", 1);
+        // No prior enter; leaves should not emit a `normal` from nothing.
+        assert!(drain_sk_deltas(rx).is_empty());
     }
 }

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -144,6 +144,31 @@ impl SignalKDelta {
         self.updates.push(delta_update);
     }
 
+    /// Add a Signal K `notifications.*` alarm update.
+    ///
+    /// The notification payload follows the Signal K alarm shape:
+    /// `{ state, method, message }`. State drives downstream UI severity
+    /// (alert < warn < alarm < emergency); `normal` clears a prior
+    /// notification at the same path. Method tells consumers whether to
+    /// show a visual badge, play a sound, or both.
+    pub(crate) fn add_notification_update(
+        &mut self,
+        path: &str,
+        value: NotificationValue,
+        source: &str,
+    ) {
+        let delta_update = DeltaUpdate {
+            timestamp: Some(Utc::now()),
+            source: Some(source.to_string()),
+            meta: Vec::new(),
+            values: vec![DeltaValue::Notification {
+                path: path.to_string(),
+                value,
+            }],
+        };
+        self.updates.push(delta_update);
+    }
+
     /// Add an AIS vessel update to the delta message.
     pub fn add_ais_vessel_update(&mut self, path: &str, vessel: &crate::ais::AisVesselApi) {
         let value = serde_json::to_value(vessel).unwrap_or(serde_json::Value::Null);
@@ -254,6 +279,46 @@ enum DeltaValue {
         /// Structured vessel data
         value: serde_json::Value,
     },
+    /// Signal K `notifications.*` alarm. Payload shape matches the
+    /// notification value defined in the Signal K spec.
+    Notification {
+        /// Full path under `notifications.` (e.g.
+        /// `notifications.radar.fur6424A.guardZone.1`).
+        path: String,
+        value: NotificationValue,
+    },
+}
+
+/// Signal K notification alarm payload. State / method / message map
+/// directly to the spec's notification value object; `state == "normal"`
+/// clears a prior alarm at the same path.
+#[derive(Serialize, Clone, Debug, ToSchema)]
+pub(crate) struct NotificationValue {
+    pub(crate) state: NotificationState,
+    pub(crate) method: Vec<NotificationMethod>,
+    pub(crate) message: String,
+}
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "lowercase")]
+// Warn / Alarm / Emergency exist to match the Signal K spec ordering
+// (Normal < Alert < Warn < Alarm < Emergency); they aren't constructed
+// yet but follow-up notification types (e.g. radar connection lost,
+// CPA/TCPA breach) will need them.
+#[allow(dead_code)]
+pub(crate) enum NotificationState {
+    Normal,
+    Alert,
+    Warn,
+    Alarm,
+    Emergency,
+}
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum NotificationMethod {
+    Visual,
+    Sound,
 }
 
 /// Geographic position (decimal degrees) serialized to match the Signal K
@@ -272,6 +337,7 @@ impl DeltaValue {
             DeltaValue::Navigation { path, .. } => path,
             DeltaValue::NavigationPosition { path, .. } => path,
             DeltaValue::Ais { path, .. } => path,
+            DeltaValue::Notification { path, .. } => path,
         }
     }
 }


### PR DESCRIPTION
## Why

Mayara tracks targets acquired inside a configured guard zone (carrying `CandidateSource::GuardZone(N)`) but never told anything outside its own GUI about them. Operators on chart plotters or other SK consumers had no way to surface a guard-zone breach.

Closes part of #69.

## How

Per-`(radar_key, zone)` active-target counter on `TrackerManager`. When a target is first acquired in zone N (`ProcessResult::NewAcquiring`), the 0 → 1 transition emits

```
notifications.radar.<key>.guardZone.<N>
```

with `state: "alert"`, `method: ["visual", "sound"]`, matching the Signal K notifications spec. When the last target with `source_zone = Some(N)` goes Lost, the matching `state: "normal"` clears the alarm. Subsequent acquisitions while the alarm is already active just bump the counter — one alarm per zone, not per target.

MARPA acquisitions (`CandidateSource::GuardZone(0)`) are deliberately skipped: that's a manual operator click, not a zone breach. Zone indices outside `1..=2` are no-ops.

The notification flows through the existing `SignalKDelta` broadcast bus into the v2 stream WebSocket, with `$source = "mayara"`. Plumbing the deltas onward to the upstream Signal K server is a plugin-side concern and tracked separately.

## Tested

- 5 new unit tests covering: first-acquisition-only alert, last-leave-only normal, per-radar/per-zone independence, MARPA (zone 0) skip, leave-without-prior-enter is a no-op.
- `cargo build --release` clean, no warnings.
- `cargo test --release` 231 tests pass (was 226 + 5 new).
- `cr review --plain` against main flagged one major finding (visibility tightening from `pub` to `pub(crate)`) — fixed before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Enables Signal K notification emission when targets are acquired or lost within configured guard zones. TrackerManager tracks active targets per radar and zone, emitting "alert" notifications on first acquisition and "normal" notifications when the last target exits a zone.

## Changes

### TrackerManager Guard Zone Tracking (`src/lib/radar/target/manager.rs`)

TrackerManager maintains a per-radar, per-zone active-target counter (`guard_zone_active: HashMap<String, [u32; 2]>`). During blob processing, newly acquiring targets with `CandidateSource::GuardZone(zone)` increment the counter for zones 1–2; a 0 → 1 transition triggers an "alert" notification at `notifications.radar.<key>.guardZone.<n>` with visual and sound methods. Lost targets decrement the counter, and a transition to 0 emits a "normal" notification to clear the alarm. Manual MARPA acquisitions (zone 0) and out-of-range zone indices (> 2) are no-ops. Timeout handling collects lost targets without holding a mutable reference, queueing zone exits for processing after the borrow completes to avoid conflicts. Unit tests verify first-acquisition-only alerts, last-leave-only clears, per-radar and per-zone independence, MARPA skipping, and no-op behavior on exits without prior entry.

### Signal K Notification Serialization (`src/lib/stream.rs`)

Extends `SignalKDelta` with notification support via a new `add_notification_update(path, value, source)` helper. The `DeltaValue` enum gains a `Notification` variant carrying a fully-qualified `notifications.*` path and a strongly-typed `NotificationValue` struct. `NotificationValue` models `{ state, method, message }` with `NotificationState` (Normal, Alert, Warn, Alarm, Emergency) and `NotificationMethod` (Visual, Sound) enums for strict typing and correct serialization (lowercase). The `DeltaValue::path()` accessor includes notification values in its result set.

## Source

Notifications are published via the existing Signal K delta broadcast bus into the v2 stream WebSocket with `$source = "mayara"`. Forwarding deltas to an upstream Signal K server is handled separately by plugins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->