### PR TITLE
fix(gui): address API and WebSocket URLs relative to the GUI mount

### DIFF
--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -11,6 +11,31 @@ const STANDALONE_INTERFACES_API =
   "/signalk/v2/api/vessels/self/radars/interfaces";
 const ENDPOINT_API = "/signalk";
 
+// Mount prefix to prepend to every API/WS path.
+//
+// Served directly by mayara, the GUI lives at `/gui/…` while its API lives at
+// the origin root (`/signalk/…`), so the prefix is empty. Behind the Signal K
+// reverse proxy the GUI is mounted at `/plugins/<id>/gui/…` and the proxy
+// forwards everything under that mount to mayara — so the API must be reached
+// at `/plugins/<id>/gui/signalk/…`, i.e. the prefix is whatever precedes
+// `/gui` *plus* `/gui` itself. The discriminator is therefore whether anything
+// precedes `/gui`: nothing → direct (empty); a sub-path → proxied.
+export function basePrefix() {
+  // Match the `…/gui` segment whether or not a trailing slash follows
+  // (e.g. `/plugins/<id>/gui` with no slash still needs the prefix).
+  const m = window.location.pathname.match(/^(.*\/gui)(?:\/|$)/);
+  return m && m[1] !== "/gui" ? m[1] : "";
+}
+
+export function apiBase(path) {
+  return basePrefix() + path;
+}
+
+export function wsBase(path) {
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${wsProtocol}//${window.location.host}${basePrefix()}${path}`;
+}
+
 // Detected mode (null = not detected yet)
 let detectedMode = null;
 
@@ -28,7 +53,7 @@ export async function detectMode() {
 
   // Try standalone first - check if / returns server mayara
   try {
-    const response = await fetch(ENDPOINT_API, {
+    const response = await fetch(apiBase(ENDPOINT_API), {
       headers: { Accept: "application/json" },
     });
     const data = await response.json();
@@ -43,7 +68,7 @@ export async function detectMode() {
 
   // Try SignalK - check if endpoint returns 200
   try {
-    const response = await fetch(SIGNALK_RADARS_API, { method: "HEAD" });
+    const response = await fetch(apiBase(SIGNALK_RADARS_API), { method: "HEAD" });
     if (response.ok) {
       detectedMode = "signalk";
       console.log("Detected SignalK mode");
@@ -64,7 +89,7 @@ export async function detectMode() {
  * @returns {string} API URL
  */
 export function getRadarsPath() {
-  return SIGNALK_RADARS_API;
+  return apiBase(SIGNALK_RADARS_API);
 }
 
 /**
@@ -72,7 +97,7 @@ export function getRadarsPath() {
  * @returns {string|null} API URL or null if not available
  */
 export function getInterfacesUrl() {
-  return STANDALONE_INTERFACES_API;
+  return apiBase(STANDALONE_INTERFACES_API);
 }
 
 /**
@@ -261,7 +286,7 @@ export function isPlaybackRadar(radarId) {
 // Recordings API
 // ============================================================================
 
-const RECORDINGS_API = "/v2/api/vessels/self/radars/recordings";
+const RECORDINGS_API = apiBase("/v2/api/vessels/self/radars/recordings");
 
 /**
  * List available recordings

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -39,6 +39,7 @@ import {
   detectMode,
   isStandaloneMode,
   isPlaybackRadar,
+  wsBase,
 } from "./api.js";
 import { setZoneEditMode, setZoneCreateMode, setRectCreateMode, setSectorEditMode, updateZoneForEditing, updateRectForEditing } from "./viewer.js";
 import { SpokeProcessingMode } from "./spoke_processor.js";
@@ -1850,20 +1851,16 @@ async function loadRadar(id) {
     // Connect to state stream
     let controlStreamUrl = radarInfo?.streamUrl;
     if (!controlStreamUrl) {
-      const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      if (isStandaloneMode()) {
-        controlStreamUrl = `${wsProtocol}//${window.location.host}/v3/api/stream`;
-      } else {
-        controlStreamUrl = `${wsProtocol}//${window.location.host}/signalk/v2/api/vessels/self/radar/stream`;
-      }
+      controlStreamUrl = wsBase("/signalk/v1/stream");
     }
     connectStateStream(controlStreamUrl, radarId);
 
     // Get spokeDataUrl
     let spokeDataUrl = radarInfo?.spokeDataUrl;
     if (!spokeDataUrl) {
-      const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      spokeDataUrl = `${wsProtocol}//${window.location.host}/signalk/v2/api/vessels/self/radars/${radarId}/stream`;
+      spokeDataUrl = wsBase(
+        `/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
+      );
     }
 
     // Notify callbacks

--- a/web/gui/debug-panel.js
+++ b/web/gui/debug-panel.js
@@ -11,6 +11,7 @@
 import { createEventTimeline, updateTimeline, selectEvent, clearEvents } from './event-timeline.js';
 import { createPacketView, showPacketDetails, clearPacketView } from './packet-view.js';
 import { createStateDiffView, showStateDiff } from './state-diff.js';
+import { apiBase, wsBase } from './api.js';
 
 // ============================================================================
 // State
@@ -39,10 +40,9 @@ let onEventSelected = null;
 // Debug API
 // ============================================================================
 
-const DEBUG_WS_URL = '/v2/api/debug';
-const DEBUG_EVENTS_URL = '/v2/api/debug/events';
-const DEBUG_RECORDING_START_URL = '/v2/api/debug/recording/start';
-const DEBUG_RECORDING_STOP_URL = '/v2/api/debug/recording/stop';
+const DEBUG_EVENTS_URL = apiBase('/v2/api/debug/events');
+const DEBUG_RECORDING_START_URL = apiBase('/v2/api/debug/recording/start');
+const DEBUG_RECORDING_STOP_URL = apiBase('/v2/api/debug/recording/stop');
 
 /**
  * Check if debug mode is available (server built with --features dev)
@@ -64,8 +64,7 @@ function connectWebSocket() {
     return;
   }
 
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const wsUrl = `${protocol}//${window.location.host}${DEBUG_WS_URL}`;
+  const wsUrl = wsBase('/v2/api/debug');
 
   console.log('Debug: Connecting to', wsUrl);
   webSocket = new WebSocket(wsUrl);

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -25,7 +25,13 @@ import {
   isAcquireTargetMode,
   acquireTargetAtPosition,
 } from "./control.js";
-import { isStandaloneMode, detectMode } from "./api.js";
+import {
+  isStandaloneMode,
+  detectMode,
+  fetchRadarIds,
+  apiBase,
+  wsBase,
+} from "./api.js";
 import "./vendor/protobuf.min.js";
 
 import { WebGPURenderer } from "./render_webgpu.js";
@@ -107,7 +113,7 @@ registerStreamMessageCallback(handleStreamMessage);
 
 window.onload = async function () {
   const urlParams = new URLSearchParams(window.location.search);
-  const id = urlParams.get("id");
+  let id = urlParams.get("id");
   const requestedRenderer = urlParams.get("renderer");
 
   // Determine which renderer to use
@@ -174,6 +180,28 @@ window.onload = async function () {
       }
     });
   });
+
+  // A bare or stale `?id` (missing, empty, or the legacy `0` placeholder) and
+  // any id the server doesn't recognise would otherwise drive an endless
+  // failing capabilities fetch. Resolve it against the discovered radars,
+  // falling back to the first one, and send the operator to the index when
+  // there are none.
+  try {
+    const ids = await fetchRadarIds();
+    if (!id || !ids.includes(id)) {
+      if (ids.length === 0) {
+        window.location.href = "index.html";
+        return;
+      }
+      id = ids[0];
+      // Reflect the radar we actually loaded so a refresh or bookmark
+      // doesn't reuse the bogus id.
+      urlParams.set("id", id);
+      history.replaceState(null, "", `?${urlParams}`);
+    }
+  } catch (e) {
+    console.error(`Could not resolve radar id: ${e}`);
+  }
 
   // Process any pending radar data that arrived before renderer was ready
   if (pendingRadarData) {
@@ -248,8 +276,7 @@ function subscribeToHeading() {
     return;
   }
 
-  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const streamUrl = `${wsProtocol}//${window.location.host}/signalk/v1/stream?subscribe=none`;
+  const streamUrl = wsBase("/signalk/v1/stream?subscribe=none");
 
   headingSocket = new WebSocket(streamUrl);
 
@@ -369,8 +396,7 @@ async function subscribeToAisViaSignalK() {
     return; // operator turned AIS off while prime was in flight
   }
 
-  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const streamUrl = `${wsProtocol}//${window.location.host}/signalk/v1/stream?subscribe=none`;
+  const streamUrl = wsBase("/signalk/v1/stream?subscribe=none");
 
   // Hold a local reference so handlers that fire after `aisSocket` is
   // replaced (e.g. a late `onclose` from a previous socket) can detect
@@ -441,7 +467,7 @@ async function subscribeToAisViaSignalK() {
 // silent (mayara standalone doesn't serve this endpoint).
 async function primeAisFromRestSnapshot() {
   try {
-    const res = await fetch("/signalk/v1/api/vessels/");
+    const res = await fetch(apiBase("/signalk/v1/api/vessels/"));
     if (!res.ok) return;
     const tree = await res.json();
     const URN = "urn:mrn:imo:mmsi:";
@@ -1319,8 +1345,9 @@ function radarLoaded(r) {
     spokeDataUrl === "undefined" ||
     spokeDataUrl === "null"
   ) {
-    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    spokeDataUrl = `${wsProtocol}//${window.location.host}/signalk/v2/api/vessels/self/radars/${r.id}/stream`;
+    spokeDataUrl = wsBase(
+      `/signalk/v2/api/vessels/self/radars/${r.id}/spokes`
+    );
   } else {
     spokeDataUrl = spokeDataUrl.replace("{id}", r.id);
   }


### PR DESCRIPTION
## Summary

When the GUI is served behind the Signal K plugin proxy at `/plugins/<id>/gui/`, its hardcoded absolute `/signalk/...` URLs resolved against the proxy root and bypassed the proxy — REST calls 404'd and the radar/state/spoke WebSockets never reached mayara. This adds a mount-prefix helper (`basePrefix`/`apiBase`/`wsBase`) derived from the document location and builds every API and WebSocket URL through it. Served directly by mayara the prefix is empty, so standalone behaviour is unchanged.

Also:

- Fixes two WebSocket fallbacks that pointed at non-existent paths (`/signalk/v2/.../radar/stream` and `.../<id>/stream`); they now use the real `/signalk/v1/stream` and `.../<id>/spokes` endpoints.
- A missing/`0`/unknown `?id` previously drove an endless failing capabilities fetch. It now resolves to the first discovered radar (or redirects to the index when none exist) and reflects the chosen id in the URL.

Pairs with the plugin-side PR that fixes WebSocket upgrade forwarding so these proxied URLs actually reach mayara.

## Tested

- `cargo build --release` (re-embeds the GUI) and `cargo test --release` pass.
- `basePrefix()` unit-tested against direct, proxied, and trailing-slash-less path shapes.
- Manually verified end-to-end against a real Furuno radar behind a local Signal K server, over both `http://` and `https://`: capabilities load, state + spoke WebSockets connect, the radar leaves standby, and the PPI paints live echoes. Confirmed direct `:6502` access is unaffected.