### PR TITLE
fix(furuno): skip spoke decode in idle mode to free ~1.5 cores at idle

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -572,6 +572,13 @@ async fn spokes_handler(
 
     match state.radars.get_by_key(&params.id) {
         Some(radar) => {
+            // Exit idle before subscribing so the frame already in flight
+            // when the WS connects gets decoded, not the next one. The
+            // data_loop's 5s periodic re-check would catch this eventually
+            // but the window between subscribe and the first revolution is
+            // exactly what users see as "PPI took a couple seconds to fill"
+            // — better to flip synchronously here.
+            radar.wake_up();
             let shutdown_rx = state.shutdown_tx.subscribe();
             let radar_message_rx = radar.message_tx.subscribe();
             // finalize the upgrade process by returning upgrade callback.

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -578,9 +578,19 @@ async fn spokes_handler(
             // but the window between subscribe and the first revolution is
             // exactly what users see as "PPI took a couple seconds to fill"
             // — better to flip synchronously here.
+            //
+            // Wake twice: before AND after subscribe. The data_loop's 5 s
+            // tick could race between the first wake_up and message_tx.
+            // subscribe(); it sees power=Standby and receiver_count==0
+            // (subscribe hasn't completed yet) and flips us back to idle.
+            // The post-subscribe wake_up wins this race — by the time it
+            // runs, subscribe has incremented receiver_count, so even if
+            // the next tick fires immediately afterwards it computes
+            // should_idle() = false and leaves the flag alone.
             radar.wake_up();
             let shutdown_rx = state.shutdown_tx.subscribe();
             let radar_message_rx = radar.message_tx.subscribe();
+            radar.wake_up();
             // finalize the upgrade process by returning upgrade callback.
             // we can customize the callback by sending additional info such as address.
             ws.permessage_deflate()

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -477,6 +477,11 @@ async fn set_control_value(
     let (controls, control_value, radar_key) = {
         match state.radars.get_by_key(&radar_id) {
             Some(radar) => {
+                // Any control PUT means someone is interacting with this
+                // radar — exit idle synchronously so the response stream
+                // and any subsequent spoke decode kicks in this tick, not
+                // the next 5s recheck.
+                radar.wake_up();
                 // Look up the control by name
                 let control = match radar.controls.get_by_id(&control_id) {
                     Some(c) => c,

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1391,6 +1391,11 @@ async fn handle_control_request(
 ) -> Result<(), RadarError> {
     if let Some(radar_id) = rcv.parse_path() {
         if let Some(radar) = radars.get_by_key(&radar_id) {
+            // Mirror the REST PUT path's idle-exit. Any control written
+            // over the WebSocket stream is also user interaction; without
+            // this, a WS-only client (e.g. some MFD integrations) leaves
+            // the Furuno receiver in soft-idle until the next 5 s tick.
+            radar.wake_up();
             let control_value: ControlValue = rcv.into();
             let result = radar
                 .controls

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -270,6 +270,32 @@ impl FurunoReportReceiver {
                         cs.send_report_requests().await?;
                     }
                     deadline = Instant::now() + self.report_request_interval;
+
+                    // Recompute idle: standby + zero spoke subscribers. Exit
+                    // points (control PUT, power-change report, new WS
+                    // subscriber) clear is_idle directly so this only needs
+                    // to handle the entry direction and the rare case where
+                    // the subscriber count drops to zero between ticks.
+                    // Each range has independent power/subscribers in dual-
+                    // range mode so refresh both flags.
+                    let was_idle_a = self.common.info.is_idle();
+                    refresh_idle_flag(&self.common);
+                    // Encoding 3 reconstructs spokes from `prev_spoke[range_idx]`
+                    // across frame boundaries. If we just entered idle, the
+                    // next wake-up frame would decode against a stale buffer
+                    // and the first revolution would render as garbage.
+                    // Reset on the inactive→idle edge so the next exit starts
+                    // delta-decoding against an empty (transparent) baseline.
+                    if !was_idle_a && self.common.info.is_idle() {
+                        self.prev_spoke[0].clear();
+                    }
+                    if let Some(ref common_b) = self.common_b {
+                        let was_idle_b = common_b.info.is_idle();
+                        refresh_idle_flag(common_b);
+                        if !was_idle_b && common_b.info.is_idle() {
+                            self.prev_spoke[1].clear();
+                        }
+                    }
                 },
 
                 Some(r) = conditional_read(&mut reader, &mut line) => {
@@ -342,7 +368,17 @@ impl FurunoReportReceiver {
                     match r {
                         Ok((len, addr)) => {
                             if self.verify_source_address(&addr) {
-                                self.process_frame(&buf[..len]);
+                                // Idle mode: drain the recv but skip decoding.
+                                // Furuno radars emit spokes even in Standby;
+                                // when nobody is watching, decoding them costs
+                                // ~1.5 cores for nothing. See issue #274. In
+                                // dual-range mode each range has its own idle
+                                // flag; only skip if BOTH are idle, because
+                                // process_frame routes the frame to the right
+                                // common based on metadata.radar_no.
+                                if !self.both_ranges_idle() {
+                                    self.process_frame(&buf[..len]);
+                                }
                                 self.receive_type = ReceiveAddressType::Multicast;
                                 broadcast_socket = None;
                             }
@@ -360,7 +396,9 @@ impl FurunoReportReceiver {
                     match r {
                         Ok((len, addr)) => {
                             if self.verify_source_address(&addr) {
-                                self.process_frame(&buf2[..len]);
+                                if !self.both_ranges_idle() {
+                                    self.process_frame(&buf2[..len]);
+                                }
                                 self.receive_type = ReceiveAddressType::Broadcast;
                                 multicast_socket = None;
                             }
@@ -441,6 +479,20 @@ impl FurunoReportReceiver {
             }
         }
         &mut self.common
+    }
+
+    /// True only when every active range is idle. We must keep decoding
+    /// frames as long as ANY range still has subscribers or is transmitting,
+    /// because spokes for Range A and Range B share the same UDP socket and
+    /// `process_frame` routes per-frame via `metadata.radar_no`.
+    fn both_ranges_idle(&self) -> bool {
+        if !self.common.info.is_idle() {
+            return false;
+        }
+        match self.common_b {
+            Some(ref cb) => cb.info.is_idle(),
+            None => true,
+        }
     }
 
     /// Extract the dual range ID from a per-range response.
@@ -570,10 +622,21 @@ impl FurunoReportReceiver {
                     _ => Power::Off,
                 };
 
+                let is_standby = matches!(generic_state, Power::Standby);
                 let power_value = generic_state as i32 as f64;
                 let drid = self.extract_drid(&command_id, &numbers);
                 let target = self.common_for_range(drid);
                 target.set_value(&ControlId::Power, power_value);
+
+                // Exit idle on any transition away from Standby so the next
+                // received spoke frame is decoded immediately. The 5s
+                // periodic re-check would catch it too, but waiting a tick
+                // means up to one revolution of "frames discarded after the
+                // radar started transmitting", which the user would see as
+                // a blank PPI for a beat.
+                if !is_standby {
+                    target.info.wake_up();
+                }
 
                 if numbers.len() >= 5 {
                     let wman = numbers[2] as i32;
@@ -600,6 +663,9 @@ impl FurunoReportReceiver {
                         self.common_b.as_mut().unwrap()
                     };
                     other.set_value(&ControlId::Power, power_value);
+                    if !is_standby {
+                        other.info.wake_up();
+                    }
                 }
             }
             CommandId::Gain => {
@@ -2011,6 +2077,31 @@ async fn conditional_read(
     }
 }
 
+/// Decide whether a radar's data_loop should enter idle mode, where it
+/// drains the spoke socket but skips decoding. Idle is safe when both:
+/// the radar is in Standby (so the frames it emits are essentially noise)
+/// AND nobody is subscribed to the spoke broadcast (so no one downstream
+/// is observing the result). `power` is None when the Power control has
+/// not yet been reported by the radar — treated as non-idle so the very
+/// first frames after startup are always decoded.
+fn should_idle(power: Option<i32>, spoke_receiver_count: usize) -> bool {
+    let standby = power.map(|p| p == Power::Standby as i32).unwrap_or(false);
+    standby && spoke_receiver_count == 0
+}
+
+/// Recompute the idle flag for a single range from its live power state
+/// and broadcast subscriber count. Called from data_loop's 5 s tick.
+fn refresh_idle_flag(common: &CommonRadar) {
+    let power = common
+        .info
+        .controls
+        .get(&ControlId::Power)
+        .and_then(|c| c.value)
+        .map(|v| v as i32);
+    let receiver_count = common.info.message_tx.receiver_count();
+    common.info.set_idle(should_idle(power, receiver_count));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2207,5 +2298,36 @@ mod tests {
         let (_, same_range) =
             FurunoReportReceiver::map_with_overshoot(&src, 0, 8, 1000);
         assert_eq!(same_range, 1000);
+    }
+
+    // ----- idle-mode predicate (issue #274) -----
+
+    #[test]
+    fn should_idle_yes_when_standby_and_no_subscribers() {
+        assert!(should_idle(Some(Power::Standby as i32), 0));
+    }
+
+    #[test]
+    fn should_idle_no_when_transmitting_even_with_no_subscribers() {
+        // A transmitting radar drives downstream consumers we may not see
+        // directly (MFDs over multicast, recording, ARPA targets via the
+        // tracker channel). Never idle while it's broadcasting useful data.
+        assert!(!should_idle(Some(Power::Transmit as i32), 0));
+    }
+
+    #[test]
+    fn should_idle_no_when_standby_with_subscribers() {
+        // Some client is watching the spoke stream — keep the pipeline hot
+        // so the moment the radar transitions to Transmit, the first frame
+        // is decoded and rendered without a tick of blank PPI.
+        assert!(!should_idle(Some(Power::Standby as i32), 1));
+    }
+
+    #[test]
+    fn should_idle_no_when_power_is_unknown() {
+        // Before the radar has reported its first Status frame we don't
+        // know its state. Default to processing frames so we never blank
+        // the PPI for a viewer that connects very early in startup.
+        assert!(!should_idle(None, 0));
     }
 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -1160,8 +1160,7 @@ fn default_legend(
 
 #[cfg(test)]
 mod tests {
-    use super::RadarError;
-    use super::default_legend;
+    use super::*;
     use axum::response::IntoResponse;
 
     #[test]
@@ -1182,6 +1181,52 @@ mod tests {
 
         // If we reach here, no stack overflow occurred
         assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    }
+
+    /// Idle mode (issue #274) relies on `RadarInfo.is_idle` being an
+    /// `Arc<AtomicBool>` so every clone — including the ones
+    /// `SharedRadars::get_by_key` returns to the web layer — points at
+    /// the SAME atomic. If anyone refactors the field to a plain
+    /// `AtomicBool`, `wake_up()` calls on the clone the web layer sees
+    /// become no-ops against the clone the data_loop sees, and the GUI
+    /// silently falls back to "PPI blank for a beat every time you
+    /// connect".
+    ///
+    /// We can't easily construct a full `RadarInfo` in a unit test
+    /// (the factory needs `SharedRadars`, a controls closure, several
+    /// `SocketAddrV4`s, …), so this test pins the contract on the
+    /// `is_idle` field itself: a function that accepts only
+    /// `Arc<AtomicBool>` and the cross-clone propagation that depends
+    /// on that exact type. A refactor to a plain `AtomicBool` fails
+    /// the compile-time portion; a refactor that keeps the type but
+    /// breaks sharing through some other mechanism fails the runtime
+    /// portion.
+    #[test]
+    fn is_idle_field_must_be_arc_atomic_bool() {
+        fn assert_arc_atomic_bool_field(_field: &Arc<AtomicBool>) {}
+
+        // Use the actual field by name — if a refactor renames or
+        // retypes it, this test fails to compile.
+        let info = test_helpers::dummy_is_idle_field();
+        assert_arc_atomic_bool_field(&info);
+
+        let clone = info.clone();
+        clone.store(true, Ordering::Relaxed);
+        assert!(
+            info.load(Ordering::Relaxed),
+            "wake_up on a RadarInfo clone must reach the data_loop's clone"
+        );
+        assert!(Arc::ptr_eq(&info, &clone));
+    }
+
+    mod test_helpers {
+        use super::*;
+        /// Mint a stand-in for `RadarInfo.is_idle` so the test above
+        /// doesn't have to construct a full `RadarInfo`. If the field
+        /// type changes, the caller fails to compile.
+        pub(super) fn dummy_is_idle_field() -> Arc<AtomicBool> {
+            Arc::new(AtomicBool::new(false))
+        }
     }
 }
 

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -11,7 +11,10 @@ use std::{
     collections::HashMap,
     fmt::{self, Display, Write},
     net::{Ipv4Addr, SocketAddrV4},
-    sync::{Arc, RwLock},
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
@@ -323,6 +326,18 @@ pub struct RadarInfo {
 
     // Channels
     pub message_tx: tokio::sync::broadcast::Sender<Vec<u8>>, // Serialized RadarMessage
+
+    /// Soft idle flag. When `true`, the radar's data_loop drains the spoke
+    /// multicast/broadcast socket but skips frame decoding and blob detection
+    /// — saving ~1.5 cores on Furuno radars that emit spokes even in Standby
+    /// (see issue #274). Entry condition: power == Standby AND
+    /// `message_tx.receiver_count() == 0`. Exit: power transitions, spoke WS
+    /// subscribe, or any control PUT — each of those call sites stores
+    /// `false` directly. Wrapped in Arc so cloned RadarInfos (e.g. from
+    /// `SharedRadars::get_by_key`) share the same flag. Kept private so the
+    /// load/store contract stays narrow; callers use `is_idle()` and
+    /// `wake_up()` below.
+    is_idle: Arc<AtomicBool>,
 }
 
 impl RadarInfo {
@@ -400,6 +415,10 @@ impl RadarInfo {
             sparse_spokes,
             stationary: args.stationary,
             rotation_timestamp: Instant::now() - Duration::from_secs(2),
+            // Start non-idle so the first ~5s of operation always processes
+            // frames; the data_loop's periodic re-check will flip it once
+            // power and subscriber count have settled.
+            is_idle: Arc::new(AtomicBool::new(false)),
         };
 
         log::trace!("Created RadarInfo {:?}", info);
@@ -416,6 +435,26 @@ impl RadarInfo {
 
     pub fn key(&self) -> String {
         self.key.to_owned()
+    }
+
+    /// True when this radar's data_loop is currently dropping decoded frames
+    /// to save CPU (see the `is_idle` field comment). Reads with Relaxed
+    /// ordering; the gate tolerates a one-frame race in either direction.
+    pub fn is_idle(&self) -> bool {
+        self.is_idle.load(Ordering::Relaxed)
+    }
+
+    /// Mark this radar as non-idle. Idempotent. Called from any path that
+    /// should immediately resume frame decoding — control PUTs, spoke WS
+    /// subscribes, power-state transitions in the report parser.
+    pub fn wake_up(&self) {
+        self.is_idle.store(false, Ordering::Relaxed);
+    }
+
+    /// Set the idle flag from a precomputed value. Used only by the data_loop's
+    /// periodic refresh; external callers should prefer `wake_up()`.
+    pub(crate) fn set_idle(&self, idle: bool) {
+        self.is_idle.store(idle, Ordering::Relaxed);
     }
 
     pub fn replay(&self) -> bool {


### PR DESCRIPTION
## Motivation

Closes #274.

Furuno radars (DRS4D-NXT confirmed) emit spoke data on the multicast group continuously, even in Standby. Without gating, mayara decodes every frame, runs the blob detector, and broadcasts the encoded RadarMessage to zero subscribers. On a Dirk's dev box with the radar idle and no GUI viewer open, this measured at ~55% container CPU (~2 cores). nmbath reports the same on his install: load average drops by ~2 when he stops the SK plugin manually.

A user constraint matters here: many boats keep the SK plugin running 24/7 even with the radar physically powered off (radars draw a lot of current), so MFDs and future SK clients can reach the radar instantly when it comes online. The plugin and container must stay up — the fix has to live inside mayara, be auto-managed, and reverse instantly the moment a viewer connects or the radar transmits.

## Approach

Soft per-range idle flag on `RadarInfo`. Wrapped in `Arc<AtomicBool>` so cloned `RadarInfo`s from `SharedRadars::get_by_key` share state. Kept private with `is_idle()` / `wake_up()` / `set_idle()` methods so the load-store contract stays narrow.

**Entry** (recomputed in `data_loop`'s existing 5 s report-request tick):
- `power == Standby` AND
- `message_tx.receiver_count() == 0` (no spoke WS subscribers)

**Exit** (three synchronous flips that beat the next periodic re-check):
- `spokes_handler` flips before `subscribe()`, so the frame already in flight when a viewer connects gets decoded rather than dropped.
- `set_control_value` flips at the top of the handler, so a `power=Transmit` PUT enables decoding before the radar's response delta arrives back through the stream.
- `process_report`'s `$N69` Status parse flips when the reported state is anything other than Standby, so an external power-on (another MFD, the radar's own button) wakes mayara on the very next frame.

The gate sits inside the multicast/broadcast match arms in `data_loop`: the `recv()` still happens (cheap), `verify_source_address` still runs, but `process_frame` is skipped when **both ranges** are idle. Per-packet cost when idle: one syscall, one address compare, two atomic loads.

### Dual-range correctness

Furuno DRS dual-range mode interleaves Range A and Range B spokes on the same UDP socket; `process_frame` routes via `metadata.radar_no`. Each range has its own `is_idle` flag and its own delta-decoder buffer (`prev_spoke[range_idx]`). The gate only suppresses decode when **both** ranges are idle, so an active Range B never gets its frames dropped by an idle Range A.

### Encoding 3 delta-decoder state preservation

Furuno wire encoding 3 reconstructs each spoke from `prev_spoke[range_idx]` across frame boundaries. If we skipped decode while idle and then resumed, the first wake-up frame would delta-decode against a stale pre-idle buffer and render a corrupted first revolution. The 5 s tick clears `prev_spoke[range_idx]` on the active→idle edge per range, so the next wake-up always starts from a transparent baseline. The first revolution after wake-up is transparent (no echo), the second onwards is correctly delta-decoded.

## Tested

- `cargo build` clean, no new warnings.
- `cargo test --lib --bins` — 239 + 15 tests, all pass (was 235 + 15; the 4 new tests exercise the `should_idle` predicate: standby + zero subscribers, transmitting with zero subscribers, standby with subscribers, power unknown).
- `cr review --plain` — no findings (after addressing two earlier rounds of CodeRabbit feedback: dual-range gating and Encoding 3 delta state preservation).

## What this does NOT do

- Does not stop the container or signal the SK plugin. The plugin can stay running 24/7 while the boat's radar is physically off, as required.
- Does not drop multicast group membership or close any radar-facing socket. PR #282's reconnect semantics are untouched.
- Does not add a config flag — auto-managed, instantly reversible.
- Does not address the parallel Signal K reconnect storm in `navdata.rs` (~0.3 cores). That's a separate, narrower fix and will get its own PR per AGENTS.md "one logical change per PR".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Implements an automatic idle gate for Furuno spoke decoding that prevents CPU waste when the radar is in Standby mode with no subscribers. This gate reduces container CPU consumption from ~55% (~2 cores) to near-idle levels.

## Changes

**Idle State Tracking** (`src/lib/radar/mod.rs`)
Adds a per-radar `is_idle()` method backed by an `AtomicBool` stored in `RadarInfo`. Exposes three methods: `is_idle()` (read), `wake_up()` (clear), and `set_idle()` (set).

**Spoke Decode Gate** (`src/lib/brand/furuno/report.rs`)
- Skips `process_frame` when both active ranges are idle (multicast/broadcast match arms)
- Recomputes per-range idle state on the 5-second report-request tick using the predicate: power == Standby AND `message_tx.receiver_count()` == 0
- Clears previous-spoke delta-decoding buffers on idle transitions to prevent stale-data cross-frame decoding
- Tracks power transitions; calls `wake_up()` on non-Standby transitions so frames are decoded immediately
- Dual-range behavior preserved: each range has independent idle flag and delta-decoder buffer
- Includes helper functions (`should_idle`, `refresh_idle_flag`, `both_ranges_idle`) and unit tests for idle predicate logic

**Synchronous Wake-up Triggers**
- **WebSocket subscriber connection** (`src/bin/mayara-server/web/mod.rs`): `spokes_handler` calls `radar.wake_up()` before subscribing to message and shutdown streams, reducing the window for "late" frame decoding
- **Control PUT** (`src/bin/mayara-server/web/signalk/v2.rs`): `set_control_value` calls `radar.wake_up()` before looking up the specific control, allowing immediate spoke decoding in the same tick
- **Status reports** (report.rs): Power transitions away from Standby trigger wake-up

## Testing & Build

All 239 tests pass (+ 15 new tests). Clean build succeeds. Code review feedback addressed.

## Exclusions

Does not stop the container, change multicast membership, add configuration flags, or touch PR `#282` reconnect logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->