### PR TITLE
perf(logging): drop env_logger regex feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ clap-verbosity-flag = "3.0.4"
 crossbeam = "0.8.4"
 directories = "6.0.0"
 enum-primitive-derive = "0.3.0"
-env_logger = "0.11.10"
+env_logger = { version = "0.11", default-features = false, features = ["humantime", "auto-color"] }
 flate2 = { version = "1", optional = true }
 futures = "0.3.32"
 futures-util = "0.3.32"


### PR DESCRIPTION
## Summary

Switches `env_logger` to `default-features = false` with only `humantime` + `auto-color`.

**Trade-off**: loses regex-based `RUST_LOG` filter expressions (only exact module-path filters work). **Benefit**: eliminates the per-call regex match `env_logger` does on every `trace!`/`debug!` site, lowering CPU when many of those sites are filtered out at runtime — which is the common case in mayara's hot paths.

Also drops `regex` as a transitive dependency in `Cargo.lock`.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes