### PR TITLE
fix(furuno): detect dead control socket so first PUT after idle succeeds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,11 @@ serde_json = "1.0.150"
 serde_repr = "0.1.20"
 serde_with = { version = "3.20.0", features = ["macros"] }
 sha1 = "0.11.0"
+# `features = ["all"]` is socket2's single feature flag — it gates the
+# platform-conditional APIs (e.g. TCP_KEEPIDLE/TCP_KEEPINTVL/TCP_KEEPCNT
+# setters) that not every target supports. We need it for
+# `TcpKeepalive::with_interval` / `with_retries` / `SockRef::set_tcp_keepalive`
+# on the Furuno control socket.
 socket2 = { version = "0.6.3", features = ["all"] }
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ serde_json = "1.0.150"
 serde_repr = "0.1.20"
 serde_with = { version = "3.20.0", features = ["macros"] }
 sha1 = "0.11.0"
-socket2 = "0.6.3"
+socket2 = { version = "0.6.3", features = ["all"] }
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["formatting"] }

--- a/src/lib/brand/furuno/command.rs
+++ b/src/lib/brand/furuno/command.rs
@@ -81,7 +81,18 @@ impl Command {
 
         match &mut self.write {
             Some(w) => {
-                w.write_all(&bytes).await.map_err(RadarError::Io)?;
+                if let Err(e) = w.write_all(&bytes).await {
+                    // Drop the half-closed writer so the next call fast-
+                    // fails with NotConnected and the periodic 5s report-
+                    // request tick in data_loop sees the error and
+                    // triggers a reconnect immediately, instead of every
+                    // user PUT queuing more writes onto a dead socket.
+                    // Furuno radars silently drop the control TCP socket
+                    // after idle; SO_KEEPALIVE in start_command_stream
+                    // shortens that window but doesn't eliminate it.
+                    self.write = None;
+                    return Err(RadarError::Io(e));
+                }
             }
             None => return Err(RadarError::NotConnected),
         };

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -31,6 +31,16 @@ use crate::radar::settings::ControlId;
 use crate::radar::{Power, RadarError, RadarInfo};
 use crate::util::PrintableSpoke;
 
+/// TCP keepalive timing for the Furuno control socket. Tunes how quickly the
+/// kernel detects that the radar has silently dropped the connection after
+/// idle (DRS4D-NXT does this after ~2 min in standby). With these settings the
+/// kernel tears the socket down within ~60 s of the peer going silent, so the
+/// next user PUT sees either a fresh writer or a clean NotConnected — never a
+/// stale half-closed socket that just hangs.
+const CONTROL_KEEPALIVE_IDLE: Duration = Duration::from_secs(30);
+const CONTROL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+const CONTROL_KEEPALIVE_RETRIES: u32 = 3;
+
 /// Furuno wire-format decoding mode. When Target Analyzer is active on NXT
 /// radars, each echo byte encodes `[dopplerClass:2 | intensity:4 | 00:2]`
 /// rather than a plain intensity in 0..PIXEL_VALUES. The report receiver
@@ -203,15 +213,12 @@ impl FurunoReportReceiver {
         // fails with BrokenPipe, and the user sees a 400 "I/O operation
         // failed". The data_loop only notices on its next 5s report-tick
         // and reconnects, but by then the GUI has already shown the error
-        // and the radar is still in standby. SO_KEEPALIVE with a 30s
-        // idle threshold and 10s probes lets the kernel tear the socket
-        // down within ~60s of the peer going silent, so by the time the
-        // user clicks transmit the writer is either fresh or visibly
-        // missing — never silently dead.
+        // and the radar is still in standby. Timing constants are at the
+        // top of the file.
         let keepalive = socket2::TcpKeepalive::new()
-            .with_time(Duration::from_secs(30))
-            .with_interval(Duration::from_secs(10))
-            .with_retries(3);
+            .with_time(CONTROL_KEEPALIVE_IDLE)
+            .with_interval(CONTROL_KEEPALIVE_INTERVAL)
+            .with_retries(CONTROL_KEEPALIVE_RETRIES);
         socket2::SockRef::from(&stream)
             .set_tcp_keepalive(&keepalive)
             .map_err(RadarError::Io)?;

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -192,11 +192,31 @@ impl FurunoReportReceiver {
             return Err(RadarError::InvalidPort);
         }
         let sock = TcpSocket::new_v4().map_err(|e| RadarError::Io(e))?;
-        self.stream = Some(
-            sock.connect(std::net::SocketAddr::V4(self.common.info.send_command_addr))
-                .await
-                .map_err(|e| RadarError::Io(e))?,
-        );
+        let stream = sock
+            .connect(std::net::SocketAddr::V4(self.common.info.send_command_addr))
+            .await
+            .map_err(|e| RadarError::Io(e))?;
+
+        // Furuno radars silently drop the control TCP socket after an idle
+        // period (observed on DRS4D-NXT after ~2 min). Without keepalive the
+        // first PUT after idle hits the stale half-closed socket, write_all
+        // fails with BrokenPipe, and the user sees a 400 "I/O operation
+        // failed". The data_loop only notices on its next 5s report-tick
+        // and reconnects, but by then the GUI has already shown the error
+        // and the radar is still in standby. SO_KEEPALIVE with a 30s
+        // idle threshold and 10s probes lets the kernel tear the socket
+        // down within ~60s of the peer going silent, so by the time the
+        // user clicks transmit the writer is either fresh or visibly
+        // missing — never silently dead.
+        let keepalive = socket2::TcpKeepalive::new()
+            .with_time(Duration::from_secs(30))
+            .with_interval(Duration::from_secs(10))
+            .with_retries(3);
+        socket2::SockRef::from(&stream)
+            .set_tcp_keepalive(&keepalive)
+            .map_err(RadarError::Io)?;
+
+        self.stream = Some(stream);
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

Furuno radars silently drop the control TCP socket after an idle period (observed on DRS4D-NXT after ~2 minutes in standby). With no keepalive, the kernel never tears the stale half-closed socket down; the writer in `Command` stays `Some(WriteHalf)` but the underlying TCP is dead.

When the user comes back to the GUI and clicks transmit, `write_all` on the stale socket returns `BrokenPipe`, `v2::set_control_value` returns HTTP 400 with body `"I/O operation failed"`, and the radar stays in standby. The `data_loop` only notices on its next 5 s report-request tick, so the GUI's retry-after-error usually succeeds — but the first PUT visibly fails and the user has to retry by hand.

This affects both the bundled GUI when served directly from mayara and the proxied GUI behind a Signal K server.

## Approach

Two changes, one mitigation each:

1. **`start_command_stream`** sets `SO_KEEPALIVE` on the freshly connected socket (`TCP_KEEPIDLE` 30 s, `TCP_KEEPINTVL` 10 s, `TCP_KEEPCNT` 3). The kernel detects a half-closed peer within ~60 s of silence, so by the time the user clicks transmit the writer is either fresh (reconnect already happened) or visibly missing — never silently dead. Needs `socket2` feature `all` (already pulled in transitively but now declared explicitly so a future dep upgrade can't break the build).

2. **`send_with_commas`** clears `self.write` to `None` when `write_all` fails. Subsequent calls fast-fail with `NotConnected` instead of queueing more writes onto a corpse, and the next 5 s report-request tick in `data_loop` propagates the same `NotConnected` via `?` and exits the loop — triggering the run-loop reconnect within seconds instead of waiting for the next periodic write to fail.

Together: keepalive shrinks the silent-dead window from "indefinite" to ~60 s, and the writer-clearing means even within that window the recovery happens on the next tick rather than the next user PUT.

## Tested

- `cargo build` — clean.
- `cargo test --lib --bins` — 235 + 15 tests, all pass.
- `cargo clippy --lib --bins` — no new findings from this change (313 pre-existing warnings, 2 pre-existing errors in `locator.rs` / `range.rs`).
- `cr review --plain` — flagged the `socket2` feature requirement, addressed in this PR by declaring `features = ["all"]` explicitly in `Cargo.toml`.
- Reproduced the original bug on a live DRS4D-NXT 6424A — first `power=2` PUT after idle returned 400 "I/O operation failed" with logs showing `User tried to set invalid power: I/O operation failed`. Will verify the fix end-to-end after the image is republished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem
Furuno radars (DRS4D-NXT and similar) silently drop the control TCP socket after ~2 minutes of idle. Without TCP keepalive, the kernel may not tear down the stale half-closed socket; the code retains a writer reference while the connection is dead. When a user issues a PUT command after idle, `write_all` fails with BrokenPipe, returning HTTP 400 and leaving the radar in standby. The periodic report-request in `data_loop` only detects this failure ~5 seconds later, making the first PUT visibly fail and requiring manual retry.

## Solution
Two mitigations are implemented:

**TCP Keepalive Configuration** (`start_command_stream` in `report.rs`):
- Separates socket connection from stream assignment
- Applies TCP keepalive settings via `socket2::TcpKeepalive` with 30s idle threshold, 10s probe interval, and 3 retry attempts
- Allows the kernel to detect and tear down half-closed connections within ~60 seconds of peer silence

**Fast-Fail on Write Error** (`send_with_commas` in `command.rs`):
- Clears `self.write` when `write_all` fails, dropping the stale writer
- Subsequent send attempts immediately fail with `NotConnected` instead of queuing writes to a dead socket
- Enables `data_loop`'s next 5-second tick to detect the failure and trigger reconnection sooner

**Dependency Update** (`Cargo.toml`):
- Explicitly enables the `"all"` feature on `socket2 = "0.6.3"` to support TCP keepalive configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->