### PR TITLE
chore(release): 3.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.5.3-dev"
+version = "3.5.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.5.3-dev"
+version = "3.5.3"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
Bump version 3.5.3-dev → 3.5.3.

After this PR merges, tag `v3.5.3` on the merge commit and push the tag to trigger `release.yml` (GitHub Release + Docker image publish).

## What ships in 3.5.3 (since v3.5.2)

- `feat(gui)`: show active renderer (webgpu/webgl) in the controls header (#252)
- `feat(arpa)`: emit Signal K notifications for guard-zone target acquisition (#260)
- `fix(gui)`: keep PPI sized to the visible viewport on mobile (#249)
- `fix(gui)`: exponential backoff for heading and AIS reconnects (#254)
- `fix(gui)`: don't reset canvas bitmap on transform-only redraws (#268)
- `fix(gui)`: address API and WebSocket URLs relative to the GUI mount (#270)
- `fix(signalk)`: skip upstream servers that accept then go silent (#256)
- `fix(signalk)`: require own-ship navigation before trusting an upstream (#258)
- `fix(signalk)`: match notifications.* in subscription filter (#262)
- `fix(web)`: respect X-Forwarded-Proto and Host port for advertised WS URLs (#264)
- `chore(coderabbit)`: exclude auto-generated CHANGELOG.md from review (#276)
- `chore(ci)`: expand .coderabbit.yaml with project-specific review rules (#248)
- `docs(agents)`: note the GUI must use relative API/WS base paths (#272)

The ARPA tracker improvements PR (#275) is still open and will land in a follow-up release.

## Tested

- `cargo update --workspace` only touched the workspace member's own version line.
- `cargo check --lib` is clean at the new version string.