### PR TITLE
chore(coderabbit): exclude auto-generated CHANGELOG.md from review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,6 +41,14 @@ reviews:
     - '!testdata/**/*.pcap'
     - '!**/*.min.js'
     - '!**/*.min.css'
+    # CHANGELOG.md is rewritten on every push to main by
+    # .github/workflows/changelog.yml running git-cliff. Any contributor
+    # edit is either redundant (will be overwritten by the workflow's
+    # own follow-up PR) or wrong. Hand-curated entries belong in
+    # CHANGELOG.manual.md, which the workflow appends. Excluding the
+    # generated file from review stops CR from repeatedly flagging
+    # phantom CHANGELOG.md edits on PRs that don't actually touch it.
+    - '!CHANGELOG.md'
 
   high_level_summary_instructions: |
     Write summaries in present tense. Describe what the code does, not


### PR DESCRIPTION
## Summary

CR has been repeatedly flagging "manual CHANGELOG.md edit" findings on PRs that don't touch the file at all (PRs #268 and #275 each got one despite `git diff origin/main..HEAD -- CHANGELOG.md` being empty). The existing `path_instruction` block correctly tells CR the file is auto-generated, but CR keeps hallucinating edits anyway.

Add `CHANGELOG.md` to `path_filters` so CR stops looking at it. Hand-curated entries belong in `CHANGELOG.manual.md` (which the changelog workflow appends), and that file is still reviewed normally.

## Tested

- `python3 -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"` parses cleanly.
- Genuine CHANGELOG.md edits will land via the auto-commit workflow (`docs(changelog): update CHANGELOG.md`), which already bypasses CI/review by design.