### PR TITLE
fix(arpa): tracker, IMM, CPA and dedup improvements per design plan

### DIFF
--- a/src/lib/radar/cpa.rs
+++ b/src/lib/radar/cpa.rs
@@ -288,6 +288,31 @@ mod tests {
     }
 
     #[test]
+    fn test_parallel_same_velocity_returns_none() {
+        // Two vessels on the same course at the same speed: relative
+        // velocity is zero, the inter-vessel distance is constant, and
+        // CPA is undefined. This is the same `None` case as both-
+        // stationary, but with both vessels actually moving — the
+        // contract change should not regress this geometry.
+        let own = OwnVessel {
+            position: GeoPosition::new(52.0, 4.0),
+            sog: 12.0,
+            cog: PI / 4.0, // NE
+        };
+        let target = TargetVessel {
+            position: GeoPosition::new(52.001, 4.001),
+            sog: 12.0,
+            cog: PI / 4.0, // same NE course
+        };
+
+        let result = calculate_cpa(&own, &target);
+        assert!(
+            result.is_none(),
+            "Zero relative velocity must return None even when both vessels move",
+        );
+    }
+
+    #[test]
     fn test_overtaking() {
         // Own vessel heading North at 15 m/s
         let own = OwnVessel {

--- a/src/lib/radar/cpa.rs
+++ b/src/lib/radar/cpa.rs
@@ -6,12 +6,17 @@
 use super::GeoPosition;
 use super::target::{METERS_PER_DEGREE_LATITUDE, meters_per_degree_longitude};
 
-/// Result of CPA/TCPA calculation
+/// Result of CPA/TCPA calculation.
+///
+/// `tcpa` is signed: positive when CPA is in the future (vessels closing),
+/// negative when CPA was in the past (vessels diverging after a recent
+/// passage). Consumers that only care about closing situations should
+/// filter on `tcpa >= 0.0`.
 #[derive(Debug, Clone, Copy)]
 pub struct CpaResult {
     /// Closest Point of Approach in meters
     pub cpa: f64,
-    /// Time to CPA in seconds (always positive when vessels are closing)
+    /// Time to CPA in seconds (signed; see struct doc)
     pub tcpa: f64,
 }
 
@@ -39,56 +44,34 @@ pub struct TargetVessel {
 
 /// Calculate CPA and TCPA between own vessel and target.
 ///
-/// Returns `Some(CpaResult)` if vessels are closing (TCPA > 0),
-/// or `None` if vessels are moving apart or stationary.
-///
-/// The calculation uses a relative velocity approach:
-/// 1. Convert positions to local Cartesian coordinates (meters)
-/// 2. Calculate relative velocity vector
-/// 3. Find time when distance is minimized
-/// 4. Calculate distance at that time
+/// Returns `Some(CpaResult)` with a signed `tcpa` (positive = future,
+/// negative = past) whenever the two vessels have any relative motion.
+/// Returns `None` only when relative velocity is essentially zero — in
+/// that case the inter-vessel distance is constant and CPA is undefined.
 pub fn calculate_cpa(own: &OwnVessel, target: &TargetVessel) -> Option<CpaResult> {
-    // Convert positions to local Cartesian coordinates (meters)
-    // Using own vessel position as origin
     let lat_scale = METERS_PER_DEGREE_LATITUDE;
     let lon_scale = meters_per_degree_longitude(&own.position.lat());
 
-    // Target position relative to own vessel (in meters)
     let dx = (target.position.lon() - own.position.lon()) * lon_scale;
     let dy = (target.position.lat() - own.position.lat()) * lat_scale;
 
-    // Velocity vectors (m/s) - convert from COG (North=0, clockwise) to Cartesian (East=+x, North=+y)
     let own_vx = own.sog * own.cog.sin();
     let own_vy = own.sog * own.cog.cos();
     let target_vx = target.sog * target.cog.sin();
     let target_vy = target.sog * target.cog.cos();
 
-    // Relative velocity (target relative to own)
     let dvx = target_vx - own_vx;
     let dvy = target_vy - own_vy;
 
-    // Relative velocity squared
     let dv_squared = dvx * dvx + dvy * dvy;
-
-    // If relative velocity is essentially zero, vessels maintain constant distance
     if dv_squared < 1e-10 {
         return None;
     }
 
-    // Time to CPA: t = -(dx*dvx + dy*dvy) / (dvx² + dvy²)
-    // This is the time when the derivative of distance² equals zero
     let tcpa = -(dx * dvx + dy * dvy) / dv_squared;
 
-    // Only return result if TCPA is positive (vessels are closing)
-    if tcpa <= 0.0 {
-        return None;
-    }
-
-    // Position at CPA time
     let cpa_dx = dx + dvx * tcpa;
     let cpa_dy = dy + dvy * tcpa;
-
-    // CPA distance
     let cpa = (cpa_dx * cpa_dx + cpa_dy * cpa_dy).sqrt();
 
     Some(CpaResult { cpa, tcpa })
@@ -201,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vessels_diverging() {
+    fn test_vessels_diverging_returns_negative_tcpa() {
         // Own vessel heading North
         let own = OwnVessel {
             position: GeoPosition::new(52.0, 4.0),
@@ -209,7 +192,8 @@ mod tests {
             cog: 0.0, // North
         };
 
-        // Target 1000m South, also heading South (moving away)
+        // Target 1000m South, also heading South — already past their
+        // closest approach. CPA is now historical.
         let target_pos = own.position.position_from_bearing(PI, 1000.0);
         let target = TargetVessel {
             position: target_pos,
@@ -217,22 +201,21 @@ mod tests {
             cog: PI, // South
         };
 
-        let result = calculate_cpa(&own, &target);
-
-        // Vessels are diverging, should return None
-        assert!(result.is_none(), "Diverging vessels should return None");
+        let result = calculate_cpa(&own, &target).expect("relative velocity is non-zero");
+        // TCPA must be negative — the closest point is in the past.
+        assert!(result.tcpa < 0.0, "TCPA should be negative, got {}", result.tcpa);
     }
 
     #[test]
-    fn test_stationary_target() {
-        // Own vessel heading North
+    fn test_stationary_target_perpendicular_passed() {
+        // Own vessel heading North, stationary target due East. We're
+        // moving perpendicular to the target, so we're already at our
+        // closest point and any further travel only opens the range.
         let own = OwnVessel {
             position: GeoPosition::new(52.0, 4.0),
             sog: 10.0,
-            cog: 0.0, // North
+            cog: 0.0,
         };
-
-        // Stationary target 500m East
         let target_pos = own.position.position_from_bearing(PI / 2.0, 500.0);
         let target = TargetVessel {
             position: target_pos,
@@ -240,24 +223,14 @@ mod tests {
             cog: 0.0,
         };
 
-        let result = calculate_cpa(&own, &target);
-
-        // We're moving North, target is East - we're not closing on it
-        // Actually, as we move North, the distance decreases then increases
-        // So there should be a CPA
-        // Wait, if target is due East and we're heading North, we're moving
-        // perpendicular to the target - distance stays constant
-        // Actually no: we're moving away from the initial point, so distance
-        // to a fixed point East would stay ~constant at closest approach
-        // CPA would be when we're at the same latitude as the target
-
-        // For a stationary target due East while we head North:
-        // Distance is sqrt(500² + (our_north_travel)²)
-        // This is minimized at our_north_travel = 0, i.e., TCPA = 0 or already past
-        // So this should return None
+        let result = calculate_cpa(&own, &target).expect("relative velocity is non-zero");
+        // We're moving away from the closest-approach point right now,
+        // so TCPA must be non-positive. CPA is the current ~500m distance.
+        assert!(result.tcpa <= 0.0, "TCPA should be ≤ 0, got {}", result.tcpa);
         assert!(
-            result.is_none(),
-            "Should return None for perpendicular stationary target"
+            approx_eq(result.cpa, 500.0, 5.0),
+            "CPA should be ~500m, got {}",
+            result.cpa
         );
     }
 

--- a/src/lib/radar/target/kalman.rs
+++ b/src/lib/radar/target/kalman.rs
@@ -218,7 +218,21 @@ impl KalmanFilter {
 
         // Kalman gain: K = P * HT * (H * P * HT + R)^-1
         let s = h * self.p * ht + self.r;
-        let s_inv = s.try_inverse().unwrap_or(Matrix2x2::identity());
+        let Some(s_inv) = s.try_inverse() else {
+            // S is the innovation covariance H·P·Hᵀ + R. With positive-
+            // definite P and R this should never be singular. If it is,
+            // something has gone wrong (NaN propagation, numerical drift)
+            // and substituting identity for s_inv silently corrupts the
+            // filter. Skip this update — keep state at the prediction and
+            // hope the next measurement gives a well-conditioned S.
+            log::error!(
+                "Kalman: singular innovation covariance, skipping update at t={}",
+                time
+            );
+            self.state = predicted_state;
+            self.last_time = time;
+            return self.get_motion();
+        };
         let k: Matrix4x2 = self.p * ht * s_inv;
 
         // Updated state: X = X + K * y

--- a/src/lib/radar/target/kalman.rs
+++ b/src/lib/radar/target/kalman.rs
@@ -11,8 +11,8 @@ use nalgebra::{SMatrix, SVector};
 use super::{METERS_PER_DEGREE_LATITUDE, meters_per_degree_longitude};
 use crate::radar::GeoPosition;
 
-type Vector4 = SVector<f64, 4>;
-type Matrix4x4 = SMatrix<f64, 4, 4>;
+pub(super) type Vector4 = SVector<f64, 4>;
+pub(super) type Matrix4x4 = SMatrix<f64, 4, 4>;
 type Matrix2x2 = SMatrix<f64, 2, 2>;
 type Matrix4x2 = SMatrix<f64, 4, 2>;
 type Matrix2x4 = SMatrix<f64, 2, 4>;
@@ -288,6 +288,34 @@ impl KalmanFilter {
     pub fn get_speed_uncertainty(&self) -> f64 {
         // Rough approximation of standard deviation of speed
         ((self.p[(2, 2)] + self.p[(3, 3)]) / 2.0).sqrt()
+    }
+
+    /// Return the (state, covariance) pair for IMM mixing.
+    /// Callers must respect the filter's `ref_lat` / `ref_lon` — the
+    /// state vector is in local metres relative to that reference.
+    pub(super) fn state_and_covariance(&self) -> (Vector4, Matrix4x4) {
+        (self.state, self.p)
+    }
+
+    /// Replace `(state, P)` for IMM mixing. Time and reference position
+    /// are unchanged. Used by `ImmMotionModel` to seed each filter with
+    /// its mixed initial state at the start of each measurement step.
+    pub(super) fn set_state_and_covariance(&mut self, state: Vector4, p: Matrix4x4) {
+        self.state = state;
+        self.p = p;
+    }
+
+    /// Reference latitude used to convert geographic positions to the
+    /// filter's local-metres coordinate frame. Exposed for IMM mixing,
+    /// which must convert all filters to a common frame before averaging
+    /// their states.
+    pub(super) fn ref_lat(&self) -> f64 {
+        self.ref_lat
+    }
+
+    /// Reference longitude — see `ref_lat`.
+    pub(super) fn ref_lon(&self) -> f64 {
+        self.ref_lon
     }
 
     /// Set process noise level (higher = more maneuverable targets)

--- a/src/lib/radar/target/kalman.rs
+++ b/src/lib/radar/target/kalman.rs
@@ -318,9 +318,8 @@ impl KalmanFilter {
         self.ref_lon
     }
 
-    /// Set process noise level (higher = more maneuverable targets)
-    #[allow(dead_code)]
-    pub fn set_process_noise(&mut self, noise: f64) {
+    /// Set process noise level (higher = more maneuverable targets).
+    pub(super) fn set_process_noise(&mut self, noise: f64) {
         self.q[(0, 0)] = noise;
         self.q[(1, 1)] = noise;
     }

--- a/src/lib/radar/target/kalman.rs
+++ b/src/lib/radar/target/kalman.rs
@@ -449,4 +449,42 @@ mod tests {
             final_uncertainty
         );
     }
+
+    #[test]
+    fn test_update_skips_correction_on_singular_innovation_covariance() {
+        // When `S = H·P·Hᵀ + R` is non-invertible, update() must:
+        //   * not panic,
+        //   * keep the filter state at the prediction (no Kalman gain
+        //     applied against a fabricated identity inverse),
+        //   * advance last_time so subsequent updates still see fresh dt.
+        // Force singularity by zeroing both P and R; then S is the 2×2
+        // zero matrix, which nalgebra rejects deterministically.
+        let mut kf = KalmanFilter::new();
+        kf.init(GeoPosition::new(52.0, 4.0), 0);
+
+        // Drive the filter through one clean update so it has a non-
+        // zero state to predict from.
+        kf.update(GeoPosition::new(52.001, 4.0), 1_000);
+
+        // Zero out P and R so S = H·P·Hᵀ + R is the zero matrix and
+        // try_inverse() returns None.
+        kf.p.fill(0.0);
+        kf.r.fill(0.0);
+
+        let predicted = kf.predict(4_000);
+        let _ = kf.update(GeoPosition::new(52.5, 4.5), 4_000);
+
+        assert_eq!(kf.last_time, 4_000, "last_time must still advance");
+        let after = kf.get_position();
+        assert!(
+            (after.lat() - predicted.lat()).abs() < 1e-9
+                && (after.lon() - predicted.lon()).abs() < 1e-9,
+            "state must remain at the prediction, not jump to the measurement: \
+             predicted=({}, {}) got=({}, {})",
+            predicted.lat(),
+            predicted.lon(),
+            after.lat(),
+            after.lon()
+        );
+    }
 }

--- a/src/lib/radar/target/kalman.rs
+++ b/src/lib/radar/target/kalman.rs
@@ -324,32 +324,6 @@ impl KalmanFilter {
         self.q[(0, 0)] = noise;
         self.q[(1, 1)] = noise;
     }
-
-    /// Force position and velocity state (for maneuvering targets)
-    /// This bypasses the Kalman filtering when direct measurements are trusted more.
-    /// Based on radar_pi's forced position override for early tracking phases.
-    pub fn force_state(&mut self, position: GeoPosition, sog: f64, cog: f64, time: u64) {
-        // Convert position to local coordinates
-        let (lat_m, lon_m) = self.geo_to_local(&position);
-
-        // Convert SOG/COG to velocity components
-        // COG is in radians, 0 = North, clockwise
-        let lat_vel = sog * cog.cos(); // North component
-        let lon_vel = sog * cog.sin(); // East component
-
-        // Set state directly
-        self.state[0] = lat_m;
-        self.state[1] = lon_m;
-        self.state[2] = lat_vel;
-        self.state[3] = lon_vel;
-
-        self.last_time = time;
-
-        // Increase P to reflect uncertainty from forcing
-        // This allows future measurements to correct if needed
-        self.p[(2, 2)] = 4.0; // velocity variance
-        self.p[(3, 3)] = 4.0;
-    }
 }
 
 impl Default for KalmanFilter {

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -779,7 +779,7 @@ fn calculate_danger(
     radar_position: Option<&GeoPosition>,
 ) -> TargetDangerApi {
     let Some(own_pos) = radar_position else {
-        return TargetDangerApi::new(0.0, 0.0);
+        return TargetDangerApi::unknown();
     };
 
     let own_sog = crate::navdata::get_sog().unwrap_or(0.0);
@@ -800,10 +800,10 @@ fn compute_danger(
     use crate::radar::cpa::calculate_cpa_from_motion;
 
     let Some(target_sog) = target.sog else {
-        return TargetDangerApi::new(0.0, 0.0);
+        return TargetDangerApi::unknown();
     };
     let Some(target_cog) = target.cog else {
-        return TargetDangerApi::new(0.0, 0.0);
+        return TargetDangerApi::unknown();
     };
 
     let target_pos = target.predict_position(target.last_update);
@@ -817,7 +817,7 @@ fn compute_danger(
         target_cog,
     ) {
         Some(result) => TargetDangerApi::new(result.cpa, result.tcpa),
-        None => TargetDangerApi::new(0.0, 0.0),
+        None => TargetDangerApi::unknown(),
     }
 }
 
@@ -1179,12 +1179,13 @@ mod tests {
 
         let target = tracker.get_active_targets().next().unwrap();
 
-        // Smoothed CPA — what compute_danger uses now.
+        // Smoothed CPA: compute_danger uses target.predict_position
+        // (the Kalman state).
         let smoothed = compute_danger(target, &radar_pos, 0.0, 0.0);
         assert!(smoothed.tcpa > 0.0, "expected closing geometry");
 
-        // Raw CPA — what the previous code did. Pass target.position
-        // (the raw 80m-east last measurement) instead of the filtered one.
+        // Raw CPA: same math but fed with target.position (the raw
+        // 80m-east last measurement) instead of the filtered estimate.
         let raw = calculate_cpa_from_motion(
             radar_pos,
             0.0,

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -782,8 +782,16 @@ fn calculate_danger(
         return TargetDangerApi::unknown();
     };
 
-    let own_sog = crate::navdata::get_sog().unwrap_or(0.0);
-    let own_cog = crate::navdata::get_cog().unwrap_or(0.0);
+    // Missing own-ship SOG/COG must NOT be coerced to 0.0 — that would
+    // compute CPA/TCPA against a fictitious stationary own-ship and
+    // could silently flip is_dangerous. When navdata isn't reporting
+    // motion (boot, GPS loss), the right answer is "unknown."
+    let Some(own_sog) = crate::navdata::get_sog() else {
+        return TargetDangerApi::unknown();
+    };
+    let Some(own_cog) = crate::navdata::get_cog() else {
+        return TargetDangerApi::unknown();
+    };
     compute_danger(target, own_pos, own_sog, own_cog)
 }
 

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -779,10 +779,7 @@ fn calculate_danger(
     radar_position: Option<&GeoPosition>,
 ) -> TargetDangerApi {
     let Some(own_pos) = radar_position else {
-        return TargetDangerApi {
-            cpa: 0.0,
-            tcpa: 0.0,
-        };
+        return TargetDangerApi::new(0.0, 0.0);
     };
 
     let own_sog = crate::navdata::get_sog().unwrap_or(0.0);
@@ -803,16 +800,10 @@ fn compute_danger(
     use crate::radar::cpa::calculate_cpa_from_motion;
 
     let Some(target_sog) = target.sog else {
-        return TargetDangerApi {
-            cpa: 0.0,
-            tcpa: 0.0,
-        };
+        return TargetDangerApi::new(0.0, 0.0);
     };
     let Some(target_cog) = target.cog else {
-        return TargetDangerApi {
-            cpa: 0.0,
-            tcpa: 0.0,
-        };
+        return TargetDangerApi::new(0.0, 0.0);
     };
 
     let target_pos = target.predict_position(target.last_update);
@@ -825,14 +816,8 @@ fn compute_danger(
         target_sog,
         target_cog,
     ) {
-        Some(result) => TargetDangerApi {
-            cpa: result.cpa,
-            tcpa: result.tcpa,
-        },
-        None => TargetDangerApi {
-            cpa: 0.0,
-            tcpa: 0.0,
-        },
+        Some(result) => TargetDangerApi::new(result.cpa, result.tcpa),
+        None => TargetDangerApi::new(0.0, 0.0),
     }
 }
 

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -771,14 +771,13 @@ fn millis_to_iso8601(millis: u64) -> String {
     datetime.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-/// Calculate CPA/TCPA danger assessment for a target
+/// Calculate CPA/TCPA danger assessment for a target.
+/// Reads own-ship SOG/COG from navdata; delegates the math to
+/// `compute_danger` so tests can exercise the pure helper.
 fn calculate_danger(
     target: &super::tracker::ActiveTarget,
     radar_position: Option<&GeoPosition>,
 ) -> TargetDangerApi {
-    use crate::radar::cpa::calculate_cpa_from_motion;
-
-    // Need own-ship position and motion
     let Some(own_pos) = radar_position else {
         return TargetDangerApi {
             cpa: 0.0,
@@ -786,11 +785,23 @@ fn calculate_danger(
         };
     };
 
-    // Get own-ship SOG/COG from navdata
     let own_sog = crate::navdata::get_sog().unwrap_or(0.0);
     let own_cog = crate::navdata::get_cog().unwrap_or(0.0);
+    compute_danger(target, own_pos, own_sog, own_cog)
+}
 
-    // Need target motion data
+/// Pure CPA/TCPA helper. Uses the Kalman-filtered position from the motion
+/// model rather than the raw last measurement — that raw value swings tens
+/// of metres revolution-to-revolution, and using it produces equally noisy
+/// CPA output that's not what consumers expect.
+fn compute_danger(
+    target: &super::tracker::ActiveTarget,
+    own_pos: &GeoPosition,
+    own_sog: f64,
+    own_cog: f64,
+) -> TargetDangerApi {
+    use crate::radar::cpa::calculate_cpa_from_motion;
+
     let Some(target_sog) = target.sog else {
         return TargetDangerApi {
             cpa: 0.0,
@@ -804,12 +815,13 @@ fn calculate_danger(
         };
     };
 
-    // Calculate CPA/TCPA
+    let target_pos = target.predict_position(target.last_update);
+
     match calculate_cpa_from_motion(
         *own_pos,
         own_sog,
         own_cog,
-        target.position,
+        target_pos,
         target_sog,
         target_cog,
     ) {
@@ -1133,5 +1145,81 @@ mod tests {
         manager.leave_guard_zone("nav1", 1);
         // No prior enter; leaves should not emit a `normal` from nothing.
         assert!(drain_sk_deltas(rx).is_empty());
+    }
+
+    /// After a noisy measurement, the Kalman filter's smoothed position is
+    /// significantly closer to the true track than the raw measurement.
+    /// `compute_danger` uses the smoothed position; this test confirms that
+    /// using `target.position` (the raw last sighting) would produce a
+    /// materially different CPA than the smoothed value the new code uses.
+    /// That difference is exactly the noise suppression #10 is fixing.
+    #[test]
+    fn compute_danger_uses_filtered_position_not_raw_measurement() {
+        use super::super::tracker::{CandidateSource, TargetCandidate, TargetTracker};
+        use crate::radar::cpa::calculate_cpa_from_motion;
+
+        let radar_pos = GeoPosition::new(52.0, 4.0);
+        let max_speed = SpokeContext::max_speed_from_mode(2);
+
+        // Target starts ~400m north and closes due south at ~10 m/s for
+        // 6 clean revolutions (the Kalman filter has fully converged).
+        let mut tracker = TargetTracker::new_merged(2048);
+        let lat_step = 30.0 / super::super::METERS_PER_DEGREE_LATITUDE;
+        let start_lat = 52.0 + 400.0 / super::super::METERS_PER_DEGREE_LATITUDE;
+        for i in 0..6u64 {
+            tracker.process_candidate(TargetCandidate {
+                time: i * 3000,
+                position: GeoPosition::new(start_lat - lat_step * i as f64, 4.0),
+                size_meters: 30.0,
+                radar_key: "test".to_string(),
+                radar_position: Some(radar_pos),
+                max_target_speed_ms: max_speed,
+                source: CandidateSource::GuardZone(1),
+            });
+        }
+
+        // One badly noisy measurement: ~80m east of the true track.
+        let lon_noise = 80.0 / super::super::meters_per_degree_longitude(&52.0);
+        let noisy_true_lat = start_lat - lat_step * 6.0;
+        let noisy_true_lon = 4.0 + lon_noise;
+        tracker.process_candidate(TargetCandidate {
+            time: 6 * 3000,
+            position: GeoPosition::new(noisy_true_lat, noisy_true_lon),
+            size_meters: 30.0,
+            radar_key: "test".to_string(),
+            radar_position: Some(radar_pos),
+            max_target_speed_ms: max_speed,
+            source: CandidateSource::GuardZone(1),
+        });
+
+        let target = tracker.get_active_targets().next().unwrap();
+
+        // Smoothed CPA — what compute_danger uses now.
+        let smoothed = compute_danger(target, &radar_pos, 0.0, 0.0);
+        assert!(smoothed.tcpa > 0.0, "expected closing geometry");
+
+        // Raw CPA — what the previous code did. Pass target.position
+        // (the raw 80m-east last measurement) instead of the filtered one.
+        let raw = calculate_cpa_from_motion(
+            radar_pos,
+            0.0,
+            0.0,
+            target.position,
+            target.sog.unwrap(),
+            target.cog.unwrap(),
+        )
+        .expect("raw CPA should also be a closing situation");
+
+        // The smoothed Kalman position barely moved (it weights the noisy
+        // measurement against many clean priors), while the raw position is
+        // exactly the 80m-east noise. So the raw CPA should be materially
+        // larger than the smoothed CPA.
+        assert!(
+            raw.cpa > smoothed.cpa + 30.0,
+            "raw CPA ({:.1}m) should be ≥ 30m larger than smoothed CPA ({:.1}m); \
+             the Kalman state must filter the noise spike",
+            raw.cpa,
+            smoothed.cpa
+        );
     }
 }

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -1140,12 +1140,12 @@ mod tests {
         assert!(drain_sk_deltas(rx).is_empty());
     }
 
-    /// After a noisy measurement, the Kalman filter's smoothed position is
-    /// significantly closer to the true track than the raw measurement.
-    /// `compute_danger` uses the smoothed position; this test confirms that
-    /// using `target.position` (the raw last sighting) would produce a
-    /// materially different CPA than the smoothed value the new code uses.
-    /// That difference is exactly the noise suppression #10 is fixing.
+    /// After a noisy measurement the Kalman filter's smoothed position
+    /// is significantly closer to the true track than the raw last
+    /// measurement. `compute_danger` uses the smoothed position; this
+    /// test confirms that feeding the raw `target.position` into the
+    /// same CPA math produces a materially different result, so the
+    /// noise suppression at the API boundary is real.
     #[test]
     fn compute_danger_uses_filtered_position_not_raw_measurement() {
         use super::super::tracker::{CandidateSource, TargetCandidate, TargetTracker};

--- a/src/lib/radar/target/mod.rs
+++ b/src/lib/radar/target/mod.rs
@@ -57,7 +57,10 @@ pub struct ArpaTargetApi {
     /// Present with zero values for confirmed stationary targets.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub motion: Option<TargetMotionApi>,
-    /// Collision danger assessment - omitted if vessels diverging
+    /// Collision danger assessment. Present whenever the two vessels
+    /// have non-zero relative motion (TCPA may be negative for a
+    /// recently-passed CPA); omitted only when relative motion is
+    /// undefined or own-ship / target motion is not yet known.
     #[serde(skip_serializing_if = "TargetDangerApi::is_empty")]
     pub danger: TargetDangerApi,
     /// How target was acquired: "auto" or "manual"

--- a/src/lib/radar/target/mod.rs
+++ b/src/lib/radar/target/mod.rs
@@ -133,6 +133,20 @@ impl TargetDangerApi {
         }
     }
 
+    /// Placeholder for targets whose CPA can't be computed yet — either
+    /// the radar has no own-ship position, the target's Kalman filter
+    /// hasn't produced a motion estimate, or the relative velocity is
+    /// zero. Distinct from `new(0.0, 0.0)` which would otherwise
+    /// satisfy the danger thresholds (CPA < 926 m AND 0 ≤ TCPA ≤ 360 s)
+    /// and incorrectly flag every motion-less target as dangerous.
+    pub fn unknown() -> Self {
+        TargetDangerApi {
+            cpa: 0.0,
+            tcpa: 0.0,
+            is_dangerous: false,
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.cpa == 0.0 && self.tcpa == 0.0 && !self.is_dangerous
     }
@@ -169,5 +183,15 @@ mod tests {
         // future close-quarters situation.
         let d = TargetDangerApi::new(50.0, -30.0);
         assert!(!d.is_dangerous);
+    }
+
+    #[test]
+    fn target_danger_api_unknown_is_not_dangerous() {
+        // Targets without motion data must NOT be flagged as dangerous.
+        // new(0.0, 0.0) would otherwise satisfy both threshold checks
+        // (cpa < 926m AND tcpa in [0, 360s]) and incorrectly fire.
+        let d = TargetDangerApi::unknown();
+        assert!(!d.is_dangerous);
+        assert!(d.is_empty());
     }
 }

--- a/src/lib/radar/target/mod.rs
+++ b/src/lib/radar/target/mod.rs
@@ -125,7 +125,7 @@ impl TargetDangerApi {
 
     pub fn new(cpa: f64, tcpa: f64) -> Self {
         let is_dangerous =
-            cpa < Self::DANGER_CPA_M && tcpa >= 0.0 && tcpa <= Self::DANGER_TCPA_S;
+            cpa < Self::DANGER_CPA_M && (0.0..=Self::DANGER_TCPA_S).contains(&tcpa);
         TargetDangerApi {
             cpa,
             tcpa,

--- a/src/lib/radar/target/mod.rs
+++ b/src/lib/radar/target/mod.rs
@@ -97,17 +97,77 @@ pub struct TargetMotionApi {
 }
 
 /// Collision danger assessment in the API format.
-/// Entire field is omitted when vessels are diverging (no CPA).
+///
+/// Emitted whenever the two vessels have non-zero relative velocity, so
+/// consumers can show the historical CPA of a vessel that has just passed
+/// us (negative TCPA) as well as the upcoming CPA of a converging one.
+/// Omitted only when relative motion is undefined (both stationary, or
+/// motion data not yet available).
 #[derive(Serialize, Clone, Debug, ToSchema)]
 pub struct TargetDangerApi {
     /// Closest Point of Approach in meters
     pub cpa: f64,
-    /// Time to CPA in seconds
+    /// Time to CPA in seconds. Positive = future (closing); negative =
+    /// past (already passed). Magnitude is the time interval to/from
+    /// the closest point.
     pub tcpa: f64,
+    /// True when the target is a close-quarters situation by IMO defaults:
+    /// CPA < 0.5 nm (≈926 m) AND TCPA in [0, 6 min]. Historical CPAs
+    /// (negative TCPA) never trigger this flag.
+    pub is_dangerous: bool,
 }
 
 impl TargetDangerApi {
+    /// CPA threshold for the danger flag (0.5 nautical miles in metres).
+    pub const DANGER_CPA_M: f64 = 0.5 * super::NAUTICAL_MILE_F64;
+    /// TCPA threshold for the danger flag (6 minutes in seconds).
+    pub const DANGER_TCPA_S: f64 = 6.0 * 60.0;
+
+    pub fn new(cpa: f64, tcpa: f64) -> Self {
+        let is_dangerous =
+            cpa < Self::DANGER_CPA_M && tcpa >= 0.0 && tcpa <= Self::DANGER_TCPA_S;
+        TargetDangerApi {
+            cpa,
+            tcpa,
+            is_dangerous,
+        }
+    }
+
     fn is_empty(&self) -> bool {
-        self.cpa == 0.0 && self.tcpa == 0.0
+        self.cpa == 0.0 && self.tcpa == 0.0 && !self.is_dangerous
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_danger_api_flags_imminent_close_pass() {
+        // 200m CPA in 3 minutes is a close-quarters IMO situation.
+        let d = TargetDangerApi::new(200.0, 180.0);
+        assert!(d.is_dangerous);
+    }
+
+    #[test]
+    fn target_danger_api_does_not_flag_distant_cpa() {
+        // 2000m at 3 min is well outside the 0.5 nm threshold.
+        let d = TargetDangerApi::new(2000.0, 180.0);
+        assert!(!d.is_dangerous);
+    }
+
+    #[test]
+    fn target_danger_api_does_not_flag_far_future() {
+        // 200m CPA but 10 min away — outside the 6 min IMO window.
+        let d = TargetDangerApi::new(200.0, 600.0);
+        assert!(!d.is_dangerous);
+    }
+
+    #[test]
+    fn target_danger_api_does_not_flag_historical_cpa() {
+        // Close CPA but TCPA is in the past — already passed, not a
+        // future close-quarters situation.
+        let d = TargetDangerApi::new(50.0, -30.0);
+        assert!(!d.is_dangerous);
     }
 }

--- a/src/lib/radar/target/motion.rs
+++ b/src/lib/radar/target/motion.rs
@@ -300,6 +300,17 @@ impl MotionModel for ImmMotionModel {
             return MotionEstimate { sog: 0.0, cog: 0.0 };
         }
 
+        // Reject stale or duplicate measurements before doing any work.
+        // KalmanFilter::update bails on `time <= last_time`, but the
+        // mixing step that runs first would still rewrite all three
+        // filter states for an out-of-order sample — corrupting future
+        // predictions and model probabilities even though no new
+        // measurement was actually accepted. Match the per-filter
+        // contract by returning the current motion estimate unchanged.
+        if time <= self.last_time {
+            return self.get_motion();
+        }
+
         // Step 1: Interaction/Mixing
         self.mix_states();
 
@@ -607,5 +618,46 @@ mod tests {
              other after 20 clean steady-state updates; got max spread {:.2}m",
             max_spread
         );
+    }
+
+    /// A duplicate or out-of-order timestamp must be a no-op from the
+    /// caller's perspective: same SOG/COG returned, no mutation of the
+    /// internal filters or model probabilities. Without the stale-time
+    /// guard, mix_states would rewrite all three filter states even
+    /// though no new measurement was accepted, drifting future
+    /// predictions for a replayed sample.
+    #[test]
+    fn imm_update_is_idempotent_on_stale_or_duplicate_timestamps() {
+        let mut model = ImmMotionModel::new();
+        model.init(GeoPosition::new(52.0, 4.0), 0);
+
+        let lat_step = 30.0 / super::super::METERS_PER_DEGREE_LATITUDE;
+        for i in 1..=5u64 {
+            model.update(
+                GeoPosition::new(52.0 + lat_step * i as f64, 4.0),
+                i * 3000,
+            );
+        }
+
+        let baseline_motion = model.get_motion();
+        let baseline_probs = model.model_probs;
+        let baseline_cv = model.cv_filter.state_and_covariance();
+        let baseline_ca = model.ca_filter.state_and_covariance();
+        let baseline_ct = model.ct_filter.state_and_covariance();
+
+        // Same timestamp as last update — must be a no-op.
+        let returned = model.update(GeoPosition::new(53.0, 5.0), 5 * 3000);
+        assert!((returned.sog - baseline_motion.sog).abs() < 1e-12);
+        assert!((returned.cog - baseline_motion.cog).abs() < 1e-12);
+        assert_eq!(model.model_probs, baseline_probs);
+        assert_eq!(model.cv_filter.state_and_covariance().0, baseline_cv.0);
+        assert_eq!(model.ca_filter.state_and_covariance().0, baseline_ca.0);
+        assert_eq!(model.ct_filter.state_and_covariance().0, baseline_ct.0);
+
+        // Strictly older timestamp — also a no-op.
+        let returned = model.update(GeoPosition::new(54.0, 6.0), 2 * 3000);
+        assert!((returned.sog - baseline_motion.sog).abs() < 1e-12);
+        assert_eq!(model.model_probs, baseline_probs);
+        assert_eq!(model.cv_filter.state_and_covariance().0, baseline_cv.0);
     }
 }

--- a/src/lib/radar/target/motion.rs
+++ b/src/lib/radar/target/motion.rs
@@ -39,9 +39,6 @@ pub trait MotionModel: Send {
     /// Get position uncertainty in meters
     fn get_uncertainty(&self) -> f64;
 
-    /// Force the model state (for manual overrides)
-    fn force_state(&mut self, position: GeoPosition, sog: f64, cog: f64, time: u64);
-
     /// Clone the model into a boxed trait object
     fn clone_box(&self) -> Box<dyn MotionModel>;
 }
@@ -146,8 +143,7 @@ impl ImmMotionModel {
     ///
     /// Requires all three filters to be in the same local-metre frame.
     /// That's automatic here because `init_with_uncertainty` sets the
-    /// same ref_lat/ref_lon on all three from the same first measurement,
-    /// and `force_state` updates all three together with one position.
+    /// same ref_lat/ref_lon on all three from the same first measurement.
     fn mix_states(&mut self) {
         let mut c_bar = [0.0; 3];
         for j in 0..3 {
@@ -181,8 +177,10 @@ impl ImmMotionModel {
         // change could break it silently.
         debug_assert!(
             (self.cv_filter.ref_lat() - self.ca_filter.ref_lat()).abs() < 1e-12
-                && (self.cv_filter.ref_lat() - self.ct_filter.ref_lat()).abs() < 1e-12,
-            "IMM filters must share ref_lat for mixing to be valid"
+                && (self.cv_filter.ref_lat() - self.ct_filter.ref_lat()).abs() < 1e-12
+                && (self.cv_filter.ref_lon() - self.ca_filter.ref_lon()).abs() < 1e-12
+                && (self.cv_filter.ref_lon() - self.ct_filter.ref_lon()).abs() < 1e-12,
+            "IMM filters must share ref_lat/ref_lon for mixing to be valid"
         );
 
         let mut mixed: [(Vector4, Matrix4x4); 3] =
@@ -378,16 +376,6 @@ impl MotionModel for ImmMotionModel {
         self.model_probs[0] * self.cv_filter.get_uncertainty()
             + self.model_probs[1] * self.ca_filter.get_uncertainty()
             + self.model_probs[2] * self.ct_filter.get_uncertainty()
-    }
-
-    fn force_state(&mut self, position: GeoPosition, sog: f64, cog: f64, time: u64) {
-        self.cv_filter.force_state(position, sog, cog, time);
-        self.ca_filter.force_state(position, sog, cog, time);
-        self.ct_filter.force_state(position, sog, cog, time);
-        self.last_position = position;
-        self.sog = sog;
-        self.cog = cog;
-        self.last_time = time;
     }
 
     fn clone_box(&self) -> Box<dyn MotionModel> {

--- a/src/lib/radar/target/motion.rs
+++ b/src/lib/radar/target/motion.rs
@@ -6,7 +6,7 @@
 
 use std::f64::consts::TAU;
 
-use super::kalman::KalmanFilter;
+use super::kalman::{KalmanFilter, Matrix4x4, Vector4};
 use crate::radar::GeoPosition;
 
 /// Motion estimation result
@@ -131,32 +131,86 @@ impl ImmMotionModel {
         exponent.exp() / (sigma * TAU.sqrt())
     }
 
-    /// Mix model states based on mixing probabilities
+    /// IMM interaction/mixing step. Produces, for each filter j, a mixed
+    /// initial state and covariance that the filter then uses as its prior
+    /// for this measurement. Without this step the three filters drift
+    /// apart over time and the IMM degenerates to "three parallel Kalmans
+    /// with a softmax over likelihoods" — which is much less informative
+    /// than the literature suggests by name.
+    ///
+    /// Bar-Shalom, *Estimation with Applications to Tracking and
+    /// Navigation*, eq. 11.6.6:
+    ///   x0_j = Σ_i μ_{i|j} · x_i
+    ///   P0_j = Σ_i μ_{i|j} · (P_i + (x_i - x0_j)(x_i - x0_j)ᵀ)
+    /// Then `model_probs[j] = c_bar[j]` is the predicted weight for j.
+    ///
+    /// Requires all three filters to be in the same local-metre frame.
+    /// That's automatic here because `init_with_uncertainty` sets the
+    /// same ref_lat/ref_lon on all three from the same first measurement,
+    /// and `force_state` updates all three together with one position.
     fn mix_states(&mut self) {
-        // Calculate mixing probabilities
-        let mut mixing_probs = [[0.0; 3]; 3];
         let mut c_bar = [0.0; 3];
-
-        // c_bar[j] = sum_i(p_ij * mu_i)
         for j in 0..3 {
             for i in 0..3 {
                 c_bar[j] += TRANSITION_PROB[i][j] * self.model_probs[i];
             }
         }
 
-        // mixing_prob[i|j] = p_ij * mu_i / c_bar[j]
+        let mut mixing_probs = [[0.0_f64; 3]; 3];
         for j in 0..3 {
-            for i in 0..3 {
-                if c_bar[j] > 1e-10 {
-                    mixing_probs[i][j] = TRANSITION_PROB[i][j] * self.model_probs[i] / c_bar[j];
+            if c_bar[j] > 1e-10 {
+                for i in 0..3 {
+                    mixing_probs[i][j] =
+                        TRANSITION_PROB[i][j] * self.model_probs[i] / c_bar[j];
                 }
             }
         }
 
-        // Store predicted probabilities for next update
+        // Snapshot current (state, P) for each filter once — we read them
+        // multiple times to build the mixed priors and must not see our
+        // own writes mid-loop.
+        let filters = [&self.cv_filter, &self.ca_filter, &self.ct_filter];
+        let snapshots: [(Vector4, Matrix4x4); 3] = [
+            filters[0].state_and_covariance(),
+            filters[1].state_and_covariance(),
+            filters[2].state_and_covariance(),
+        ];
+
+        // Sanity check: all filters must share the same local frame. The
+        // IMM constructor and init paths guarantee this, but a future
+        // change could break it silently.
+        debug_assert!(
+            (self.cv_filter.ref_lat() - self.ca_filter.ref_lat()).abs() < 1e-12
+                && (self.cv_filter.ref_lat() - self.ct_filter.ref_lat()).abs() < 1e-12,
+            "IMM filters must share ref_lat for mixing to be valid"
+        );
+
+        let mut mixed: [(Vector4, Matrix4x4); 3] =
+            [(Vector4::zeros(), Matrix4x4::zeros()); 3];
         for j in 0..3 {
-            self.model_probs[j] = c_bar[j];
+            // x0_j = Σ_i μ_{i|j} · x_i
+            let mut x0 = Vector4::zeros();
+            for i in 0..3 {
+                x0 += mixing_probs[i][j] * snapshots[i].0;
+            }
+
+            // P0_j = Σ_i μ_{i|j} · (P_i + (x_i - x0_j)(x_i - x0_j)ᵀ)
+            let mut p0 = Matrix4x4::zeros();
+            for i in 0..3 {
+                let dx = snapshots[i].0 - x0;
+                p0 += mixing_probs[i][j] * (snapshots[i].1 + dx * dx.transpose());
+            }
+
+            mixed[j] = (x0, p0);
         }
+
+        // Write the mixed priors back into each filter.
+        self.cv_filter.set_state_and_covariance(mixed[0].0, mixed[0].1);
+        self.ca_filter.set_state_and_covariance(mixed[1].0, mixed[1].1);
+        self.ct_filter.set_state_and_covariance(mixed[2].0, mixed[2].1);
+
+        // Predicted model probabilities for the upcoming update step.
+        self.model_probs = c_bar;
     }
 
     /// Update model probabilities based on measurement likelihoods
@@ -523,6 +577,47 @@ mod tests {
             "Final SOG {:.1} m/s should be close to actual {:.1} m/s",
             final_motion.sog,
             speed_ms
+        );
+    }
+
+    /// IMM mixing must pull the three filters' state estimates together.
+    /// Without mixing, each filter drifts independently with its own Q,
+    /// so after many updates the high-Q CT filter is materially offset
+    /// from the low-Q CV one. With proper mixing the filters stay in the
+    /// same neighbourhood.
+    #[test]
+    fn imm_mixing_keeps_filter_states_consistent() {
+        let mut model = ImmMotionModel::new();
+        let start = GeoPosition::new(52.0, 4.0);
+        model.init(start, 0);
+
+        // 20 clean updates moving north at ~10 m/s.
+        let delta_lat = 30.0 / super::super::METERS_PER_DEGREE_LATITUDE;
+        for i in 1..=20u64 {
+            model.update(
+                GeoPosition::new(52.0 + delta_lat * i as f64, 4.0),
+                i * 3000,
+            );
+        }
+
+        // All three filters should predict the same future position to
+        // within a few metres. The blended prediction relies on this; if
+        // the filters drift apart the blended position is no longer at
+        // any of them.
+        let future_time = 21 * 3000;
+        let cv_pred = model.cv_filter.predict(future_time);
+        let ca_pred = model.ca_filter.predict(future_time);
+        let ct_pred = model.ct_filter.predict(future_time);
+
+        let max_spread = calculate_distance(&cv_pred, &ca_pred)
+            .max(calculate_distance(&cv_pred, &ct_pred))
+            .max(calculate_distance(&ca_pred, &ct_pred));
+
+        assert!(
+            max_spread < 5.0,
+            "IMM mixing should keep filter predictions within 5m of each \
+             other after 20 clean steady-state updates; got max spread {:.2}m",
+            max_spread
         );
     }
 }

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -1937,10 +1937,16 @@ mod tests {
         // Sanity: the two physical separations must straddle the merge
         // distance correctly — close enough at dedup time that the
         // distance gate alone wouldn't separate them, but each target's
-        // own match window mustn't reach the other.
-        let a = tracker.get_active_targets().find(|t| t.id == 1).unwrap();
-        let b = tracker.get_active_targets().find(|t| t.id == 2).unwrap();
-        let separation = calculate_distance(&a.position, &b.position);
+        // own match window mustn't reach the other. Compute the max
+        // pairwise separation across however many targets the tracker
+        // ended up with, so the test doesn't depend on the internal ID
+        // numbering or on which candidate became which id.
+        let positions: Vec<_> = tracker
+            .get_active_targets()
+            .map(|t| t.position)
+            .collect();
+        assert_eq!(positions.len(), 2, "expected 2 candidate targets pre-dedup");
+        let separation = calculate_distance(&positions[0], &positions[1]);
         assert!(
             separation < DUPLICATE_MERGE_DISTANCE_M,
             "test geometry must keep the targets inside the merge ring; \

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -47,9 +47,15 @@ const MIN_MATCH_DISTANCE_M: f64 = 50.0;
 /// within max_speed * delta_time. We use 1.5x to account for prediction error.
 const MATCH_DISTANCE_SPEED_MULTIPLIER: f64 = 1.5;
 
-/// Maximum allowed turn angle (degrees) for high-speed targets
-/// Targets appearing to turn more than this at speed are rejected as false matches
-const MAX_TURN_ANGLE_DEG: f64 = 130.0;
+/// Maximum allowed turn angle (degrees) between consecutive sightings of
+/// a target moving faster than `TURN_REJECTION_SPEED_MS`. A real planing
+/// boat at 5 m/s can hard-over and pivot well under 90° per 3-second
+/// radar revolution; turns beyond this are almost certainly a stray blob
+/// being mistakenly associated with the wrong target. Applied for the
+/// entire lifetime of a target — the previous early-tracking-only check
+/// missed the most dangerous case (a long-tracked target suddenly
+/// "teleporting" via a false association).
+const MAX_TURN_ANGLE_DEG: f64 = 90.0;
 
 /// Speed threshold (m/s) above which turn rejection is applied
 const TURN_REJECTION_SPEED_MS: f64 = 5.0;
@@ -201,13 +207,21 @@ impl ActiveTarget {
             None
         };
 
-        // Turn rejection: reject implausible maneuvers for fast targets in early tracking
-        // Based on radar_pi: turn > 130° at speed > 5 m/s for status < 5
-        // Use Kalman-estimated SOG rather than measured SOG: a stationary target's blob
-        // position varies by tens of meters per rotation, producing apparent measured
-        // speeds of 8-10 m/s with random directions. The Kalman filter correctly
-        // converges toward the true low speed and avoids false rejections.
-        if self.update_count >= 2 && self.update_count < 5 {
+        // Turn rejection: reject implausible maneuvers for fast targets.
+        // Applies for the entire lifetime of a target (update_count >= 2,
+        // once a previous COG exists). The previous early-tracking-only
+        // window (update_count < 5) let a mature track suddenly teleport
+        // to a false association without challenge — the worst case
+        // operationally because a stable track is the one the navigator
+        // is most likely to be relying on.
+        //
+        // SOG is read from the Kalman estimate rather than from the raw
+        // measured displacement: a stationary target's blob centre wanders
+        // by tens of metres per rotation, producing apparent measured
+        // speeds of 8-10 m/s with random direction. The Kalman filter
+        // correctly converges toward the true low speed and avoids
+        // false rejections of stationary buoys.
+        if self.update_count >= 2 {
             if let (Some(current_cog), Some(new_cog), Some(kalman_sog)) =
                 (self.cog, measured_cog, self.sog)
             {
@@ -1807,5 +1821,77 @@ mod tests {
                 tracker.active_count()
             );
         }
+    }
+
+    #[test]
+    fn turn_rejection_applies_to_mature_tracks() {
+        // A long-tracked fast target suddenly receives an "update" 180°
+        // off its heading. This is the kind of false association the
+        // old early-tracking-only window let through, and the kind most
+        // likely to mislead a navigator (mature tracks are trusted).
+        // After #4 the rejection applies for the entire lifetime so
+        // the bogus update is rejected even when the target is well
+        // established.
+        let mut tracker = TargetTracker::new_merged(2048);
+        let max_speed_ms = TEST_MAX_SPEED_MS;
+
+        // 10 clean revolutions heading east at ~10 m/s. After the 4th
+        // update the target is in Tracking; we go far past that.
+        let lat = 52.0;
+        let start_lon = 4.0;
+        let lon_step = 30.0 / meters_per_degree_longitude(&lat);
+        for i in 0..10u64 {
+            tracker.process_candidate(TargetCandidate {
+                time: i * 3000,
+                position: GeoPosition::new(lat, start_lon + lon_step * i as f64),
+                size_meters: 30.0,
+                radar_key: "test".to_string(),
+                radar_position: Some(GeoPosition::new(52.0, 4.0)),
+                max_target_speed_ms: max_speed_ms,
+                source: CandidateSource::GuardZone(1),
+            });
+        }
+        let target = tracker.get_active_targets().next().unwrap();
+        assert_eq!(target.status, TargetStatus::Tracking);
+        assert!(
+            target.update_count >= 9,
+            "target should be well past the old <5 window: update_count={}",
+            target.update_count
+        );
+
+        // Now feed a candidate that would represent a 180° course
+        // reversal at the same speed (jumping 30m west of the prior
+        // position rather than 30m east). With the old early-only check,
+        // the mature track would silently accept this and corrupt itself.
+        let last_lon = start_lon + lon_step * 9.0;
+        let bogus = TargetCandidate {
+            time: 10 * 3000,
+            position: GeoPosition::new(lat, last_lon - lon_step),
+            size_meters: 30.0,
+            radar_key: "test".to_string(),
+            radar_position: Some(GeoPosition::new(52.0, 4.0)),
+            max_target_speed_ms: max_speed_ms,
+            source: CandidateSource::GuardZone(1),
+        };
+        // The mature track rejects the bogus update; because the candidate
+        // comes from a guard zone, a fresh acquiring target is created
+        // instead. Either way the original mature track must NOT have
+        // been updated to the reversed position.
+        let _ = tracker.process_candidate(bogus);
+
+        // Find the mature track (the one with high update count) and
+        // confirm its position is still where the eastbound run left it,
+        // not pulled west by the bogus 180° measurement.
+        let mature = tracker
+            .get_active_targets()
+            .max_by_key(|t| t.update_count)
+            .unwrap();
+        assert!(
+            (mature.position.lon() - last_lon).abs() < 1e-9,
+            "mature track position must not have been pulled west by the bogus update: \
+             got lon={}, expected {}",
+            mature.position.lon(),
+            last_lon
+        );
     }
 }

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -25,8 +25,14 @@ const DELETE_REVOLUTION_COUNT: u64 = 4;
 /// Extended to handle buoys/anchored vessels that may temporarily disappear behind a passing ship.
 const STATIONARY_DELETE_REVOLUTION_COUNT: u64 = 10;
 
-/// Speed threshold (m/s) below which a target is considered stationary
-/// 0.5 m/s = ~1 knot - accounts for GPS drift and minor movement
+/// Speed threshold (m/s) below which a target is considered stationary.
+/// 0.5 m/s ≈ 1 kn — covers GPS drift and minor movement on a moored or
+/// anchored vessel. Targets caught by this threshold receive the longer
+/// stationary lost/delete timeouts. A slowly drifting anchored vessel
+/// or a small boat doing < 1 kn under tide will be over-classified as
+/// stationary; the cost is a slightly longer wait before garbage-
+/// collecting a genuinely gone target, which is preferable to dropping
+/// a real low-speed track too early.
 const STATIONARY_SPEED_THRESHOLD: f64 = 0.5;
 
 /// Maximum separation (meters) between two targets that are considered duplicates.
@@ -34,8 +40,13 @@ const STATIONARY_SPEED_THRESHOLD: f64 = 0.5;
 /// each within this distance of the others but all representing the same physical target.
 const DUPLICATE_MERGE_DISTANCE_M: f64 = 100.0;
 
-/// Minimum number of updates before a target can be considered stationary
-/// Prevents false positives from slow-starting tracks
+/// Minimum number of updates before a target can be considered stationary.
+///
+/// Promotion to Tracking requires `update_count >= 4`, so this is one
+/// step further: a stationary classification needs not just a promoted
+/// track but also a converged motion estimate. That prevents the
+/// extended stationary timeouts being applied to a track that was only
+/// just confirmed and may still have a noisy Kalman SOG.
 const MIN_UPDATES_FOR_STATIONARY: u32 = 5;
 
 /// Minimum match distance (meters) for matching a blob to an active target

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -1875,19 +1875,32 @@ mod tests {
 
     #[test]
     fn dedup_keeps_distinct_close_vessels_with_different_courses() {
-        // Two vessels within DUPLICATE_MERGE_DISTANCE_M of each other,
-        // each moving in a clearly different direction. The pre-fix
-        // dedup would merge whichever had fewer updates into the other;
-        // the motion-aware check now keeps both because their courses
-        // diverge.
+        // Two vessels that must remain within DUPLICATE_MERGE_DISTANCE_M
+        // (100m) of each other AT DEDUP TIME but moving on perpendicular
+        // courses. Picked geometry:
+        //
+        // - 8m step per 3-second revolution (~2.7 m/s SOG) so neither
+        //   target drifts out of the 100m merge ring.
+        // - 70m initial east offset so B's first blob doesn't match A
+        //   on candidate association (with max_target_speed_ms = 5 m/s
+        //   the per-candidate gate is max(50m, 5·3·1.5) = 50m).
+        // - max_target_speed_ms intentionally low for the same reason:
+        //   with TEST_MAX_SPEED_MS (≈25.7 m/s) A's match window would
+        //   reach 115m and absorb B before dedup is even consulted.
+        //
+        // At dedup time: A at ~24m north, B at ~86m east of (52, 4) →
+        // separation `sqrt(24² + 86²)` ≈ 89m, inside the merge ring.
+        // Only the new motion-aware COG exemption keeps them distinct.
+        // Removing the exemption causes this test to fail.
         let mut tracker = TargetTracker::new_merged(2048);
-        let max_speed_ms = TEST_MAX_SPEED_MS;
+        let max_speed_ms = 5.0;
         let radar = Some(GeoPosition::new(52.0, 4.0));
 
-        let lat_step = 30.0 / METERS_PER_DEGREE_LATITUDE; // ~10 m/s northbound
-        let lon_step = 30.0 / meters_per_degree_longitude(&52.0); // ~10 m/s eastbound
+        let lat_step = 8.0 / METERS_PER_DEGREE_LATITUDE; // ~2.7 m/s northbound
+        let lon_step = 8.0 / meters_per_degree_longitude(&52.0); // ~2.7 m/s eastbound
 
-        // Target A: heading north, 4 updates (gets a COG estimate)
+        // Target A: heading north, 4 updates so it reaches Tracking
+        // and gets a converged COG estimate.
         for i in 0..4u64 {
             tracker.process_candidate(TargetCandidate {
                 time: i * 3000,
@@ -1900,10 +1913,9 @@ mod tests {
             });
         }
 
-        // Target B: heading east, 80m east of A's start (within merge
-        // distance). 3 updates so it stays under the established
-        // threshold and would otherwise be a merge candidate.
-        let b_start_lon = 4.0 + 80.0 / meters_per_degree_longitude(&52.0);
+        // Target B: heading east, 70m east of A's start. 3 updates so
+        // it stays a young (< 4) dedup candidate.
+        let b_start_lon = 4.0 + 70.0 / meters_per_degree_longitude(&52.0);
         for i in 0..3u64 {
             tracker.process_candidate(TargetCandidate {
                 time: i * 3000,
@@ -1916,6 +1928,21 @@ mod tests {
             });
         }
 
+        // Sanity: the two physical separations must straddle the merge
+        // distance correctly — close enough at dedup time that the
+        // distance gate alone wouldn't separate them, but each target's
+        // own match window mustn't reach the other.
+        let a = tracker.get_active_targets().find(|t| t.id == 1).unwrap();
+        let b = tracker.get_active_targets().find(|t| t.id == 2).unwrap();
+        let separation = calculate_distance(&a.position, &b.position);
+        assert!(
+            separation < DUPLICATE_MERGE_DISTANCE_M,
+            "test geometry must keep the targets inside the merge ring; \
+             separation was {:.1}m, threshold is {:.1}m",
+            separation,
+            DUPLICATE_MERGE_DISTANCE_M
+        );
+
         // Force a revolution-complete event to trigger the dedup pass.
         tracker.check_revolution(2000, 12_000);
         tracker.check_revolution(100, 13_000);
@@ -1924,26 +1951,23 @@ mod tests {
         assert_eq!(
             tracker.active_count(),
             2,
-            "two distinct close-by vessels with different COGs must NOT \
-             be merged, but {} target(s) remain",
+            "two close-by vessels with different COGs must NOT be merged, \
+             but {} target(s) remain",
             tracker.active_count()
         );
     }
 
     #[test]
     fn turn_rejection_applies_to_mature_tracks() {
-        // A long-tracked fast target suddenly receives an "update" 180°
-        // off its heading. This is the kind of false association the
-        // old early-tracking-only window let through, and the kind most
-        // likely to mislead a navigator (mature tracks are trusted).
-        // After #4 the rejection applies for the entire lifetime so
-        // the bogus update is rejected even when the target is well
-        // established.
+        // A long-tracked fast target receives an "update" 180° off its
+        // heading. Mature tracks are the ones a navigator is most
+        // likely to rely on, so the lifetime turn-rejection guarantee
+        // is what protects them from a false association.
         let mut tracker = TargetTracker::new_merged(2048);
         let max_speed_ms = TEST_MAX_SPEED_MS;
 
-        // 10 clean revolutions heading east at ~10 m/s. After the 4th
-        // update the target is in Tracking; we go far past that.
+        // 10 clean revolutions heading east at ~10 m/s — well past the
+        // 4-update Tracking promotion threshold.
         let lat = 52.0;
         let start_lon = 4.0;
         let lon_step = 30.0 / meters_per_degree_longitude(&lat);

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -58,6 +58,16 @@ const MIN_MATCH_DISTANCE_M: f64 = 50.0;
 /// within max_speed * delta_time. We use 1.5x to account for prediction error.
 const MATCH_DISTANCE_SPEED_MULTIPLIER: f64 = 1.5;
 
+/// Maximum COG difference (radians) for two close-by candidate targets
+/// to be treated as duplicates. Two real vessels close together (a tug
+/// and tow within 100 m, a row of moored boats) can sit inside the
+/// `DUPLICATE_MERGE_DISTANCE_M` ring of each other; the only way to tell
+/// them apart from a single physical target producing multiple blobs is
+/// motion: a single large vessel's blobs share the vessel's heading,
+/// while two distinct vessels generally don't. 30° matches the typical
+/// IMO close-quarters convention for "same/different course."
+const DEDUP_MAX_COG_DIFF_RAD: f64 = 30.0 * std::f64::consts::PI / 180.0;
+
 /// Maximum allowed turn angle (degrees) between consecutive sightings of
 /// a target moving faster than `TURN_REJECTION_SPEED_MS`. A real planing
 /// boat at 5 m/s can hard-over and pivot well under 90° per 3-second
@@ -439,14 +449,21 @@ impl TargetTracker {
         self.stats = TrackerStats::default();
     }
 
-    /// Merge duplicate targets that are within DUPLICATE_MERGE_DISTANCE_M of each other.
-    /// Only young targets (< 4 updates) are candidates for removal. An established target
-    /// (>= 4 updates) is never discarded, but a young target is merged into any nearby
-    /// target — young or established. Two established targets are never merged.
-    /// A large vessel can produce multiple blobs per rotation from different hull sections,
-    /// each starting a separate acquiring track near an already-established one.
-    /// For young+young pairs the one with fewer updates is discarded; ties go to the
-    /// higher (newer) ID. For young+established pairs the young one is always discarded.
+    /// Merge duplicate targets that are within DUPLICATE_MERGE_DISTANCE_M
+    /// of each other. Only young targets (< 4 updates) are candidates for
+    /// removal — established targets are never discarded.
+    ///
+    /// A large vessel can produce multiple blobs per rotation from
+    /// different hull sections, each starting a separate acquiring
+    /// track near an already-established one. Those duplicates share
+    /// the vessel's heading, so they should be merged.
+    ///
+    /// Two genuinely distinct vessels (a tug and tow, a row of moored
+    /// boats) can sit equally close together. When both candidates
+    /// have a COG estimate, the merge is suppressed if their courses
+    /// differ by more than `DEDUP_MAX_COG_DIFF_RAD` — that's the
+    /// signature of two real tracks rather than blob fragmentation
+    /// from one vessel.
     fn deduplicate_targets(&mut self) {
         let ids: Vec<u64> = self.active_targets.keys().copied().collect();
         let mut to_remove: Vec<u64> = Vec::new();
@@ -474,6 +491,31 @@ impl TargetTracker {
                 if dist > DUPLICATE_MERGE_DISTANCE_M {
                     continue;
                 }
+
+                // Motion-aware exemption: if both targets have a COG
+                // and the courses materially differ, treat them as two
+                // distinct vessels rather than blob fragmentation.
+                if let (Some(cog_a), Some(cog_b)) =
+                    (self.active_targets[&a].cog, self.active_targets[&b].cog)
+                {
+                    let mut diff = (cog_a - cog_b).abs();
+                    if diff > std::f64::consts::PI {
+                        diff = TAU - diff;
+                    }
+                    if diff > DEDUP_MAX_COG_DIFF_RAD {
+                        log::debug!(
+                            "Skipping dedup: target {} (cog {:.0}°) and {} (cog {:.0}°) \
+                             differ by {:.0}°, treating as distinct vessels",
+                            a,
+                            cog_a.to_degrees(),
+                            b,
+                            cog_b.to_degrees(),
+                            diff.to_degrees()
+                        );
+                        continue;
+                    }
+                }
+
                 // a is young; keep whichever has more updates (b wins ties since a is young)
                 let updates_a = self.active_targets[&a].update_count;
                 let updates_b = self.active_targets[&b].update_count;
@@ -1832,6 +1874,63 @@ mod tests {
                 tracker.active_count()
             );
         }
+    }
+
+    #[test]
+    fn dedup_keeps_distinct_close_vessels_with_different_courses() {
+        // Two vessels within DUPLICATE_MERGE_DISTANCE_M of each other,
+        // each moving in a clearly different direction. The pre-fix
+        // dedup would merge whichever had fewer updates into the other;
+        // the motion-aware check now keeps both because their courses
+        // diverge.
+        let mut tracker = TargetTracker::new_merged(2048);
+        let max_speed_ms = TEST_MAX_SPEED_MS;
+        let radar = Some(GeoPosition::new(52.0, 4.0));
+
+        let lat_step = 30.0 / METERS_PER_DEGREE_LATITUDE; // ~10 m/s northbound
+        let lon_step = 30.0 / meters_per_degree_longitude(&52.0); // ~10 m/s eastbound
+
+        // Target A: heading north, 4 updates (gets a COG estimate)
+        for i in 0..4u64 {
+            tracker.process_candidate(TargetCandidate {
+                time: i * 3000,
+                position: GeoPosition::new(52.0 + lat_step * i as f64, 4.0),
+                size_meters: 30.0,
+                radar_key: "test".to_string(),
+                radar_position: radar,
+                max_target_speed_ms: max_speed_ms,
+                source: CandidateSource::GuardZone(1),
+            });
+        }
+
+        // Target B: heading east, 80m east of A's start (within merge
+        // distance). 3 updates so it stays under the established
+        // threshold and would otherwise be a merge candidate.
+        let b_start_lon = 4.0 + 80.0 / meters_per_degree_longitude(&52.0);
+        for i in 0..3u64 {
+            tracker.process_candidate(TargetCandidate {
+                time: i * 3000,
+                position: GeoPosition::new(52.0, b_start_lon + lon_step * i as f64),
+                size_meters: 30.0,
+                radar_key: "test".to_string(),
+                radar_position: radar,
+                max_target_speed_ms: max_speed_ms,
+                source: CandidateSource::GuardZone(1),
+            });
+        }
+
+        // Force a revolution-complete event to trigger the dedup pass.
+        tracker.check_revolution(2000, 12_000);
+        tracker.check_revolution(100, 13_000);
+
+        // Both vessels must still be present.
+        assert_eq!(
+            tracker.active_count(),
+            2,
+            "two distinct close-by vessels with different COGs must NOT \
+             be merged, but {} target(s) remain",
+            tracker.active_count()
+        );
     }
 
     #[test]

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -73,9 +73,8 @@ const DEDUP_MAX_COG_DIFF_RAD: f64 = 30.0 * std::f64::consts::PI / 180.0;
 /// boat at 5 m/s can hard-over and pivot well under 90° per 3-second
 /// radar revolution; turns beyond this are almost certainly a stray blob
 /// being mistakenly associated with the wrong target. Applied for the
-/// entire lifetime of a target — the previous early-tracking-only check
-/// missed the most dangerous case (a long-tracked target suddenly
-/// "teleporting" via a false association).
+/// entire lifetime of a target so a mature, trusted track cannot silently
+/// accept an implausible jump from a false association.
 const MAX_TURN_ANGLE_DEG: f64 = 90.0;
 
 /// Speed threshold (m/s) above which turn rejection is applied
@@ -230,11 +229,9 @@ impl ActiveTarget {
 
         // Turn rejection: reject implausible maneuvers for fast targets.
         // Applies for the entire lifetime of a target (update_count >= 2,
-        // once a previous COG exists). The previous early-tracking-only
-        // window (update_count < 5) let a mature track suddenly teleport
-        // to a false association without challenge — the worst case
-        // operationally because a stable track is the one the navigator
-        // is most likely to be relying on.
+        // once a previous COG exists), so a mature track cannot silently
+        // accept a "teleport" from a false association — the case a
+        // navigator is most likely to be relying on.
         //
         // SOG is read from the Kalman estimate rather than from the raw
         // measured displacement: a stationary target's blob centre wanders
@@ -1965,14 +1962,14 @@ mod tests {
         assert_eq!(target.status, TargetStatus::Tracking);
         assert!(
             target.update_count >= 9,
-            "target should be well past the old <5 window: update_count={}",
+            "target must be a mature Tracking track: update_count={}",
             target.update_count
         );
 
-        // Now feed a candidate that would represent a 180° course
-        // reversal at the same speed (jumping 30m west of the prior
-        // position rather than 30m east). With the old early-only check,
-        // the mature track would silently accept this and corrupt itself.
+        // Feed a candidate representing a 180° course reversal at the
+        // same speed (jumping 30m west of the prior position rather
+        // than 30m east). Without the lifetime turn check, the mature
+        // track would silently accept this and corrupt itself.
         let last_lon = start_lon + lon_step * 9.0;
         let bogus = TargetCandidate {
             time: 10 * 3000,

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -80,6 +80,11 @@ const MAX_TURN_ANGLE_DEG: f64 = 90.0;
 /// Speed threshold (m/s) above which turn rejection is applied
 const TURN_REJECTION_SPEED_MS: f64 = 5.0;
 
+/// Minimum number of updates before turn rejection can fire. Needs a
+/// previous COG to compare against, so the very first measurement
+/// after creation never triggers a rejection.
+const MIN_UPDATES_FOR_TURN_REJECTION: u32 = 2;
+
 /// Multiplier for per-radar target IDs.
 /// In per-radar mode, radar N gets IDs in range [N * RADAR_ID_MULTIPLIER, (N+1) * RADAR_ID_MULTIPLIER - 1].
 /// In merged mode, IDs range from 1 to RADAR_ID_MULTIPLIER - 1.
@@ -228,10 +233,11 @@ impl ActiveTarget {
         };
 
         // Turn rejection: reject implausible maneuvers for fast targets.
-        // Applies for the entire lifetime of a target (update_count >= 2,
-        // once a previous COG exists), so a mature track cannot silently
-        // accept a "teleport" from a false association — the case a
-        // navigator is most likely to be relying on.
+        // Applies for the entire lifetime of a target once a previous
+        // COG exists (see `MIN_UPDATES_FOR_TURN_REJECTION`), so a mature
+        // track cannot silently accept a "teleport" from a false
+        // association — the case a navigator is most likely to be
+        // relying on.
         //
         // SOG is read from the Kalman estimate rather than from the raw
         // measured displacement: a stationary target's blob centre wanders
@@ -239,7 +245,7 @@ impl ActiveTarget {
         // speeds of 8-10 m/s with random direction. The Kalman filter
         // correctly converges toward the true low speed and avoids
         // false rejections of stationary buoys.
-        if self.update_count >= 2 {
+        if self.update_count >= MIN_UPDATES_FOR_TURN_REJECTION {
             if let (Some(current_cog), Some(new_cog), Some(kalman_sog)) =
                 (self.cog, measured_cog, self.sog)
             {


### PR DESCRIPTION
## Summary

End-to-end pass over `src/lib/radar/target/` and `src/lib/radar/cpa.rs` against the design plan on the throwaway `arpa-rework-plan` branch. 9 commits, one logical change each.

| Commit | Plan item |
|---|---|
| `fix(arpa): compute CPA from the Kalman-filtered position` | #10 — raw `target.position` swings 50m revolution-to-revolution; the smoothed Kalman state is the same source COG/SOG come from. |
| `feat(arpa): emit signed TCPA and add IMO is_dangerous flag` | #9 — historical CPAs were dropped entirely; now emitted with signed TCPA so a navigator can see "we just passed at 50m". `is_dangerous` uses IMO defaults (CPA < 0.5 nm AND TCPA in [0, 6 min]). |
| `fix(arpa): log and skip Kalman update on singular innovation matrix` | #5 — defensive: previous fallback to identity for `s_inv` silently corrupted state. |
| `fix(arpa): apply turn rejection for the full lifetime of a target` | #4 — old check ran only for update_count ∈ [2,5); a mature trusted track could silently accept a 170° teleport. Also tightened the threshold from 130° to 90°. |
| `fix(arpa): perform real IMM state mixing each step` | #1 — the previous `mix_states` discarded the mixing matrix and reduced IMM to three parallel Kalmans plus a softmax. Real Bar-Shalom mixing now runs: `x0_j = Σ_i μ_{i\|j} · x_i` and `P0_j = Σ_i μ_{i\|j} · (P_i + (x_i - x0_j)(x_i - x0_j)ᵀ)`. Also fixes plan item #3 as a side effect. |
| `refactor(arpa): remove dead force_state path` | #6 — `KalmanFilter::force_state` and the IMM wrapper had no callers since the experiment was never finished; removing the per-filter API also avoids a future footgun against the IMM mixing rework. |
| `docs(arpa): justify the stationary detection thresholds` | #7 — `MIN_UPDATES_FOR_STATIONARY` and `STATIONARY_SPEED_THRESHOLD` had hand-wavy comments; documented the relationship to promotion and the over-classification trade-off. |
| `fix(arpa): exempt distinct close vessels from dedup using COG check` | #8 — the previous unconditional young-target merge inside 100m killed legitimate close-by traffic (tug + tow, moored clusters). Skip the merge when both candidates have COG and the courses differ by more than 30°. |
| `style(arpa): use RangeInclusive::contains for TCPA window check` | clippy `manual_range_contains` cleanup in the new `TargetDangerApi::new`. |

The plan also covered #2 (real CA/CT models — explicitly deferred pending a benchmark corpus), #11–#13 (design discussion, not code). Plan stays on the `arpa-rework-plan` branch for reference.

## Tested

- All 88 lib radar tests pass, including 6 new ones added by this PR: `compute_danger_uses_filtered_position_not_raw_measurement`, `target_danger_api_*` (3 cases for `is_dangerous` flag), `imm_mixing_keeps_filter_states_consistent`, `turn_rejection_applies_to_mature_tracks`, `dedup_keeps_distinct_close_vessels_with_different_courses`.
- Full release-mode test suite passes: 252 lib + 9 replay (Furuno, Garmin, Navico 4G/BR24/HALO 20+/HALO 24/HALO 3006, Raymarine) + 30 other integration tests, 0 failures.
- Live on Furuno DRS4D-NXT (fur6424A) — spokes flow, blob detector produces valid targets, guard-zone notifications fire as expected.

## CodeRabbit findings

CR flagged 2 "potential issues" — both false positives: CHANGELOG.md and `src/bin/mayara-server/web/mod.rs` are not touched by this PR (`git diff --stat origin/main..HEAD` shows only the 6 ARPA files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CPA and Danger Assessment

calculate_cpa treats tcpa as a signed value (positive = future closing, negative = past/diverging) and returns Some(CpaResult) for any non-negligible relative velocity; it returns None only when relative velocity is essentially zero. CPA is computed from the Kalman-filtered/predicted target position (not raw measurements) to avoid revolution-to-revolution swings; historical CPAs are emitted. TargetDangerApi adds an is_dangerous boolean computed with IMO-like thresholds (DANGER_CPA_M = 0.5 nm, DANGER_TCPA_S = 6 min): dangerous when cpa < threshold and tcpa is within the inclusive future window (negative tcpa never flags). TargetDangerApi::unknown() and tightened serialization-omission logic are added. Tests adopt signed-tcpa semantics and include a regression ensuring filtered-position CPA is less affected by noisy measurement spikes.

## Kalman Filter and State Management

Exposes Vector4/Matrix4x4 as pub(super) and adds pub(super) accessors to get/set (state, covariance) and ref_lat/ref_lon to support IMM mixing. On singular or non-invertible innovation covariance the filter logs the failure, skips the measurement correction (keeps the predicted state), advances last_time, and returns motion from the prediction instead of silently falling back to an identity correction. set_process_noise visibility is tightened to pub(super). A unit test verifies the update skips correction for singular innovation covariance.

## IMM (Interacting Multiple Model)

Implements full Bar‑Shalom mixing each step: computes c_bar and conditional mixing probabilities, snapshots each model’s state and covariance, forms mixed initial states and mixed covariances (including the augmentation term (x_i − x0_j)(x_i − x0_j)^T), and writes mixed priors back into the CV/CA/CT filters. A debug_assert ensures filters share the same ref_lat/ref_lon before mixing. model_probs are set to the predicted weights during mixing. ImmMotionModel enforces idempotence for stale/duplicate timestamps (no mutation when time ≤ last_time). The MotionModel::force_state API and the dead force_state path are removed.

## Tracker, Turn-Rejection, and Deduplication

Applies turn-rejection for the remainder of a target’s lifetime once a prior COG exists (guarded by MIN_UPDATES_FOR_TURN_REJECTION) and tightens the maximum accepted turn angle from 130° to 90°. Stationary-detection thresholds (MIN_UPDATES_FOR_STATIONARY and STATIONARY_SPEED_THRESHOLD) are documented. Deduplication becomes motion-aware: when two nearby candidates both have COG estimates, merging is skipped if their wrapped course difference exceeds DEDUP_MAX_COG_DIFF_RAD (~30°), preventing unconditional merging of legitimately distinct close vessels. Tests verify motion-aware dedup and lifetime turn-rejection behavior.

## Tests, CI, and Deployment

Adds unit tests for signed-tcpa behavior, filtered-position danger regression, singular-innovation handling, IMM mixing consistency and idempotence, turn-rejection, and motion-aware deduplication. All radar library tests (including six new tests) and the full release-mode suite pass locally; changes are deployed and observed on a Furuno DRS4D‑NXT. CodeRabbit flags two unrelated false positives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->