### PR TITLE
feat(gui): gray out AIS toggle when no heading source is available

### DIFF
--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -411,6 +411,17 @@ div.myr_ppi {
   stroke: #666;
 }
 
+/* No heading reference: AIS can't be placed, so the toggle is inert. */
+.myr_ais_lozenge.myr_ais_disabled {
+  opacity: 0.5;
+  border-color: #666666;
+}
+
+.myr_ais_lozenge.myr_ais_disabled .myr_ais_lozenge_button {
+  cursor: not-allowed;
+  background: rgba(50, 50, 50, 0.6);
+}
+
 /* ============================================
    VRM/EBL Lozenge - VRM/EBL marker toggle (bottom-left, above AIS)
    ============================================ */

--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -312,6 +312,13 @@ class PPI {
     return null;
   }
 
+  // True when any heading reference is available — the SignalK true
+  // heading or the radar-derived heading. AIS placement needs one of
+  // these; the UI grays the AIS toggle when neither is present.
+  hasHeading() {
+    return this.trueHeading !== null || this.lastHeading !== null;
+  }
+
   getHeadingMode() {
     return this.headingMode;
   }

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -843,6 +843,7 @@ function onHeadingReceived() {
     toggleBtn.classList.remove("myr_heading_disabled");
     toggleBtn.title = "Click to toggle: Heading Up / North Up";
   }
+  updateAisLozenge();
 }
 
 // Called when the heading WebSocket closes — true loss of source.
@@ -864,6 +865,7 @@ function onHeadingLost() {
     toggleBtn.innerHTML = "H Up";
     toggleBtn.title = "Heading data required for North Up mode";
   }
+  updateAisLozenge();
 }
 
 // Create the power lozenge on the viewer
@@ -1004,9 +1006,13 @@ function createAisLozenge() {
   if (ppi) {
     ppi.setShowAis(showAis);
   }
+  updateAisLozenge();
 }
 
 function toggleAisOverlay() {
+  // Inert while no heading reference is available — vessels can't be
+  // placed, so toggling on would show nothing.
+  if (ppi && !ppi.hasHeading()) return;
   showAis = !showAis;
   try {
     localStorage.setItem("mayaraShowAis", String(showAis));
@@ -1029,6 +1035,12 @@ function updateAisLozenge() {
   if (!lozenge) return;
   lozenge.classList.remove("myr_ais_on", "myr_ais_off");
   lozenge.classList.add(showAis ? "myr_ais_on" : "myr_ais_off");
+
+  const noHeading = ppi ? !ppi.hasHeading() : false;
+  lozenge.classList.toggle("myr_ais_disabled", noHeading);
+  lozenge.title = noHeading
+    ? "AIS unavailable — no heading source to position targets"
+    : "Click to toggle AIS overlay";
 }
 
 // VRM/EBL lozenge - cycles through marker visibility states. Click steps


### PR DESCRIPTION
## Motivation

AIS targets can't be placed on the PPI without a heading reference. When no heading is available, the AIS toggle still looked active but turning it on showed nothing — appearing broken. This makes the unavailable state explicit.

## Approach

Add a `ppi.hasHeading()` predicate (true when either the SignalK true heading or the radar-derived heading is present). When neither is available, dim the AIS lozenge, set a `not-allowed` cursor and an explanatory tooltip, and ignore clicks. The state is re-evaluated as heading availability changes (heading received/lost, initial load, toggle).

Companion to #296 (which makes AIS plot from the radar heading): with both, the toggle is only grayed when there is genuinely no heading at all — not merely when the SignalK true-heading subscription is absent.

## Tested

- `cargo build --release` and `cargo test` pass (GUI-only change).
- Verified the lozenge state in a real DOM across three cases: no heading → disabled + tooltip; radar `lastHeading` only → enabled; SignalK true heading → enabled.

## Note

Heading availability is re-checked on heading received/lost, initial load, and toggle interaction. A radar-only heading appearing mid-session with no SignalK heading event un-grays on the next heading event or interaction rather than instantly.