### PR TITLE
fix(gui): hide ON-TIME/TX-TIME when the radar does not report them

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1915,18 +1915,22 @@ function convertTimeToSeconds(value, units) {
 }
 
 function getOperatingTime() {
-  const onTimeUnits = getControl("operatingTime")?.units || "s";
-  const txTimeUnits = getControl("transmitTime")?.units || "s";
+  const onTimeControl = getControl("operatingTime");
+  const txTimeControl = getControl("transmitTime");
 
   return {
-    onTime: convertTimeToSeconds(
-      myr_control_values.operatingTime?.value || 0,
-      onTimeUnits
-    ),
-    txTime: convertTimeToSeconds(
-      myr_control_values.transmitTime?.value || 0,
-      txTimeUnits
-    ),
+    onTime: onTimeControl
+      ? convertTimeToSeconds(
+          myr_control_values.operatingTime?.value || 0,
+          onTimeControl.units || "s"
+        )
+      : null,
+    txTime: txTimeControl
+      ? convertTimeToSeconds(
+          myr_control_values.transmitTime?.value || 0,
+          txTimeControl.units || "s"
+        )
+      : null,
   };
 }
 

--- a/web/gui/ppi.js
+++ b/web/gui/ppi.js
@@ -140,8 +140,8 @@ class PPI {
 
     // Power mode state
     this.powerMode = "off";
-    this.onTimeSeconds = 0;
-    this.txTimeSeconds = 0;
+    this.onTimeSeconds = null;
+    this.txTimeSeconds = null;
 
     // Guard zones and no-transmit sectors
     this.guardZones = [null, null];
@@ -356,8 +356,8 @@ class PPI {
     const isStandby = powerMode !== "transmit";
     const wasStandby = this.powerMode !== "transmit";
     this.powerMode = powerMode;
-    this.onTimeSeconds = onTimeSeconds || 0;
-    this.txTimeSeconds = txTimeSeconds || 0;
+    this.onTimeSeconds = onTimeSeconds ?? null;
+    this.txTimeSeconds = txTimeSeconds ?? null;
 
     if (isStandby && !wasStandby) {
       this.clearRadarDisplay();
@@ -950,7 +950,10 @@ class PPI {
       return;
     }
 
-    const showTimes = this.powerMode === "standby";
+    const hasOnTime = this.onTimeSeconds !== null;
+    const hasTxTime = this.txTimeSeconds !== null;
+    const showTimes =
+      this.powerMode === "standby" && (hasOnTime || hasTxTime);
     const standbyY = showTimes ? this.center_y - 40 : this.center_y;
 
     ctx.fillText(this.powerMode.toUpperCase(), this.center_x, standbyY);
@@ -959,12 +962,16 @@ class PPI {
       ctx.font = "bold 20px/1 Verdana, Geneva, sans-serif";
       let yOffset = this.center_y + 10;
 
-      const onTimeStr = this.#formatSecondsAsTimeZero(this.onTimeSeconds);
-      ctx.fillText("ON-TIME: " + onTimeStr, this.center_x, yOffset);
-      yOffset += 30;
+      if (hasOnTime) {
+        const onTimeStr = this.#formatSecondsAsTimeZero(this.onTimeSeconds);
+        ctx.fillText("ON-TIME: " + onTimeStr, this.center_x, yOffset);
+        yOffset += 30;
+      }
 
-      const txTimeStr = this.#formatSecondsAsTimeZero(this.txTimeSeconds);
-      ctx.fillText("TX-TIME: " + txTimeStr, this.center_x, yOffset);
+      if (hasTxTime) {
+        const txTimeStr = this.#formatSecondsAsTimeZero(this.txTimeSeconds);
+        ctx.fillText("TX-TIME: " + txTimeStr, this.center_x, yOffset);
+      }
     }
 
     ctx.restore();


### PR DESCRIPTION
Quantum radars do not broadcast operating or transmit hours — verified against the Q24D captures and firmware, where no such field exists in any report. The standby overlay still drew `ON-TIME: 00:00:00` / `TX-TIME: 00:00:00` because the absent controls were coerced to `0`, which looked like a decode bug.

`getOperatingTime()` now returns `null` for a missing `operatingTime`/`transmitTime` control, and the PPI overlay skips each unavailable line (centering STANDBY when neither is present). Radars that do report these values (RD magnetron, Furuno, Navico, Garmin) are unaffected.

Tested: `cargo test` (all pass) and `cargo build`; verified the overlay logic against the Q24D report set.