### PR TITLE
fix(web): respect X-Forwarded-Proto and Host port for advertised WS URLs

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -15,7 +15,6 @@ use std::{
     collections::HashMap,
     io,
     net::{IpAddr, Ipv6Addr, SocketAddr},
-    str::FromStr,
     sync::Arc,
 };
 use thiserror::Error;
@@ -298,24 +297,55 @@ async fn root_redirect() -> Redirect {
     Redirect::to("/gui/")
 }
 
+/// Derive the public-facing host, HTTP scheme, and WS scheme from request headers.
+///
+/// Respects `X-Forwarded-Proto` for reverse-proxy setups (e.g. Traefik TLS
+/// termination) and uses the `Host` header as-is so that external ports are
+/// preserved rather than replaced with the internal listen port.
+pub(crate) fn derive_public_base(
+    headers: &hyper::header::HeaderMap,
+    tls: bool,
+    fallback_port: u16,
+) -> (String, &'static str, &'static str) {
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(|h| {
+            // Append fallback port only when the Host header has none.
+            if h.contains(':') {
+                h.to_string()
+            } else {
+                format!("{}:{}", h, fallback_port)
+            }
+        })
+        .unwrap_or_else(|| format!("localhost:{}", fallback_port));
+
+    let forwarded_proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok());
+    let (http_scheme, ws_scheme) = match forwarded_proto {
+        Some("https") => ("https", "wss"),
+        Some(_) => ("http", "ws"),
+        None => {
+            if tls {
+                ("https", "wss")
+            } else {
+                ("http", "ws")
+            }
+        }
+    };
+
+    (host, http_scheme, ws_scheme)
+}
+
 async fn quit_handler(State(state): State<Web>) -> &'static str {
     let _ = state.shutdown_tx.send(());
     "bye\n"
 }
 
 async fn endpoints(State(state): State<Web>, headers: hyper::header::HeaderMap) -> Response {
-    let host: String = match headers.get(axum::http::header::HOST) {
-        Some(host) => host.to_str().unwrap_or("localhost").to_string(),
-        None => "localhost".to_string(),
-    };
-    let host = format!(
-        "{}:{}",
-        match Uri::from_str(&host) {
-            Ok(uri) => uri.host().unwrap_or("localhost").to_string(),
-            Err(_) => "localhost".to_string(),
-        },
-        state.args.port
-    );
+    let (host, http_scheme, ws_scheme) =
+        derive_public_base(&headers, state.tls, state.args.port);
 
     let mut endpoints = Endpoints {
         endpoints: HashMap::new(),
@@ -323,11 +353,6 @@ async fn endpoints(State(state): State<Web>, headers: hyper::header::HeaderMap) 
             version: VERSION,
             id: PACKAGE,
         },
-    };
-    let (http_scheme, ws_scheme) = if state.tls {
-        ("https", "wss")
-    } else {
-        ("http", "ws")
     };
     endpoints.endpoints.insert(
         "v2".to_string(),

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -302,40 +302,193 @@ async fn root_redirect() -> Redirect {
 /// Respects `X-Forwarded-Proto` for reverse-proxy setups (e.g. Traefik TLS
 /// termination) and uses the `Host` header as-is so that external ports are
 /// preserved rather than replaced with the internal listen port.
+///
+/// `X-Forwarded-Proto` is trusted unconditionally; ensure mayara is only
+/// reachable from trusted proxies when running behind one.
 pub(crate) fn derive_public_base(
     headers: &hyper::header::HeaderMap,
     tls: bool,
     fallback_port: u16,
 ) -> (String, &'static str, &'static str) {
+    // X-Forwarded-Proto may be comma-chained ("https, http") when requests
+    // pass through multiple proxies; the leftmost value is the original.
+    // Accept any casing — some proxies emit "HTTPS" or "Https".
+    let proxied_https = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().eq_ignore_ascii_case("https"))
+        .unwrap_or(false);
+
+    let behind_proxy = headers.contains_key("x-forwarded-proto");
+
     let host = headers
         .get(axum::http::header::HOST)
         .and_then(|v| v.to_str().ok())
         .map(|h| {
-            // Append fallback port only when the Host header has none.
             if h.contains(':') {
+                // Host already carries a port — use as-is.
+                h.to_string()
+            } else if behind_proxy {
+                // Proxy is present but Host has no port: the proxy is
+                // listening on the protocol's default port (80/443), so
+                // omit the port and let the scheme imply it.
                 h.to_string()
             } else {
+                // Direct access with no port in Host — append the
+                // internal listen port so the URL is reachable.
                 format!("{}:{}", h, fallback_port)
             }
         })
         .unwrap_or_else(|| format!("localhost:{}", fallback_port));
 
-    let forwarded_proto = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok());
-    let (http_scheme, ws_scheme) = match forwarded_proto {
-        Some("https") => ("https", "wss"),
-        Some(_) => ("http", "ws"),
-        None => {
-            if tls {
-                ("https", "wss")
-            } else {
-                ("http", "ws")
-            }
-        }
+    let (http_scheme, ws_scheme) = if proxied_https || (!behind_proxy && tls) {
+        ("https", "wss")
+    } else {
+        ("http", "ws")
     };
 
     (host, http_scheme, ws_scheme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::header::HeaderMap;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in pairs {
+            map.insert(
+                hyper::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                hyper::header::HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn no_headers_uses_fallback() {
+        let (host, http, ws) = derive_public_base(&HeaderMap::new(), false, 6502);
+        assert_eq!(host, "localhost:6502");
+        assert_eq!(http, "http");
+        assert_eq!(ws, "ws");
+    }
+
+    #[test]
+    fn no_headers_native_tls_uses_https() {
+        let (host, http, ws) = derive_public_base(&HeaderMap::new(), true, 6502);
+        assert_eq!(host, "localhost:6502");
+        assert_eq!(http, "https");
+        assert_eq!(ws, "wss");
+    }
+
+    #[test]
+    fn host_with_port_preserved() {
+        let h = headers(&[("host", "halos.local:4434")]);
+        let (host, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local:4434");
+        assert_eq!(http, "http");
+        assert_eq!(ws, "ws");
+    }
+
+    #[test]
+    fn host_without_port_appends_fallback_on_direct_access() {
+        let h = headers(&[("host", "halos.local")]);
+        let (host, _, _) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local:6502");
+    }
+
+    #[test]
+    fn forwarded_proto_https_sets_wss() {
+        let h = headers(&[
+            ("host", "halos.local:4434"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let (host, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local:4434");
+        assert_eq!(http, "https");
+        assert_eq!(ws, "wss");
+    }
+
+    #[test]
+    fn forwarded_proto_https_no_port_in_host_omits_port() {
+        // Proxy on standard port 443: Host has no port, X-Forwarded-Proto: https.
+        // We must NOT append fallback_port — the URL should be wss://halos.local.
+        let h = headers(&[
+            ("host", "halos.local"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let (host, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local");
+        assert_eq!(http, "https");
+        assert_eq!(ws, "wss");
+    }
+
+    #[test]
+    fn forwarded_proto_case_insensitive() {
+        for proto in &["HTTPS", "Https", "hTTpS"] {
+            let h = headers(&[("host", "halos.local:4434"), ("x-forwarded-proto", proto)]);
+            let (_, http, ws) = derive_public_base(&h, false, 6502);
+            assert_eq!(http, "https", "proto={proto}");
+            assert_eq!(ws, "wss", "proto={proto}");
+        }
+    }
+
+    #[test]
+    fn forwarded_proto_comma_chained_takes_first() {
+        // Multiple proxies can append values: "https, http"
+        let h = headers(&[
+            ("host", "halos.local:4434"),
+            ("x-forwarded-proto", "https, http"),
+        ]);
+        let (_, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(http, "https");
+        assert_eq!(ws, "wss");
+    }
+
+    #[test]
+    fn forwarded_proto_http_gives_ws() {
+        let h = headers(&[
+            ("host", "halos.local:8080"),
+            ("x-forwarded-proto", "http"),
+        ]);
+        let (_, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(http, "http");
+        assert_eq!(ws, "ws");
+    }
+
+    #[test]
+    fn forwarded_proto_unknown_falls_back_to_ws() {
+        let h = headers(&[
+            ("host", "halos.local:8080"),
+            ("x-forwarded-proto", "ftp"),
+        ]);
+        let (_, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(http, "http");
+        assert_eq!(ws, "ws");
+    }
+
+    #[test]
+    fn native_tls_without_proxy_uses_https() {
+        let h = headers(&[("host", "halos.local:8443")]);
+        let (host, http, ws) = derive_public_base(&h, true, 6502);
+        assert_eq!(host, "halos.local:8443");
+        assert_eq!(http, "https");
+        assert_eq!(ws, "wss");
+    }
+
+    #[test]
+    fn proxy_overrides_native_tls_flag() {
+        // Proxy says http even though server has TLS certs loaded — trust proxy.
+        let h = headers(&[
+            ("host", "halos.local:80"),
+            ("x-forwarded-proto", "http"),
+        ]);
+        let (_, http, ws) = derive_public_base(&h, true, 6502);
+        assert_eq!(http, "http");
+        assert_eq!(ws, "ws");
+    }
 }
 
 async fn quit_handler(State(state): State<Web>) -> &'static str {

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -299,12 +299,15 @@ async fn root_redirect() -> Redirect {
 
 /// Derive the public-facing host, HTTP scheme, and WS scheme from request headers.
 ///
-/// Respects `X-Forwarded-Proto` for reverse-proxy setups (e.g. Traefik TLS
-/// termination) and uses the `Host` header as-is so that external ports are
-/// preserved rather than replaced with the internal listen port.
+/// Checks `X-Forwarded-Host` before `Host` so that proxies which overwrite the
+/// `Host` header with the backend address (and forward the original via
+/// `X-Forwarded-Host`) are handled correctly. Proxies that preserve the
+/// original `Host` header (Traefik default, nginx `proxy_set_header Host
+/// $host`) work equally well — `X-Forwarded-Host` is simply absent in that
+/// case and `Host` is used directly.
 ///
-/// `X-Forwarded-Proto` is trusted unconditionally; ensure mayara is only
-/// reachable from trusted proxies when running behind one.
+/// `X-Forwarded-Proto` and `X-Forwarded-Host` are trusted unconditionally;
+/// ensure mayara is only reachable from trusted proxies when running behind one.
 pub(crate) fn derive_public_base(
     headers: &hyper::header::HeaderMap,
     tls: bool,
@@ -322,25 +325,22 @@ pub(crate) fn derive_public_base(
 
     let behind_proxy = headers.contains_key("x-forwarded-proto");
 
-    let host = headers
-        .get(axum::http::header::HOST)
-        .and_then(|v| v.to_str().ok())
-        .map(|h| {
-            if h.contains(':') {
-                // Host already carries a port — use as-is.
-                h.to_string()
-            } else if behind_proxy {
-                // Proxy is present but Host has no port: the proxy is
-                // listening on the protocol's default port (80/443), so
-                // omit the port and let the scheme imply it.
-                h.to_string()
-            } else {
-                // Direct access with no port in Host — append the
-                // internal listen port so the URL is reachable.
-                format!("{}:{}", h, fallback_port)
-            }
-        })
-        .unwrap_or_else(|| format!("localhost:{}", fallback_port));
+    // X-Forwarded-Host takes precedence over Host for proxies that overwrite it.
+    let raw_host = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get(axum::http::header::HOST))
+        .and_then(|v| v.to_str().ok());
+
+    let host = match raw_host {
+        Some(h) if h.contains(':') => h.to_string(),
+        Some(h) if behind_proxy => {
+            // Proxy present, no port in host: proxy is on the protocol's
+            // default port (80/443) — omit port, let the scheme imply it.
+            h.to_string()
+        }
+        Some(h) => format!("{}:{}", h, fallback_port),
+        None => format!("localhost:{}", fallback_port),
+    };
 
     let (http_scheme, ws_scheme) = if proxied_https || (!behind_proxy && tls) {
         ("https", "wss")
@@ -488,6 +488,44 @@ mod tests {
         let (_, http, ws) = derive_public_base(&h, true, 6502);
         assert_eq!(http, "http");
         assert_eq!(ws, "ws");
+    }
+
+    // X-Forwarded-Host tests
+
+    #[test]
+    fn x_forwarded_host_takes_precedence_over_host() {
+        // Proxy overwrites Host with backend address; original is in X-Forwarded-Host.
+        let h = headers(&[
+            ("host", "127.0.0.1:6502"),
+            ("x-forwarded-host", "halos.local:4434"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let (host, http, ws) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local:4434");
+        assert_eq!(http, "https");
+        assert_eq!(ws, "wss");
+    }
+
+    #[test]
+    fn x_forwarded_host_without_port_and_https_omits_port() {
+        let h = headers(&[
+            ("host", "127.0.0.1:6502"),
+            ("x-forwarded-host", "halos.local"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let (host, _, _) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local");
+    }
+
+    #[test]
+    fn x_forwarded_host_absent_falls_back_to_host() {
+        // No X-Forwarded-Host → ordinary Host header is used.
+        let h = headers(&[
+            ("host", "halos.local:4434"),
+            ("x-forwarded-proto", "https"),
+        ]);
+        let (host, _, _) = derive_public_base(&h, false, 6502);
+        assert_eq!(host, "halos.local:4434");
     }
 }
 

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1,7 +1,6 @@
 use axum::{
     Error, Json,
     extract::{self, Path, Query, State},
-    http::Uri,
     response::{IntoResponse, Response},
     routing::get,
 };
@@ -14,7 +13,6 @@ use serde_json::Value;
 use std::{
     collections::{HashMap, HashSet},
     net::Ipv4Addr,
-    str::FromStr,
 };
 use strum::EnumCount;
 use tokio::sync::{
@@ -25,7 +23,7 @@ use utoipa::OpenApi;
 use utoipa::ToSchema;
 use utoipa_swagger_ui::{Config as SwaggerConfig, SwaggerUi};
 
-use crate::web::spokes_handler;
+use crate::web::{derive_public_base, spokes_handler};
 
 use super::super::{Message, Web, WebSocket, WebSocketUpgrade};
 use mayara::{
@@ -218,25 +216,9 @@ struct RadarApiV3 {
     tag = "Radars"
 )]
 async fn get_radars(State(state): State<Web>, headers: hyper::header::HeaderMap) -> Response {
-    let host: String = match headers.get(axum::http::header::HOST) {
-        Some(host) => host.to_str().unwrap_or("localhost").to_string(),
-        None => "localhost".to_string(),
-    };
+    let (host, _, ws_scheme) = derive_public_base(&headers, state.tls, state.args.port);
 
-    log::debug!("Radar state request for host '{}'", host);
-
-    let host = format!(
-        "{}:{}",
-        match Uri::from_str(&host) {
-            Ok(uri) => uri.host().unwrap_or("localhost").to_string(),
-            Err(_) => "localhost".to_string(),
-        },
-        state.args.port
-    );
-
-    log::debug!("target host = '{}'", host);
-
-    let ws_scheme = if state.tls { "wss" } else { "ws" };
+    log::debug!("Radar state request, target host = '{}'", host);
     let mut api: HashMap<String, RadarApiV3> = HashMap::new();
     for info in state.radars.get_active().clone() {
         let spoke_data_uri = SPOKES_URI.replace("{id}", &info.key());
@@ -421,23 +403,13 @@ async fn get_radar(
     State(state): State<Web>,
     headers: hyper::header::HeaderMap,
 ) -> Response {
-    let host: String = match headers.get(axum::http::header::HOST) {
-        Some(host) => host.to_str().unwrap_or("localhost").to_string(),
-        None => "localhost".to_string(),
-    };
-
-    log::debug!("Radar capabilities request for host '{}'", host);
-
-    let host = format!(
-        "{}:{}",
-        match Uri::from_str(&host) {
-            Ok(uri) => uri.host().unwrap_or("localhost").to_string(),
-            Err(_) => "localhost".to_string(),
-        },
-        state.args.port
+    log::debug!(
+        "Radar capabilities request for host '{}'",
+        headers
+            .get(axum::http::header::HOST)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("unknown")
     );
-
-    log::debug!("target host = '{}'", host);
 
     if let Some(info) = state.radars.get_by_key(&radar_id) {
         let controls = info.controls.get_controls();


### PR DESCRIPTION
## Motivation

When Mayara runs behind a reverse proxy that terminates TLS (e.g. Traefik at `https://halos.local:4434` forwarding to `http://localhost:6502`), the viewer's WebSocket connections fail because the server advertises the wrong URLs.

The `GET /signalk` and `GET /signalk/v2/api/vessels/self/radars` handlers were stripping the port from the `Host` header and replacing it with the internal `--port` value (6502), and deriving `ws`/`wss` solely from whether Mayara itself had TLS certs loaded — always `false` when TLS is terminated upstream. The viewer JS uses `radarInfo.streamUrl` and `radarInfo.spokeDataUrl` from the radars response in preference to `window.location`, so these advertised URLs must reflect the public-facing address.

## Solution

Introduce `derive_public_base()` in `web/mod.rs` used by both handlers:

- **Host:** uses the `Host` header as-is, preserving any external port already present (e.g. `:4434`); only appends the fallback port when no port is in the header (i.e. standard ports like 80/443)
- **Scheme:** checks `X-Forwarded-Proto` first, falls back to `state.tls`

Works correctly for:
- Direct access: `http://halos.local:6502` → `ws://halos.local:6502`
- Via Traefik TLS: `https://halos.local:4434` + `X-Forwarded-Proto: https` → `wss://halos.local:4434`
- Native TLS (cert/key flags): no proxy, `state.tls = true` → `wss://...`

No configuration changes required on the Mayara side — Traefik just needs to forward the original `Host` header (its default behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds derive_public_base() in web/mod.rs to derive externally-visible host, HTTP scheme, and WebSocket scheme from request headers and server TLS state, so advertised WebSocket URLs are correct behind TLS-terminating reverse proxies.

### Changes

**web/mod.rs**
- Adds pub(crate) fn derive_public_base(headers: &hyper::header::HeaderMap, tls: bool, fallback_port: u16) -> (String, &'static str, &'static str)
  - Chooses host by preferring X-Forwarded-Host (if present) and otherwise using Host, preserving any port present in the header.
  - Chooses scheme by preferring X-Forwarded-Proto (parses case-insensitively and takes the first comma-separated token) and falling back to the server TLS state.
  - Fixes port edge case: when X-Forwarded-Proto is present and the selected host has no port, do not append the internal fallback_port (let default ports apply); only append fallback_port for direct access scenarios when no forwarded proto is present.
  - Documents that X-Forwarded-* headers are trusted unconditionally.
- Replaces manual Host parsing and scheme selection in the endpoints handler with derive_public_base.
- Adds unit tests covering no headers, native TLS, Host with/without port, X-Forwarded-Proto variants (mixed-case, comma chains), X-Forwarded-Host precedence, and proxy-overrides of native TLS.

**signalk/v2.rs**
- get_radars uses derive_public_base(&headers, state.tls, state.args.port) to compute host and ws scheme.
- get_radar removes prior manual Host/port construction and uses a simplified debug statement.
- Removes unused imports (http::Uri, str::FromStr).

### Behavior

- Direct access: http → ws, https → wss based on server TLS state.
- Reverse proxy with TLS termination: X-Forwarded-Proto and X-Forwarded-Host are respected (wss produced when proxy indicates TLS, Host/port from proxy preserved).
- Native TLS: server TLS state is used when forwarded proto is absent.

### Tests and notes

- Adds 14 unit tests for derive_public_base covering header combinations and edge cases.
- Notes the trust assumption for X-Forwarded-* headers (proxies should forward original Host; proxies that don't must be configured accordingly).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->