### PR TITLE
chore: drop stale mayara-gui references from Makefile header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 # Mayara Build System
 #
-# GUI is downloaded from npm (@marineyachtradar/mayara-gui) during build.
-# For GUI development, clone mayara-gui repo as sibling and use 'make dev'.
-#
 # Usage:
 #   make          - Build release with docs (recommended)
 #   make release  - Build release with docs


### PR DESCRIPTION
## Summary

The GUI lives in-tree under `web/gui/` and is compiled in via `rust-embed`. The two header comment lines in the Makefile that claimed the GUI is downloaded from npm (`@marineyachtradar/mayara-gui`) and that GUI development requires a sibling `mayara-gui` checkout were no longer true and were misleading new contributors.

Removed the two lines plus the now-redundant blank `#` spacer between them and the `# Usage:` block.