### PR TITLE
fix(gui): show own-ship nav and heading UI without a heading subscription

### DIFF
--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -9,6 +9,17 @@ const RANGE_SCALE = 0.9;
 
 const NAUTICAL_MILE = 1852.0;
 
+// Exponential-smoothing factor for the radar-derived heading. The bearing
+// field on each spoke is quantized, so the per-spoke `bearing - angle` heading
+// wobbles by a fraction of a degree frame to frame even with a steady boat.
+// In head-up mode the AIS/ARPA overlay subtracts this heading to place
+// geographic targets bow-up (the spoke raster is drawn bow-up and does NOT
+// subtract it), so the wobble shows up as targets jumping. Smoothing the
+// heading on its unit vector (circular-mean safe across the 360->0 wrap) kills
+// the jitter while staying responsive: at typical spoke rates the time
+// constant is well under the timescale of a real turn.
+const HEADING_SMOOTH_ALPHA = 0.1;
+
 function divides_near(a, b) {
   let remainder = a % b;
   return remainder <= 1.0 || remainder >= b - 1;
@@ -101,6 +112,11 @@ class PPI {
     this.range = 0;
     this.spoke_range = 0;
     this.lastHeading = null;
+    // Smoothed unit vector of the radar-derived heading; null until the first
+    // spoke carries a bearing, so smoothing starts from a real value rather
+    // than pulling toward an arbitrary north.
+    this.headingSin = null;
+    this.headingCos = null;
     this.headingRotation = 0;
     this.headingMode = "headingUp";
     this.trueHeading = null;
@@ -679,9 +695,24 @@ class PPI {
       const heading =
         (spoke.bearing + this.spokesPerRevolution - spoke.angle) %
         this.spokesPerRevolution;
-      this.lastHeading = (heading * 360) / this.spokesPerRevolution;
+      const headingRad = (heading * 2 * Math.PI) / this.spokesPerRevolution;
+      const sin = Math.sin(headingRad);
+      const cos = Math.cos(headingRad);
+      if (this.headingSin === null) {
+        // First valid heading: seed the smoother so it converges from the
+        // real value, not from north.
+        this.headingSin = sin;
+        this.headingCos = cos;
+      } else {
+        this.headingSin += (sin - this.headingSin) * HEADING_SMOOTH_ALPHA;
+        this.headingCos += (cos - this.headingCos) * HEADING_SMOOTH_ALPHA;
+      }
+      const smoothed = Math.atan2(this.headingSin, this.headingCos);
+      this.lastHeading = ((smoothed * 180) / Math.PI + 360) % 360;
     } else {
       this.lastHeading = null;
+      this.headingSin = null;
+      this.headingCos = null;
     }
 
     // Don't draw spokes in standby mode

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -26,7 +26,6 @@ import {
   acquireTargetAtPosition,
 } from "./control.js";
 import {
-  isStandaloneMode,
   detectMode,
   fetchRadarIds,
   apiBase,
@@ -69,6 +68,7 @@ var renderMethod = "webgpu"; // "webgpu" or "webgl"
 // Heading mode: "headingUp" or "northUp"
 var headingMode = "headingUp";
 var trueHeading = 0; // in radians
+var haveSignalKHeading = false; // true once a navigation.headingTrue delta lands
 var lastLoggedHeading = null; // last heading value logged to console
 var lastHeadingTime = 0; // Timestamp of last heading update
 
@@ -269,13 +269,13 @@ window.onload = async function () {
   });
 };
 
-// Subscribe to navigation.headingTrue via SignalK WebSocket
+// Subscribe to own-ship navigation.headingTrue and navigation.position via the
+// mayara stream. This runs in every mode: mayara serves `vessels.self` nav from
+// its upstream Signal K source regardless of whether the GUI is reached
+// directly (mode "standalone") or behind the Signal K proxy. Relying on it
+// instead of radar spokes means own-ship position and heading are available
+// even while the radar is in standby.
 function subscribeToHeading() {
-  if (isStandaloneMode()) {
-    console.log("Standalone mode: heading subscription disabled (no SignalK)");
-    return;
-  }
-
   const streamUrl = wsBase("/signalk/v1/stream?subscribe=none");
 
   headingSocket = new WebSocket(streamUrl);
@@ -309,6 +309,7 @@ function subscribeToHeading() {
             for (const value of update.values) {
               if (value.path === "navigation.headingTrue") {
                 trueHeading = value.value; // Already in radians
+                haveSignalKHeading = true;
                 if (
                   lastLoggedHeading === null ||
                   Math.abs(trueHeading - lastLoggedHeading) >
@@ -665,12 +666,27 @@ function updateHeadingDisplay(mode) {
   return mode || headingMode;
 }
 
+// Resolve the heading to show in the position box, in degrees. Prefer the
+// Signal K true heading once a real delta has arrived (haveSignalKHeading
+// guards against the 0-radian initial value); otherwise fall back to the
+// radar-derived heading (already smoothed). Returns null when neither exists.
+function positionBoxHeadingDeg() {
+  if (haveSignalKHeading && trueHeading != null && !Number.isNaN(trueHeading)) {
+    return (trueHeading * 180) / Math.PI;
+  }
+  if (lastRadarHeading != null && !Number.isNaN(lastRadarHeading)) {
+    return lastRadarHeading;
+  }
+  return null;
+}
+
 function refreshPositionBoxHeading() {
   const box = document.getElementById("myr_position_box");
   if (!box) return;
   const hdgEl = box.querySelector(".myr_pos_heading");
-  if (hdgEl && trueHeading != null && !Number.isNaN(trueHeading)) {
-    hdgEl.textContent = `HdgT: ${((trueHeading * 180) / Math.PI).toFixed(1)}°`;
+  const hdgDeg = positionBoxHeadingDeg();
+  if (hdgEl && hdgDeg != null) {
+    hdgEl.textContent = `HdgT: ${hdgDeg.toFixed(1)}°`;
   }
 }
 
@@ -784,12 +800,9 @@ function updatePositionBox(lat, lon, heading) {
     coords[1].textContent = formatCoord(lon, false);
   }
 
-  // Use the Signal K true heading (navigation.headingTrue) rather than the
-  // spoke-derived value. The radar's inline bearing field encodes heading
-  // in brand-specific units and is unreliable as a navigation display;
-  // Signal K's stream is the authoritative source.
-  if (hdgEl && trueHeading != null && !Number.isNaN(trueHeading)) {
-    hdgEl.textContent = `HdgT: ${((trueHeading * 180) / Math.PI).toFixed(1)}°`;
+  const hdgDeg = positionBoxHeadingDeg();
+  if (hdgEl && hdgDeg != null) {
+    hdgEl.textContent = `HdgT: ${hdgDeg.toFixed(1)}°`;
   }
 
   box.style.display = "block";
@@ -1430,6 +1443,20 @@ function radarLoaded(r) {
             if (heading >= 360) heading -= 360;
           }
           updatePositionBox(lastSpoke.lat, lastSpoke.lon, heading);
+        }
+        // When the upstream has no navigation.headingTrue, onHeadingReceived()
+        // never fires from the heading socket, but the radar-derived heading
+        // from spokes is still a valid reference. Enable the heading-dependent
+        // UI (H-Up toggle, AIS lozenge) the first time any heading appears.
+        // Gated on the toggle still being disabled so it runs once on
+        // transition, not every spoke; enable-only, so brief radar gaps don't
+        // flip the toggle back off.
+        const headingToggle = document.getElementById("myr_heading_toggle");
+        if (
+          ppi.hasHeading() &&
+          headingToggle?.classList.contains("myr_heading_disabled")
+        ) {
+          onHeadingReceived();
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Why

Behind the Signal K proxy the viewer detects "standalone" mode (mayara answers `/signalk` through the proxy), and in that mode it skipped the `vessels.self` subscription for `navigation.headingTrue` / `navigation.position`. Own-ship position and heading then came only from radar spokes, which are produced while transmitting — so in standby the viewer showed no position, no heading, the H-Up toggle stayed disabled, and the AIS overlay had no own-ship reference to plot against.

A secondary issue: when only the radar-derived heading is available, AIS/ARPA targets jumped frame to frame. The per-spoke `bearing` field is quantized, and in head-up mode the overlay subtracts that heading while the spoke raster does not, so the jitter moved every target.

## How

- Always open the `vessels.self` nav subscription. mayara serves own-ship position and heading from its upstream regardless of mode or radar transmit state, so the viewer no longer depends on spokes for them.
- Enable the H-Up toggle and AIS lozenge from the radar-derived heading when no Signal K heading is published.
- Smooth the radar-derived heading on its unit vector (circular-mean safe across the wrap) to stop the AIS/ARPA jump, and fall back to it in the position box instead of showing a misleading `0`.

## Tested

Verified live against a DRS4D-NXT behind a Signal K server, both the proxied (`/plugins/<id>/gui/`) and direct (`:6502`) URLs: own-ship position and heading display in standby, the H-Up toggle is clickable, and AIS targets are stable. `cargo test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The GUI now reliably displays own-ship position and heading in all modes, including when the viewer is behind a Signal K proxy or when the radar is in standby, and stabilizes AIS target placement.

### web/gui/ppi.js

Introduces exponential smoothing (circular mean via unit-vector smoothing) for radar-derived heading to eliminate jitter. A new `HEADING_SMOOTH_ALPHA` constant sets the smoothing factor to 0.1. The `drawSpoke()` method now:
- Computes spoke-based heading from bearing and angle
- Incrementally smooths the heading using sine/cosine components (`headingSin`/`headingCos`) to handle the 360°→0° wraparound safely
- Derives `lastHeading` from the smoothed components using `atan2`
- Clears the smoothed state when spoke heading inputs are missing

### web/gui/viewer.js

Refactors heading handling to always subscribe to `vessels.self` navigation streams (position and heading) and to enable heading-dependent UI based on either Signal K or radar-derived heading. Key changes:

- Adds `haveSignalKHeading` flag to track arrival of the first real heading delta from Signal K
- `subscribeToHeading()` now unconditionally opens the `vessels.self` subscription for `navigation.headingTrue` and `navigation.position`, ensuring own-ship data are available regardless of mode or radar TX state
- Introduces `positionBoxHeadingDeg()` helper that prefers Signal K true heading once a delta arrives, otherwise falls back to the radar-derived heading
- Spoke processing conditionally calls `onHeadingReceived()` once when radar spokes provide a usable heading but the Signal K socket hasn't yet fired, gated to avoid re-triggering during brief radar gaps
- `onHeadingReceived()` enables the H-Up toggle and AIS lozenge when any heading becomes available
- Heading display in the position box stays in sync across periodic refreshes and position updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->