### PR TITLE
feat(gui): support magnetic heading with true/magnetic readout toggle

### DIFF
--- a/ENDUSER.md
+++ b/ENDUSER.md
@@ -126,9 +126,13 @@ For real radar use, you need `--net=host` so Mayara can see the multicast traffi
 - Check that no firewall is blocking port 6502.
 
 **Radar sweep shows but no AIS or ARPA targets:**
-- AIS and ARPA targets are placed relative to your own ship, so the display needs a **heading reference** to draw them. Mayara uses the radar's own heading if the radar reports it, or a true heading from Signal K (`navigation.headingTrue`) otherwise.
-- When no heading is available from either source, the **AIS** toggle is grayed out — that is the signal that a heading is missing, not that AIS is off.
+- AIS and ARPA targets are placed relative to your own ship, so the display needs a **heading reference** to draw them. Mayara uses the radar's own heading if the radar reports it, or a heading from Signal K otherwise.
+- Signal K can supply true heading (`navigation.headingTrue`) or magnetic heading (`navigation.headingMagnetic`). If only magnetic heading is published, Mayara converts it to true using the magnetic variation (`navigation.magneticVariation`) so targets are placed correctly — so a magnetic compass needs a variation source for the overlays to work.
+- When no usable heading is available from any source, the **AIS** toggle is grayed out — that is the signal that a heading is missing, not that AIS is off.
 - If you have a heading sensor, make sure it's feeding the radar or Signal K. The radar sweep itself does not need a heading, which is why it can show while targets stay hidden.
+
+**Heading readout (true vs magnetic):**
+- The position box shows the current heading as `HdgT` (true) or `HdgM` (magnetic). When both are available, click the heading line to switch which one is displayed; the choice is remembered in your browser. This only changes the readout — targets are always placed using true heading.
 
 ## Need help?
 

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1466,6 +1466,11 @@ async fn send_current_navigation(
             delta.add_navigation_update("navigation.headingTrue", h, "mayara");
         }
     }
+    if subscriptions.is_subscribed_path("navigation.headingMagnetic", false) {
+        if let Some(h) = navdata::get_heading_magnetic() {
+            delta.add_navigation_update("navigation.headingMagnetic", h, "mayara");
+        }
+    }
 
     if let Some(d) = delta.build() {
         send_message(socket, d).await?;

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -29,6 +29,11 @@ use crate::{
 };
 
 static HEADING_TRUE: AtomicF64 = AtomicF64::new(f64::NAN);
+static HEADING_MAGNETIC: AtomicF64 = AtomicF64::new(f64::NAN);
+static MAGNETIC_VARIATION: AtomicF64 = AtomicF64::new(f64::NAN);
+/// Set once a real true-heading source delivers a value, after which derived
+/// magnetic+variation headings are ignored so a real true heading always wins.
+static TRUE_HEADING_AUTHORITATIVE: AtomicBool = AtomicBool::new(false);
 static POSITION_VALID: AtomicBool = AtomicBool::new(false);
 static POSITION_LAT: AtomicF64 = AtomicF64::new(f64::NAN);
 static POSITION_LON: AtomicF64 = AtomicF64::new(f64::NAN);
@@ -262,11 +267,26 @@ fn build_seed_updates(vessel: &Value) -> Option<Value> {
     Some(json!([{ "values": values }]))
 }
 
+/// Source label used when a true heading is derived from magnetic heading and
+/// variation. `set_heading_true` keys off this to decide whether the caller is
+/// a real (authoritative) true source or the derivation path.
+const DERIVED_SOURCE: &str = "magnetic+variation";
+
 ///
 /// Get the heading in radians [0..2*PI>
 ///
 pub fn get_heading_true() -> Option<f64> {
     let heading = HEADING_TRUE.load(Ordering::Acquire);
+    if !heading.is_nan() {
+        return Some(heading);
+    }
+    return None;
+}
+
+/// Get the magnetic heading in radians [0..2*PI>, if known. Forwarded to the
+/// GUI for the true/magnetic readout toggle; never used for radar geometry.
+pub fn get_heading_magnetic() -> Option<f64> {
+    let heading = HEADING_MAGNETIC.load(Ordering::Acquire);
     if !heading.is_nan() {
         return Some(heading);
     }
@@ -285,6 +305,12 @@ pub(crate) fn set_heading_true(heading: Option<f64>, source: &str) {
             "set_heading_true: heading {h} rad ({} deg) from '{source}' is out of range",
             h.to_degrees()
         );
+        // Any real true-heading source (SignalK headingTrue, NMEA0183 HDT,
+        // emulator, static config) takes permanent precedence over a value
+        // derived from magnetic heading + variation.
+        if source != DERIVED_SOURCE {
+            TRUE_HEADING_AUTHORITATIVE.store(true, Ordering::Release);
+        }
         let h = h.rem_euclid(TAU);
 
         let old = HEADING_TRUE.swap(h, Ordering::AcqRel);
@@ -294,6 +320,76 @@ pub(crate) fn set_heading_true(heading: Option<f64>, source: &str) {
         }
     } else {
         HEADING_TRUE.store(f64::NAN, Ordering::Release);
+    }
+}
+
+/// Derive a true heading from magnetic heading and variation, both in radians.
+/// Signal K convention: `true = magnetic + variation`. Returns `None` unless
+/// both inputs are present.
+pub(crate) fn derive_true_heading(magnetic: Option<f64>, variation: Option<f64>) -> Option<f64> {
+    match (magnetic, variation) {
+        (Some(m), Some(v)) => Some((m + v).rem_euclid(std::f64::consts::TAU)),
+        _ => None,
+    }
+}
+
+/// Whether the magnetic+variation derivation should run. It must not when a
+/// real true-heading source is authoritative.
+fn should_derive(true_authoritative: bool) -> bool {
+    !true_authoritative
+}
+
+/// Set the magnetic heading in radians. Broadcast to the GUI (for the readout
+/// toggle) and feed the magnetic→true derivation.
+pub(crate) fn set_heading_magnetic(heading: Option<f64>, source: &str) {
+    use std::f64::consts::TAU;
+
+    if let Some(h) = heading {
+        assert!(
+            h > -TAU && h < 2.0 * TAU,
+            "set_heading_magnetic: heading {h} rad ({} deg) from '{source}' is out of range",
+            h.to_degrees()
+        );
+        let h = h.rem_euclid(TAU);
+        let old = HEADING_MAGNETIC.swap(h, Ordering::AcqRel);
+        if (old - h).abs() > 0.001 || old.is_nan() {
+            broadcast_nav_update("navigation.headingMagnetic", h, source);
+        }
+    } else {
+        HEADING_MAGNETIC.store(f64::NAN, Ordering::Release);
+    }
+    recompute_derived_true();
+}
+
+/// Set the magnetic variation in radians and feed the magnetic→true derivation.
+/// Not displayed, so no GUI broadcast.
+pub(crate) fn set_magnetic_variation(variation: Option<f64>) {
+    match variation {
+        Some(v) => MAGNETIC_VARIATION.store(v, Ordering::Release),
+        None => MAGNETIC_VARIATION.store(f64::NAN, Ordering::Release),
+    }
+    recompute_derived_true();
+}
+
+/// Recompute the canonical true heading from magnetic heading + variation,
+/// unless a real true-heading source is already authoritative. Only arms the
+/// own-ship-nav probe when a true heading is actually produced, so a
+/// magnetic-only feed without variation does not falsely satisfy the probe.
+fn recompute_derived_true() {
+    if !should_derive(TRUE_HEADING_AUTHORITATIVE.load(Ordering::Acquire)) {
+        return;
+    }
+    let magnetic = {
+        let v = HEADING_MAGNETIC.load(Ordering::Acquire);
+        (!v.is_nan()).then_some(v)
+    };
+    let variation = {
+        let v = MAGNETIC_VARIATION.load(Ordering::Acquire);
+        (!v.is_nan()).then_some(v)
+    };
+    if let Some(t) = derive_true_heading(magnetic, variation) {
+        set_heading_true(Some(t), DERIVED_SOURCE);
+        mark_signalk_own_ship_nav_seen();
     }
 }
 
@@ -387,7 +483,7 @@ pub(crate) fn set_sog(sog: Option<f64>) {
 const NMEA0183_SERVICE_NAME: &str = "_nmea-0183._tcp.local.";
 
 /// Subscription for own-ship navigation data only
-const SUBSCRIBE_SELF: &'static str = "{\"context\":\"vessels.self\",\"subscribe\":[{\"path\":\"navigation.headingTrue\"},{\"path\":\"navigation.position\"},{\"path\":\"navigation.speedOverGround\"},{\"path\":\"navigation.courseOverGroundTrue\"}]}\r\n";
+const SUBSCRIBE_SELF: &'static str = "{\"context\":\"vessels.self\",\"subscribe\":[{\"path\":\"navigation.headingTrue\"},{\"path\":\"navigation.headingMagnetic\"},{\"path\":\"navigation.magneticVariation\"},{\"path\":\"navigation.position\"},{\"path\":\"navigation.speedOverGround\"},{\"path\":\"navigation.courseOverGroundTrue\"}]}\r\n";
 
 /// Additional subscription for all vessels (sent after own-ship context is known)
 const SUBSCRIBE_ALL: &'static str =
@@ -1390,6 +1486,14 @@ fn apply_signalk_value(values_entry: &Value, source: &str) {
                 mark_signalk_own_ship_nav_seen();
             }
         }
+        // Magnetic heading and variation are in radians (Signal K convention),
+        // unlike the NMEA0183 HDT path which converts from degrees.
+        "navigation.headingMagnetic" => {
+            set_heading_magnetic(value.as_f64(), source);
+        }
+        "navigation.magneticVariation" => {
+            set_magnetic_variation(value.as_f64());
+        }
         "navigation.speedOverGround" => {
             set_sog(value.as_f64());
         }
@@ -1533,5 +1637,50 @@ mod tests {
         // already-capped backoff or probe timeout.
         assert_eq!(next_consecutive(u32::MAX, false), u32::MAX);
         assert_eq!(next_consecutive(u32::MAX - 1, false), u32::MAX);
+    }
+
+    // ----- magnetic -> true heading derivation -----
+
+    use std::f64::consts::TAU;
+
+    #[test]
+    fn derive_true_adds_magnetic_and_variation() {
+        // Signal K convention: true = magnetic + variation (radians).
+        let t = derive_true_heading(Some(1.0), Some(0.1)).unwrap();
+        assert!((t - 1.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn derive_true_wraps_modulo_tau() {
+        // Magnetic near a full turn plus easterly variation wraps into [0, TAU).
+        let t = derive_true_heading(Some(TAU - 0.05), Some(0.2)).unwrap();
+        assert!((0.0..TAU).contains(&t));
+        assert!((t - 0.15).abs() < 1e-9);
+    }
+
+    #[test]
+    fn derive_true_westerly_variation_reduces_true() {
+        // Westerly variation is negative, so true < magnetic.
+        let t = derive_true_heading(Some(1.0), Some(-0.2)).unwrap();
+        assert!((t - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn derive_true_requires_variation() {
+        // Magnetic alone is not enough — without variation there is no usable
+        // true heading for plotting.
+        assert_eq!(derive_true_heading(Some(1.0), None), None);
+    }
+
+    #[test]
+    fn derive_true_requires_magnetic() {
+        assert_eq!(derive_true_heading(None, Some(0.1)), None);
+    }
+
+    #[test]
+    fn should_derive_blocks_when_true_is_authoritative() {
+        // A real true-heading source must win over derived values.
+        assert!(!should_derive(true));
+        assert!(should_derive(false));
     }
 }

--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -149,6 +149,13 @@ div.myr_ppi {
   white-space: nowrap;
 }
 
+/* Click affordance shown only when both true and magnetic headings exist, so
+   the operator can switch the readout between them. */
+.myr_position_box .myr_pos_heading.myr_pos_heading_toggleable {
+  cursor: pointer;
+  text-decoration: underline dotted;
+}
+
 /* ============================================
    Power Lozenge - Status indicator on viewer
    ============================================ */

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -338,14 +338,18 @@ function subscribeToHeading() {
                 }
                 onHeadingReceived();
                 updateHeadingDisplay();
-              } else if (
-                value.path === "navigation.headingMagnetic" &&
-                value.value != null
-              ) {
+              } else if (value.path === "navigation.headingMagnetic") {
                 // Display-only: feeds the HdgT/HdgM readout toggle. Plotting
-                // never uses this — it stays on the canonical true heading.
-                magneticHeading = value.value; // Already in radians
-                haveMagneticHeading = true;
+                // never uses this — it stays on the canonical true heading. A
+                // null value means the magnetic source dropped out, so clear
+                // the state to remove the HdgM option and toggle affordance.
+                if (value.value != null) {
+                  magneticHeading = value.value; // Already in radians
+                  haveMagneticHeading = true;
+                } else {
+                  magneticHeading = 0;
+                  haveMagneticHeading = false;
+                }
                 refreshPositionBoxHeading();
                 updateHeadingDisplayToggle();
               } else if (

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -69,6 +69,8 @@ var renderMethod = "webgpu"; // "webgpu" or "webgl"
 var headingMode = "headingUp";
 var trueHeading = 0; // in radians
 var haveSignalKHeading = false; // true once a navigation.headingTrue delta lands
+var magneticHeading = 0; // in radians, for the readout toggle only
+var haveMagneticHeading = false; // true once a navigation.headingMagnetic delta lands
 var lastLoggedHeading = null; // last heading value logged to console
 var lastHeadingTime = 0; // Timestamp of last heading update
 
@@ -84,6 +86,16 @@ var showAis = (() => {
     return localStorage.getItem("mayaraShowAis") !== "false";
   } catch {
     return true;
+  }
+})();
+
+// Heading readout preference: show magnetic instead of true when both exist.
+// Display-only — never affects plotting, which always uses the true heading.
+var preferMagneticHeading = (() => {
+  try {
+    return localStorage.getItem("mayaraPreferMagnetic") === "true";
+  } catch {
+    return false;
   }
 })();
 
@@ -290,6 +302,10 @@ function subscribeToHeading() {
       context: "vessels.self",
       subscribe: [
         { path: "navigation.headingTrue", period: 200 },
+        // Magnetic heading drives only the readout toggle; plotting uses the
+        // true heading (which mayara derives from magnetic + variation when no
+        // true heading is published).
+        { path: "navigation.headingMagnetic", period: 200 },
         // Position drives AIS overlay placement — without this the
         // overlay falls back to spoke metadata, which is only updated
         // when the radar is transmitting and can disagree with the
@@ -322,6 +338,16 @@ function subscribeToHeading() {
                 }
                 onHeadingReceived();
                 updateHeadingDisplay();
+              } else if (
+                value.path === "navigation.headingMagnetic" &&
+                value.value != null
+              ) {
+                // Display-only: feeds the HdgT/HdgM readout toggle. Plotting
+                // never uses this — it stays on the canonical true heading.
+                magneticHeading = value.value; // Already in radians
+                haveMagneticHeading = true;
+                refreshPositionBoxHeading();
+                updateHeadingDisplayToggle();
               } else if (
                 value.path === "navigation.position" &&
                 value.value?.latitude != null &&
@@ -666,16 +692,26 @@ function updateHeadingDisplay(mode) {
   return mode || headingMode;
 }
 
-// Resolve the heading to show in the position box, in degrees. Prefer the
-// Signal K true heading once a real delta has arrived (haveSignalKHeading
-// guards against the 0-radian initial value); otherwise fall back to the
-// radar-derived heading (already smoothed). Returns null when neither exists.
+// Resolve the heading to show in the position box as { deg, label }. With both
+// true and magnetic available, honor the readout preference; with only one,
+// show it; otherwise fall back to the radar-derived true heading (smoothed).
+// The haveSignalKHeading / haveMagneticHeading guards reject the 0-radian
+// initial values. Returns null when no heading exists.
 function positionBoxHeadingDeg() {
-  if (haveSignalKHeading && trueHeading != null && !Number.isNaN(trueHeading)) {
-    return (trueHeading * 180) / Math.PI;
+  const haveTrue =
+    haveSignalKHeading && trueHeading != null && !Number.isNaN(trueHeading);
+  const haveMag =
+    haveMagneticHeading &&
+    magneticHeading != null &&
+    !Number.isNaN(magneticHeading);
+  if (haveMag && (preferMagneticHeading || !haveTrue)) {
+    return { deg: (magneticHeading * 180) / Math.PI, label: "HdgM" };
+  }
+  if (haveTrue) {
+    return { deg: (trueHeading * 180) / Math.PI, label: "HdgT" };
   }
   if (lastRadarHeading != null && !Number.isNaN(lastRadarHeading)) {
-    return lastRadarHeading;
+    return { deg: lastRadarHeading, label: "HdgT" };
   }
   return null;
 }
@@ -684,9 +720,9 @@ function refreshPositionBoxHeading() {
   const box = document.getElementById("myr_position_box");
   if (!box) return;
   const hdgEl = box.querySelector(".myr_pos_heading");
-  const hdgDeg = positionBoxHeadingDeg();
-  if (hdgEl && hdgDeg != null) {
-    hdgEl.textContent = `HdgT: ${hdgDeg.toFixed(1)}°`;
+  const hdg = positionBoxHeadingDeg();
+  if (hdgEl && hdg != null) {
+    hdgEl.textContent = `${hdg.label}: ${hdg.deg.toFixed(1)}°`;
   }
 }
 
@@ -710,6 +746,15 @@ function createPositionBox() {
     <div class="myr_pos_heading">HdgT: ---°</div>
   `;
   box.addEventListener("click", cycleCoordFormat);
+  // Clicking the heading line toggles the true/magnetic readout (when both
+  // exist) without also cycling the coordinate format.
+  const hdgEl = box.querySelector(".myr_pos_heading");
+  if (hdgEl) {
+    hdgEl.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleHeadingDisplay();
+    });
+  }
   container.appendChild(box);
 }
 
@@ -720,6 +765,38 @@ function cycleCoordFormat() {
   if (lastRadarLat !== null && lastRadarLon !== null) {
     updatePositionBox(lastRadarLat, lastRadarLon, lastRadarHeading);
   }
+}
+
+// Toggle the heading readout between true and magnetic. Inert unless both are
+// available (nothing to switch to otherwise). Display-only: never touches the
+// heading used for plotting. Persists the choice per browser.
+function toggleHeadingDisplay() {
+  const haveTrue = haveSignalKHeading && !Number.isNaN(trueHeading);
+  const haveMag = haveMagneticHeading && !Number.isNaN(magneticHeading);
+  if (!(haveTrue && haveMag)) return;
+  preferMagneticHeading = !preferMagneticHeading;
+  try {
+    localStorage.setItem("mayaraPreferMagnetic", String(preferMagneticHeading));
+  } catch {
+    // localStorage unavailable (private mode) — preference is session-only.
+  }
+  refreshPositionBoxHeading();
+  updateHeadingDisplayToggle();
+}
+
+// Show the click affordance on the heading line only when both true and
+// magnetic headings exist, i.e. when switching is actually possible.
+function updateHeadingDisplayToggle() {
+  const box = document.getElementById("myr_position_box");
+  if (!box) return;
+  const hdgEl = box.querySelector(".myr_pos_heading");
+  if (!hdgEl) return;
+  const canToggle =
+    haveSignalKHeading &&
+    !Number.isNaN(trueHeading) &&
+    haveMagneticHeading &&
+    !Number.isNaN(magneticHeading);
+  hdgEl.classList.toggle("myr_pos_heading_toggleable", canToggle);
 }
 
 // Format degrees to degrees, minutes, seconds (DMS)
@@ -800,9 +877,9 @@ function updatePositionBox(lat, lon, heading) {
     coords[1].textContent = formatCoord(lon, false);
   }
 
-  const hdgDeg = positionBoxHeadingDeg();
-  if (hdgEl && hdgDeg != null) {
-    hdgEl.textContent = `HdgT: ${hdgDeg.toFixed(1)}°`;
+  const hdg = positionBoxHeadingDeg();
+  if (hdgEl && hdg != null) {
+    hdgEl.textContent = `${hdg.label}: ${hdg.deg.toFixed(1)}°`;
   }
 
   box.style.display = "block";
@@ -857,6 +934,7 @@ function onHeadingReceived() {
     toggleBtn.title = "Click to toggle: Heading Up / North Up";
   }
   updateAisLozenge();
+  updateHeadingDisplayToggle();
 }
 
 // Called when the heading WebSocket closes — true loss of source.


### PR DESCRIPTION
## Why

Vessels that publish only `navigation.headingMagnetic` (no `navigation.headingTrue`) got no usable heading, so no head-up rotation and no AIS/ARPA overlay — even though the data was there. Boats with a satellite compass have true; boats with a magnetic compass have magnetic; some have both.

## How

- When no real true heading is delivered, derive one from magnetic heading + variation (`true = magnetic + variation`, both radians) so plotting — which always uses true/geographic bearings — stays correct. A magnetic compass therefore needs a `navigation.magneticVariation` source for the overlays to work; without it there is no usable heading.
- A real `navigation.headingTrue` from any source always wins over the derived value.
- Forward `navigation.headingMagnetic` to the GUI for display only. The position box shows `HdgT` or `HdgM`; when both are available, clicking the heading line switches which is shown (persisted per browser).

The display choice never affects plotting or the radar's geographic math (antenna offset, brand heading reports) — those always use true heading.

## Tested

`cargo test` passes, including new unit tests for the magnetic→true derivation and the true-wins precedence. Verified live against a Signal K feed: true-only forwards `headingTrue` with no regression; injecting `navigation.headingMagnetic` makes mayara forward both while the real true heading stays authoritative, and the GUI readout toggles between `HdgT` and `HdgM`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Adds support for vessels publishing only magnetic heading by deriving true heading from `navigation.headingMagnetic` and `navigation.magneticVariation`. When no authoritative true heading is available, the system computes true heading as magnetic heading + magnetic variation (in radians). If true heading is received from any source, it takes precedence over the derived value.

## Backend Changes

**Signal K subscription and forwarding** (`src/bin/mayara-server/web/signalk/v2.rs`):
- Extends navigation subscriptions to request `navigation.headingMagnetic` and `navigation.magneticVariation` in addition to existing paths
- Updates `send_current_navigation` to forward magnetic heading to clients when subscribed

**Navigation data management** (`src/lib/navdata.rs`):
- Adds global atomic storage for magnetic heading and magnetic variation
- Implements `derive_true_heading()` to compute true heading from magnetic heading + magnetic variation (with TAU wrapping for angle normalization)
- Introduces derivation gating: true heading derivation only occurs when both magnetic heading and variation are available, and when no authoritative true heading has been received
- Marks derived true headings with a distinct source label to distinguish from received values
- Exports `get_heading_magnetic()` for client queries
- Includes unit tests for derivation logic (addition, wrapping, variation effects, input requirements) and precedence rules

## Frontend Changes

**GUI rendering** (`web/gui/viewer.js`):
- Adds module-scoped state tracking for magnetic heading availability and user preference
- Persists user's heading display choice (`preferMagneticHeading`) in `localStorage`
- Refactors `positionBoxHeadingDeg()` to return both numeric value and label (`HdgM`/`HdgT`), with fallback to radar-derived true heading
- Makes heading line in position box clickable when both true and magnetic headings are available to toggle display preference
- Updates display affordance via `updateHeadingDisplayToggle()` when heading data changes

**Styling** (`web/gui/layout.css`):
- Adds `.myr_position_box .myr_pos_heading.myr_pos_heading_toggleable` rule to indicate clickable heading with pointer cursor and dotted underline

## Display Behavior

- Position box displays `HdgT` (true heading) or `HdgM` (magnetic heading) label alongside value
- User can click heading to toggle between readouts when both are available
- Heading display toggle is purely cosmetic; all plotting and geographic computations (antenna offset, AIS/ARPA placement) always use true heading regardless of display preference

## Documentation

Updates `ENDUSER.md` troubleshooting section to explain magnetic heading support, true heading derivation via magnetic variation, and clarify that target placement uses true heading even when display is switched to magnetic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->