### PR TITLE
fix(ci): force-switch to main when committing the regenerated CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,9 +161,15 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        # git-cliff has already rewritten CHANGELOG.md in the working
+        # tree during the previous step. Snapshot it, then force the
+        # switch to main so the uncommitted modification doesn't block
+        # the checkout (the snapshot is restored right after). Without
+        # -f, `git switch -C` aborts with "Your local changes ... would
+        # be overwritten by checkout" and the changelog PR never opens.
         cp CHANGELOG.md /tmp/CHANGELOG.md
         git fetch origin main
-        git switch -C main origin/main
+        git switch -fC main origin/main
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         cp /tmp/CHANGELOG.md CHANGELOG.md


### PR DESCRIPTION
## Summary

The v3.5.3 release workflow (run 26657818741) failed in the post-release "Commit changelog" step. git-cliff regenerates CHANGELOG.md in the working tree, the step snapshots it to /tmp, then calls \`git switch -C main origin/main\` — which aborts because of the uncommitted CHANGELOG.md modification, and \`set -e\` propagates the failure. Net result: GitHub Release published OK (binaries attached, notes generated), but no follow-up \`docs(changelog): update CHANGELOG.md for v3.5.3\` PR was opened, and the dependent "Publish Docker Image" job was skipped.

Add \`-f\` to the switch so the working-tree CHANGELOG.md is discarded (the snapshot in /tmp is restored on the very next line, so this is intentional).

## Tested

- \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\` passes.
- The failure mode is reproduced by the v3.5.3 run log: https://github.com/MarineYachtRadar/mayara-server/actions/runs/26657818741/job/78574523161