### PR TITLE
fix(gui): plot AIS using radar heading when SignalK true heading absent

### DIFF
--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -301,6 +301,17 @@ class PPI {
     return this.trueHeading;
   }
 
+  // Heading in radians for overlay placement, preferring the Signal K
+  // true heading and falling back to the radar-derived heading
+  // (`lastHeading`, stored in degrees). Mirrors the source preference the
+  // radar image already uses so AIS plots whenever the sweep can rotate.
+  // Returns null when no heading source is available.
+  #effectiveHeadingRad() {
+    if (this.trueHeading !== null) return this.trueHeading;
+    if (this.lastHeading !== null) return (this.lastHeading * Math.PI) / 180;
+    return null;
+  }
+
   getHeadingMode() {
     return this.headingMode;
   }
@@ -1327,8 +1338,12 @@ class PPI {
 
   #drawAisVessel(ctx, mmsi, vessel, pixelsPerMeter) {
     if (!vessel.position) return;
-    // Don't draw vessels until we have heading data
-    if (this.trueHeading === null) return;
+    // Don't draw vessels until we have a heading reference. Accept the
+    // radar-derived heading too, not just the Signal K true heading —
+    // otherwise AIS never plots in head-up mode without a SignalK
+    // heading subscription, even though the sweep rotates fine.
+    const heading = this.#effectiveHeadingRad();
+    if (heading === null) return;
 
     // Calculate screen position from lat/lon
     // We need own-ship position to calculate relative position
@@ -1373,8 +1388,7 @@ class PPI {
     // Don't draw if outside display range
     if (pixelDist > this.beam_length * 1.5) return;
 
-    // Apply heading rotation for display mode
-    const heading = this.trueHeading;
+    // Apply heading rotation for display mode (heading resolved above)
     const adjustedBearing = bearingRad - heading + this.headingRotation;
 
     // Convert polar to cartesian (bearing is clockwise from north)


### PR DESCRIPTION
## Motivation

The AIS overlay only drew vessels when `this.trueHeading` (the SignalK true-heading subscription) was set. But the radar image already rotates fine on `this.lastHeading` (radar-derived heading). Behind a SignalK proxy the viewer commonly runs without a heading subscription, so `trueHeading` stays `null` and **every AIS vessel was silently skipped** — even with the sweep rotating and own-ship position known. Symptom: AIS vessels load (`aisVessels.size > 0`, `showAis: true`, own-ship set) but none render.

## Approach

Resolve an effective heading (radians) that prefers `trueHeading` and falls back to `lastHeading` (degrees → radians) — the same source preference the radar image uses — and gate/rotate the AIS draw on that. Vessels now plot whenever the display has any heading reference.

## Tested

- `cargo build --release` and `cargo test` pass (15 AIS-store/subscription tests green; change is GUI JS).
- Verified the new gate against a real failing session (`trueHeading: null`, `lastHeading: -46.43°`, own-ship set, 45 vessels): previously skipped, now draws. SignalK-heading-present and no-own-ship cases unchanged; the genuine no-heading case still skips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a private helper method `#effectiveHeadingRad()` that returns an overlay heading in radians by preferring the Signal K true heading and falling back to the radar-derived heading (converting from degrees to radians), or returns null when neither is available. This method mirrors the source preference the radar image already uses for rotation.

Updates AIS vessel rendering in `#drawAisVessel()` to use this effective heading instead of requiring the true heading to be present. Replaces the check `if (this.trueHeading === null) return;` with a call to `#effectiveHeadingRad()`, allowing AIS vessels to render whenever any heading reference is available. This resolves the case where a viewer runs behind a Signal K proxy without a heading subscription—the sweep rotates fine on radar-derived heading, but AIS vessels were previously hidden entirely despite having position and vessel data available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->