### PR TITLE
chore: remove broken dev and run-dev Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,12 @@
 #   make test     - Build and run tests
 #   make docs     - Generate rustdoc only
 #   make run      - Build and run server
-#   make run-dev  - Build and run dev server (live GUI reload)
 #   make mpi      - Build for linux and deploy and run on merrimac-pi
 #   make docker   - Build the Docker image
 #   make demo     - Rebuild the docker demo image
 #   make clean    - Clean build artifacts
 
-.PHONY: all release debug dev docs run run-dev clean test fixtures docker demo changelog
+.PHONY: all release debug docs run clean test fixtures docker demo changelog
 
 # Default: build release with embedded docs
 all: release
@@ -62,24 +61,10 @@ mpit:
 	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
 	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v -v --transmit --pass-ais
 
-# Build debug with dev feature (GUI served from filesystem, no embedding)
-# Useful for GUI development - just refresh browser after editing JS/HTML
-dev:
-	@echo "Building dev (no GUI embedding)..."
-	cargo build --features dev
-	@echo ""
-	@echo "Build complete: target/debug/mayara-server"
-	@echo "GUI served from mayara-gui/ directory (edit and refresh)"
-
 # Build and run the server
 run: release
 	@echo "Starting server..."
 	./target/release/mayara-server
-
-# Build and run dev server (live GUI reload)
-run-dev: dev
-	@echo "Starting dev server..."
-	./target/debug/mayara-server
 
 # Pcap fixture files used by replay integration tests
 FIXTURES = \


### PR DESCRIPTION
## Summary

The `dev` target ran `cargo build --features dev`, but no `dev` feature exists in `Cargo.toml` — invoking it errors out. The `run-dev` target depended on `dev` and was equally unusable. The `dev` target's echo message also referred to a `mayara-gui/` directory that no longer exists.

Live GUI reload is still available without a special target: `cargo run` (debug build) uses `rust-embed`'s `debug_assertions` path, which reads `web/` from the filesystem on each request.

This is a follow-up to #308, which dropped the stale `mayara-gui` references from the Makefile header but left the same misconception live in the target itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Removes the broken Makefile targets `dev` and `run-dev`. The `dev` target attempted to invoke `cargo build --features dev`, but the `dev` feature does not exist in Cargo.toml, making the target non-functional. The `run-dev` target depended on `dev` and was therefore also unusable. The `dev` target's echo message additionally referenced the removed `mayara-gui/` directory.

Updates the Makefile's usage comment block to document additional top-level commands and removes `dev` and `run-dev` from the `.PHONY` declarations.

Live GUI reload functionality remains available via `cargo run` (debug build), which uses rust-embed's `debug_assertions` path to read from the `web/` directory on each request.

This is a follow-up to `#308`, which previously removed stale `mayara-gui` references from the Makefile header but left the broken targets in place.

**Lines changed:** +1/-16

<!-- end of auto-generated comment: release notes by coderabbit.ai -->