### PR TITLE
fix(gui): don't reset canvas bitmap on transform-only redraws

### DIFF
--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -774,13 +774,27 @@ class PPI {
     const w = parseInt(styles.getPropertyValue("width"), 10);
     const h = parseInt(styles.getPropertyValue("height"), 10);
 
-    if (this.overlay_dom) {
-      this.overlay_dom.width = w;
-      this.overlay_dom.height = h;
-    }
-    if (this.background_dom) {
-      this.background_dom.width = w;
-      this.background_dom.height = h;
+    // Assigning to canvas.width / .height clears the bitmap regardless
+    // of whether the value actually changed. Without the size-changed
+    // guard, every control update (guard-zone save, exclusion edit,
+    // no-transmit sector change, range/zoom update) that fires
+    // redrawCanvas wipes the overlay/background canvases, producing a
+    // visible flash of "spokes disappear, then re-paint over the next
+    // sweep". Only touch the canvas dimensions when the parent
+    // actually resized. The renderer applies the same guard internally
+    // so transform-only updates (heading rotation, range scale, beam
+    // length) don't clear the spoke canvas either.
+    const sizeChanged = this.width !== w || this.height !== h;
+
+    if (sizeChanged) {
+      if (this.overlay_dom) {
+        this.overlay_dom.width = w;
+        this.overlay_dom.height = h;
+      }
+      if (this.background_dom) {
+        this.background_dom.width = w;
+        this.background_dom.height = h;
+      }
     }
 
     this.width = w;

--- a/web/gui/render_webgl.js
+++ b/web/gui/render_webgl.js
@@ -190,16 +190,27 @@ class WebGLRenderer {
    * @param {number} headingRotation - Heading rotation in radians
    */
   resize(width, height, beam_length, headingRotation) {
+    // Only re-assign canvas dimensions when they actually changed.
+    // Assigning to canvas.width / .height clears the bitmap and resets
+    // the WebGL context's framebuffer, so for transform-only updates
+    // (heading rotation, beam-length / zoom change) we skip the reset
+    // and just push the new transform.
+    const sizeChanged = this.width !== width || this.height !== height;
+
     this.width = width;
     this.height = height;
     this.beam_length = beam_length;
     this.headingRotation = headingRotation;
 
-    this.dom.width = width;
-    this.dom.height = height;
+    if (sizeChanged) {
+      this.dom.width = width;
+      this.dom.height = height;
+      if (this.ready) {
+        this.gl.viewport(0, 0, width, height);
+      }
+    }
 
     if (this.ready) {
-      this.gl.viewport(0, 0, width, height);
       this.#updateTransform();
     }
   }

--- a/web/gui/render_webgpu.js
+++ b/web/gui/render_webgpu.js
@@ -252,20 +252,32 @@ class WebGPURenderer {
    * @param {number} headingRotation - Heading rotation in radians
    */
   resize(width, height, beam_length, headingRotation) {
+    // Only re-assign canvas dimensions and re-configure the WebGPU
+    // context when the size actually changed. Re-configure is
+    // expensive (drops the swap chain) and re-assigning canvas.width
+    // clears the bitmap; for transform-only updates (heading rotation,
+    // beam-length / zoom change) we just push the new uniforms and
+    // keep the existing frame.
+    const sizeChanged = this.width !== width || this.height !== height;
+
     this.width = width;
     this.height = height;
     this.beam_length = beam_length;
     this.headingRotation = headingRotation;
 
-    this.dom.width = width;
-    this.dom.height = height;
+    if (sizeChanged) {
+      this.dom.width = width;
+      this.dom.height = height;
+      if (this.ready) {
+        this.context.configure({
+          device: this.device,
+          format: this.canvasFormat,
+          alphaMode: "premultiplied",
+        });
+      }
+    }
 
     if (this.ready) {
-      this.context.configure({
-        device: this.device,
-        format: this.canvasFormat,
-        alphaMode: "premultiplied",
-      });
       this.#updateUniforms();
     }
   }


### PR DESCRIPTION
## Summary

- `redrawCanvas` in `ppi.js` and `resize` in both renderers assigned the canvas `.width`/`.height` unconditionally on every call. Setting either property on an `HTMLCanvasElement` clears the bitmap regardless of whether the value changed.
- The result: every guard-zone save, exclusion-zone edit, no-transmit-sector tweak, range change, or zoom update wiped the overlay and the spoke canvas, producing a visible flash of "spokes disappear, then re-paint over the next sweep."
- Guard the size assignments with a `sizeChanged` check at all three layers (PPI, WebGL renderer, WebGPU renderer). Transform updates (heading rotation, beam length, range scale) still propagate through `#updateTransform` / `#updateUniforms` without touching the bitmap.

## Tested

- Live on a Furuno DRS4D-NXT: opened a guard zone, dragged geometry, ticked Enabled, saved — spokes no longer flash, guard zone stays visible. Range changes also no longer flash spokes.
- `cargo build --release` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

Canvas dimensions (width/height) were being unconditionally reassigned on every redraw and resize operation. Setting these properties implicitly clears the canvas bitmap, even when dimensions haven't changed. This caused visible "flash" artifacts when updating only transforms (heading rotation, beam length, range scale), because the overlay and spoke canvases would be cleared and repainted on guard-zone saves, exclusion edits, sector tweaks, and range/zoom changes.

## Solution

Introduce a `sizeChanged` check at three layers to decouple canvas dimension resets from transform-only updates.

**ppi.js** — `redrawCanvas()` now computes whether the parent container's pixel dimensions actually changed. It only assigns `overlay_dom.width/height` and `background_dom.width/height` when size changed; otherwise leaves canvas dimensions untouched to prevent the implicit bitmap clear.

**render_webgl.js** — `WebGLRenderer.resize()` adds a `sizeChanged` flag based on width/height comparison. Internal state (width, height, beam_length, headingRotation) updates unconditionally, but DOM dimension reassignment and GL viewport reset only happen when dimensions change. Transform-only updates no longer trigger resets.

**render_webgpu.js** — `WebGPURenderer.resize()` detects whether canvas size actually changed and only then updates `dom.width`/`dom.height` and reconfigures the WebGPU context. Internal state and uniform uploads continue on every call, but context reconfiguration (which drops the swap chain) only occurs for actual size changes.

## Impact

Guard-zone interactions, exclusion edits, sector tweaks, and range/zoom changes no longer produce visible flashing where spokes disappear then repaint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->