### PR TITLE
ci: delete PR test image when the pull request closes

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -8,7 +8,7 @@ name: Docker PR test image
 
 on:
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [labeled, synchronize, reopened, closed]
 
 concurrency:
   group: docker-pr-${{ github.event.pull_request.number }}
@@ -17,12 +17,13 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  PACKAGE: mayara-server
   LABEL: build-image
 
 jobs:
   build:
     name: Build ${{ matrix.platform }}
-    if: contains(github.event.pull_request.labels.*.name, 'build-image')
+    if: github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'build-image')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,3 +153,82 @@ jobs:
               body,
             });
           }
+
+  cleanup:
+    name: Delete PR test image
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      pull-requests: write
+
+    steps:
+    - name: Delete pr<N> image versions
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const pr = context.payload.pull_request.number;
+          const pkg = process.env.PACKAGE;
+          // Match only this PR's tags: exactly `pr<N>` or `pr<N>-<sha>`.
+          // A prefix/substring test would let pr2 match pr267, so use exact + `-` boundary.
+          const exact = `pr${pr}`;
+          const prefix = `pr${pr}-`;
+          const isOurs = (tag) => tag === exact || tag.startsWith(prefix);
+
+          const versions = await github.paginate(
+            github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg,
+            {
+              org: context.repo.owner,
+              package_type: 'container',
+              package_name: pkg,
+              per_page: 100,
+            },
+          ).catch((err) => {
+            // Package may not exist if this PR never had the build-image label.
+            if (err.status === 404) return [];
+            throw err;
+          });
+
+          const toDelete = versions.filter((v) =>
+            (v.metadata?.container?.tags || []).some(isOurs),
+          );
+
+          if (toDelete.length === 0) {
+            core.info(`No image versions tagged pr${pr} found — nothing to clean up.`);
+            return;
+          }
+
+          for (const v of toDelete) {
+            core.info(`Deleting version ${v.id} (tags: ${v.metadata.container.tags.join(', ')})`);
+            await github.rest.packages.deletePackageVersionForOrg({
+              org: context.repo.owner,
+              package_type: 'container',
+              package_name: pkg,
+              package_version_id: v.id,
+            });
+          }
+          core.info(`Deleted ${toDelete.length} image version(s) for pr${pr}.`);
+
+    - name: Update PR comment
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const pr = context.payload.pull_request.number;
+          const marker = '<!-- docker-pr-test-image -->';
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr,
+          });
+          const existing = comments.find((c) => c.body && c.body.includes(marker));
+          if (!existing) return;
+          const body = [
+            marker,
+            `🧹 Docker test image for this PR (\`pr${pr}\`) was deleted on close.`,
+          ].join('\n');
+          await github.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: existing.id,
+            body,
+          });

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -189,9 +189,13 @@ jobs:
             throw err;
           });
 
-          const toDelete = versions.filter((v) =>
-            (v.metadata?.container?.tags || []).some(isOurs),
-          );
+          // Delete only versions whose tags are *exclusively* this PR's tags.
+          // Deletion is version-level, so a digest shared with e.g. `latest`
+          // must be left alone; `some` would take the shared tags down with it.
+          const toDelete = versions.filter((v) => {
+            const tags = v.metadata?.container?.tags || [];
+            return tags.length > 0 && tags.every(isOurs);
+          });
 
           if (toDelete.length === 0) {
             core.info(`No image versions tagged pr${pr} found — nothing to clean up.`);


### PR DESCRIPTION
Per-PR Docker test images (`pr<N>`) accumulate in GHCR with no expiry. Once a PR is merged or closed its image is dead weight.

This extends the per-PR Docker workflow to clean up after itself: the `pull_request` trigger now also fires on `closed`, running a `cleanup` job that deletes the package versions tagged `pr<N>` and `pr<N>-<sha>` for that PR. The build/push jobs are gated off the `closed` action so they don't run on close.

Tag matching is exact (`pr<N>` or the `pr<N>-` prefix) so e.g. closing PR #2 cannot delete PR #267's image. Cleanup is a no-op (logged, not failed) when the PR never built an image. The comment posted on build is updated to note the image was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The Docker PR test image workflow is enhanced with automatic cleanup when pull requests close.

The `pull_request` trigger now includes the `closed` event type, allowing the workflow to run when PRs are closed. Workflow-level environment variables (`PACKAGE: mayara-server` and `LABEL: build-image`) are added for use across jobs.

The `build` and `push` jobs are gated to skip on `closed` events via an updated condition on the build job: `github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'build-image')`.

A new `cleanup` job runs exclusively on PR close. It queries GHCR for container package versions, filters those tagged with `pr<N>` (exact match) or `pr<N>-*` (prefix match) to target only the closed PR's images and avoid accidental deletion across PR numbers, and deletes matching versions. The tag matching logic prevents cross-PR deletion (e.g., closing PR `#2` cannot delete PR `#267` tags). If no images are found, the cleanup is a no-op and logs an info message. After deletion, the job updates the existing PR comment (identified by the `<!-- docker-pr-test-image -->` marker) to indicate the image was removed on close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->