### PR TITLE
docs: fix incorrect GitHub URLs in ENDUSER and BUILDING

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -52,7 +52,7 @@ rustup update
 ### Clone the Repository
 
 ```bash
-git clone https://github.com/your-repo/mayara-server.git
+git clone https://github.com/MarineYachtRadar/mayara-server.git
 cd mayara-server
 ```
 

--- a/ENDUSER.md
+++ b/ENDUSER.md
@@ -25,7 +25,7 @@ A common setup is to run Mayara on a small wired device (like a Raspberry Pi) co
 
 ## Download
 
-Pre-built binaries are available on the [GitHub releases page](https://github.com/mayara-server/mayara-server/releases).
+Pre-built binaries are available on the [GitHub releases page](https://github.com/MarineYachtRadar/mayara-server/releases).
 
 Choose the right file for your platform:
 


### PR DESCRIPTION
## Summary

- `ENDUSER.md` linked the GitHub releases page under the wrong organisation (`mayara-server/mayara-server`)
- `BUILDING.md`'s `git clone` example still carried a `your-repo` placeholder

Both now point at `MarineYachtRadar/mayara-server`.

A wider audit of all 24 first-party markdown files turned up no other broken links — relative file paths and anchor fragments all resolve cleanly.