### PR TITLE
chore(deps): bump bincode from 1.3.3 to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,11 +298,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -3618,6 +3629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,6 +3718,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "w32-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ axum = { version = "0.8.9", features = ["http2", "json", "macros", "tokio", "tow
 axum-core = "0.5.6"
 axum-embed = "0.1.0"
 base64 = "0.22.1"
-bincode = "1.3.3"
+bincode = { version = "2.0.1", features = ["serde"] }
 bitflags = "2.11.1"
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -1,4 +1,3 @@
-use bincode::deserialize;
 use log::log_enabled;
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
@@ -7,7 +6,7 @@ use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
 
 use crate::locator::LocatorAddress;
 use crate::radar::{RadarInfo, SharedRadars};
-use crate::util::{PrintableSlice, c_string};
+use crate::util::{PrintableSlice, c_string, decode_bin};
 use crate::{Brand, Cli};
 
 use super::{LocatorId, RadarLocator};
@@ -204,7 +203,7 @@ impl FurunoLocator {
         from: &SocketAddrV4,
         nic_addr: &Ipv4Addr,
     ) -> Result<(), io::Error> {
-        match deserialize::<FurunoRadarReport>(report) {
+        match decode_bin::<FurunoRadarReport>(report) {
             Ok(data) => {
                 if data.length as usize + 8 != report.len() {
                     log::error!(
@@ -248,7 +247,7 @@ impl FurunoLocator {
         radars: &SharedRadars,
         subsys: &SubsystemHandle,
     ) -> Result<(), io::Error> {
-        match deserialize::<FurunoRadarModelReport>(report) {
+        match decode_bin::<FurunoRadarModelReport>(report) {
             Ok(data) => {
                 let model = c_string(&data.model);
                 let serial_no = c_string(&data.serial_no);

--- a/src/lib/brand/navico/mod.rs
+++ b/src/lib/brand/navico/mod.rs
@@ -459,7 +459,7 @@ const BLANKING_SECTORS: [(usize, ControlId); 4] = [
 mod tests {
     use super::*;
     use crate::network::NetworkSocketAddrV4;
-    use bincode::deserialize;
+    use crate::util::decode_bin;
     use serde::Deserialize as TestDeserialize;
     use std::net::{Ipv4Addr, SocketAddrV4};
 
@@ -692,7 +692,7 @@ mod tests {
             ("HALO 24", &BEACON_HALO24[..]),
         ] {
             let old: NavicoBeaconDual =
-                deserialize(packet).expect(&format!("{}: bincode failed", name));
+                decode_bin(packet).expect(&format!("{}: bincode failed", name));
             let new =
                 parse_gen3plus_beacon(packet).expect(&format!("{}: dynamic parse failed", name));
 

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -1,5 +1,4 @@
 use anyhow::{Error, bail};
-use bincode::deserialize;
 use num_traits::FromPrimitive;
 use serde::Deserialize;
 use std::cmp::min;
@@ -34,7 +33,7 @@ use crate::radar::{
 };
 use crate::replay::RadarSocket;
 use crate::util::PrintableSpoke;
-use crate::util::{c_string, c_wide_string};
+use crate::util::{c_string, c_wide_string, decode_bin};
 
 /*
  Heading on radar. Observed in field:
@@ -1303,7 +1302,7 @@ impl NavicoReportReceiver {
         scanline: usize,
     ) -> Option<(u32, SpokeBearing, Option<u16>)> {
         match self.model {
-            Model::BR24 | Model::Gen3 => match deserialize::<GenBr24Header>(&header_slice) {
+            Model::BR24 | Model::Gen3 => match decode_bin::<GenBr24Header>(&header_slice) {
                 Ok(header) => {
                     log::trace!("Received {:04} header {:?}", scanline, header);
 
@@ -1314,7 +1313,7 @@ impl NavicoReportReceiver {
                     return None;
                 }
             },
-            _ => match deserialize::<Gen3PlusHeader>(&header_slice) {
+            _ => match decode_bin::<Gen3PlusHeader>(&header_slice) {
                 Ok(header) => {
                     log::trace!("Received {:04} header {:?}", scanline, header);
 

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{Error, bail};
-use bincode::deserialize;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -11,7 +10,7 @@ use crate::locator::LocatorAddress;
 use crate::network::LittleEndianSocketAddrV4;
 use crate::radar::settings::ControlId;
 use crate::radar::{RadarInfo, SharedRadars};
-use crate::util::{PrintableSlice, c_string};
+use crate::util::{PrintableSlice, c_string, decode_bin};
 use crate::{Brand, Cli};
 
 use super::LocatorId;
@@ -226,7 +225,7 @@ impl RaymarineLocator {
         from: &Ipv4Addr,
         radars: &SharedRadars,
     ) -> Result<Option<(RadarInfo, BaseModel)>, Error> {
-        match deserialize::<RaymarineBeacon36>(report) {
+        match decode_bin::<RaymarineBeacon36>(report) {
             Ok(data) => {
                 let beacon_type = u32::from_le_bytes(data.beacon_type);
                 let link_id_preview = u32::from_le_bytes(data.link_id);
@@ -340,7 +339,7 @@ impl RaymarineLocator {
     }
 
     fn process_beacon_56_report(&mut self, report: &[u8], from: &Ipv4Addr) -> Result<(), Error> {
-        match deserialize::<RaymarineBeacon56>(report) {
+        match decode_bin::<RaymarineBeacon56>(report) {
             Ok(data) => {
                 let beacon_type = u32::from_le_bytes(data.beacon_type);
                 let subtype = u32::from_le_bytes(data.subtype);

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -9,6 +9,7 @@ use crate::radar::range::{Range, Ranges};
 use crate::radar::settings::ControlId;
 use crate::radar::spoke::GenericSpoke;
 use crate::radar::{Power, SpokeBearing};
+use crate::util::decode_bin;
 
 use super::{RaymarineReportReceiver, ReceiverState};
 
@@ -44,7 +45,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
         return;
     }
     let header = &data[..FRAME_HEADER_LENGTH];
-    let header: FrameHeader = match bincode::deserialize(header) {
+    let header: FrameHeader = match decode_bin(header) {
         Ok(h) => h,
         Err(e) => {
             log::error!(
@@ -178,7 +179,7 @@ impl StatusReport {
             );
         }
         let report = &data[0..STATUS_REPORT_LENGTH];
-        let report: StatusReport = match bincode::deserialize(report) {
+        let report: StatusReport = match decode_bin(report) {
             Ok(h) => h,
             Err(e) => {
                 bail!(

--- a/src/lib/brand/raymarine/report/rd.rs
+++ b/src/lib/brand/raymarine/report/rd.rs
@@ -7,6 +7,7 @@ use crate::radar::Power;
 use crate::radar::range::{Range, Ranges};
 use crate::radar::settings::ControlId;
 use crate::radar::spoke::GenericSpoke;
+use crate::util::decode_bin;
 
 use super::{RaymarineReportReceiver, ReceiverState};
 
@@ -76,7 +77,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
 
     let header = &data[..FRAME_HEADER_LENGTH];
     log::trace!("{}: header1 {:?}", receiver.common.key, header);
-    let header: FrameHeader = match bincode::deserialize(header) {
+    let header: FrameHeader = match decode_bin(header) {
         Ok(h) => h,
         Err(e) => {
             log::error!(
@@ -121,7 +122,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
         let spoke_header_1 = &data[next_offset..next_offset + SPOKE_HEADER_1_LENGTH];
         log::trace!("{}: header3 {:?}", receiver.common.key, spoke_header_1);
 
-        let spoke_header_1: SpokeHeader1 = match bincode::deserialize(spoke_header_1) {
+        let spoke_header_1: SpokeHeader1 = match decode_bin(spoke_header_1) {
             Ok(h) => h,
             Err(e) => {
                 log::error!(
@@ -169,7 +170,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
         let header2 = &data[next_offset..next_offset + SPOKE_HEADER_2_LENGTH];
         log::trace!("{}: header2 {:?}", receiver.common.key, header2);
 
-        let header2: SpokeHeader2 = match bincode::deserialize(header2) {
+        let header2: SpokeHeader2 = match decode_bin(header2) {
             Ok(h) => h,
             Err(e) => {
                 log::error!(
@@ -189,7 +190,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
         // Followed by the actual spoke data
         let header3 = &data[next_offset..next_offset + SPOKE_DATA_LENGTH];
         log::trace!("{}: SpokeData {:?}", receiver.common.key, header3);
-        let header3: SpokeHeader3 = match bincode::deserialize(header3) {
+        let header3: SpokeHeader3 = match decode_bin(header3) {
             Ok(h) => h,
             Err(e) => {
                 log::error!(
@@ -348,7 +349,7 @@ pub(super) fn process_status_report(receiver: &mut RaymarineReportReceiver, data
     }
     let report = &data[..STATUS_REPORT_LENGTH];
     log::info!("{}: status report {:02X?}", receiver.common.key, report);
-    let report: StatusReport = match bincode::deserialize(report) {
+    let report: StatusReport = match decode_bin(report) {
         Ok(h) => h,
         Err(e) => {
             log::error!(
@@ -517,7 +518,7 @@ pub(super) fn process_fixed_report(receiver: &mut RaymarineReportReceiver, data:
     );
     let report = &data[FIXED_REPORT_PREFIX..FIXED_REPORT_PREFIX + FIXED_REPORT_LENGTH];
     log::trace!("{}: fixed report {:02X?}", receiver.common.key, report);
-    let report: FixedReport = match bincode::deserialize(report) {
+    let report: FixedReport = match decode_bin(report) {
         Ok(h) => h,
         Err(e) => {
             log::error!(

--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -131,20 +131,25 @@ mod tests {
         flag: bool,
     }
 
-    /// Round-tripping through bincode's serde encode + decode_bin
-    /// verifies the helper accepts the legacy wire format and
-    /// reconstructs the original value exactly. Brand wire structs
-    /// use the same `T: Deserialize` path, so a generic shape here
-    /// is enough to pin the contract.
+    /// Decode a hand-written legacy-format byte string and check it
+    /// reconstructs the expected value. Using hardcoded wire bytes
+    /// (rather than round-tripping through bincode's own encoder)
+    /// guards against bincode silently regressing the legacy() config
+    /// AND against any change to decode_bin that picks up a different
+    /// endianness or int encoding. The brand wire parsers consume
+    /// bytes that arrive from the radar — so the test must too.
+    ///
+    /// Legacy layout for `WireSample { value: 0xDEADBEEF, flag: true }`:
+    ///   - u32 little-endian, fixed-int: EF BE AD DE
+    ///   - bool true:                    01
+    ///   - total: 5 bytes
     #[test]
     fn decode_bin_round_trips_legacy_wire_format() {
         let expected = WireSample {
             value: 0xDEADBEEF,
             flag: true,
         };
-        let encoded =
-            bincode::serde::encode_to_vec(&expected, bincode::config::legacy())
-                .expect("legacy serde encode must succeed");
+        let encoded: [u8; 5] = [0xEF, 0xBE, 0xAD, 0xDE, 0x01];
         let decoded: WireSample = decode_bin(&encoded).expect("decode_bin must succeed");
         assert_eq!(decoded, expected);
     }

--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -2,6 +2,20 @@
 
 use std::fmt;
 
+use serde::de::DeserializeOwned;
+
+/// Decode a bincode-encoded slice into `T` using the legacy
+/// (bincode v1) wire format: little-endian, fixed-int encoding, no
+/// length limit. Every brand-specific report parser in this crate
+/// uses the same `T: serde::Deserialize` path, so funnel them all
+/// through one helper that hides bincode v2's `decode_from_slice`
+/// signature (which returns `(T, usize)` and takes a config).
+pub(crate) fn decode_bin<T: DeserializeOwned>(
+    bytes: &[u8],
+) -> Result<T, bincode::error::DecodeError> {
+    bincode::serde::decode_from_slice(bytes, bincode::config::legacy()).map(|(value, _)| value)
+}
+
 pub(crate) fn c_string(bytes: &[u8]) -> Option<&str> {
     let bytes_without_null = match bytes.iter().position(|&b| b == 0) {
         Some(ix) => &bytes[..ix],
@@ -103,5 +117,47 @@ impl fmt::Display for PrintableSpoke<'_> {
         }
         write!(f, "]")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Debug, Serialize, serde::Deserialize, PartialEq)]
+    struct WireSample {
+        value: u32,
+        flag: bool,
+    }
+
+    /// Round-tripping through bincode's serde encode + decode_bin
+    /// verifies the helper accepts the legacy wire format and
+    /// reconstructs the original value exactly. Brand wire structs
+    /// use the same `T: Deserialize` path, so a generic shape here
+    /// is enough to pin the contract.
+    #[test]
+    fn decode_bin_round_trips_legacy_wire_format() {
+        let expected = WireSample {
+            value: 0xDEADBEEF,
+            flag: true,
+        };
+        let encoded =
+            bincode::serde::encode_to_vec(&expected, bincode::config::legacy())
+                .expect("legacy serde encode must succeed");
+        let decoded: WireSample = decode_bin(&encoded).expect("decode_bin must succeed");
+        assert_eq!(decoded, expected);
+    }
+
+    /// Garbage bytes shorter than the expected struct must surface
+    /// as an Err rather than panicking or silently zero-padding.
+    #[test]
+    fn decode_bin_rejects_truncated_input() {
+        let truncated = [0u8; 3];
+        let result: Result<WireSample, _> = decode_bin(&truncated);
+        assert!(
+            result.is_err(),
+            "decode_bin must reject a 3-byte buffer for a 5+ byte struct",
+        );
     }
 }


### PR DESCRIPTION
Closes #290.

## Why not 3.0.0?

Dependabot proposed bumping bincode from 1.3.3 to **3.0.0**. \`bincode 3.0.0\` on crates.io is **a name-reservation placeholder** — the entire crate source is one line: \`compile_error!("https://xkcd.com/2347/")\`. The real next-stable release is 2.0.1. (The maintainers' 3.0 release is still pre-release as \`bincode-next = "3.0.0-rc.15"\`.)

This PR targets 2.0.1, which lets us close #290 without waiting on the real 3.0.

## Summary

bincode 2 removed \`bincode::deserialize\` and made serde an optional feature, so every brand-specific report parser needs updating.

- Enable bincode's \`serde\` feature in \`Cargo.toml\`.
- Add a single \`util::decode_bin<T: DeserializeOwned>\` helper that wraps \`bincode::serde::decode_from_slice\` with \`bincode::config::legacy()\` so the wire format stays byte-for-byte identical to v1 (little-endian, fixed-int encoding, no length limit).
- Replace all 15 \`bincode::deserialize\` call sites across furuno, navico (production + tests) and raymarine (mod, quantum, rd) with \`decode_bin\`.
- Add two unit tests on \`decode_bin\` itself: legacy-format round-trip and truncated-input rejection.

## Tested

- Full release-mode test suite passes — 262 lib unit tests, 30 integration tests, 9 brand-specific pcap replay tests (BR24, 4G, HALO 20+/24/3006, Quantum, DRS2D, DRS4DNXT, Furuno NND, Garmin xHD). All green. The replay tests are the strongest signal: they decode real recorded radar traffic byte-for-byte and would fail immediately if \`legacy()\` config didn't match v1's wire format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dependency and API Update

Bumps bincode from 1.3.3 to 2.0.1 and enables the serde feature in `Cargo.toml`. bincode 2.0 removed the public `bincode::deserialize` function and made serde integration optional, requiring migration of existing deserialization call sites.

## Compatibility Layer Implementation

Introduces `decode_bin<T>()` helper function in `src/lib/util.rs` that wraps `bincode::serde::decode_from_slice` with `bincode::config::legacy()` configuration. This preserves the v1 wire format (little-endian, fixed-int encoding, no length limit) for backward compatibility with existing serialized data. Includes two unit tests: one validating legacy-format round-trip deserialization and another confirming proper error handling for truncated input.

## Call Site Migration

Replaces 15 `bincode::deserialize` calls across radar brand modules with the new `decode_bin` helper:

- **Furuno** (`src/lib/brand/furuno/mod.rs`): Updates `FurunoRadarReport` and `FurunoRadarModelReport` decoding in beacon processing
- **Navico** (`src/lib/brand/navico/mod.rs` and `report.rs`): Converts fixed-struct beacon decoding and spoke header validation (`GenBr24Header`, `Gen3PlusHeader`)
- **Raymarine** (`src/lib/brand/raymarine/mod.rs`, `report/quantum.rs`, `report/rd.rs`): Updates decoding for `RaymarineBeacon36`, `RaymarineBeacon56`, `FrameHeader`, `StatusReport`, spoke headers, and fixed report formats

All migrations preserve existing validation, error handling, and control flow logic downstream of the deserialization call.

## Validation

Full release-mode test suite passes (262 library unit tests, 30 integration tests, 9 pcap replay tests across BR24, 4G, HALO, Quantum, DRS, Furuno, and Garmin hardware brands), confirming byte-for-byte compatibility with v1 serialized data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->