### PR TITLE
feat(navico): skip spoke decode in idle mode to free CPU at idle

### DIFF
--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -578,6 +578,8 @@ impl NavicoReportReceiver {
                         // This enables Doppler returns from the HALO radars.
                         self.send_info_packets().await?;
                     }
+                    // Re-evaluate idle mode (Standby + no spoke subscribers).
+                    self.common.info.refresh_idle_flag();
                 },
 
                 r = self.report_socket.as_mut().unwrap().recv_buf_from(&mut self.report_buf)  => {
@@ -611,7 +613,13 @@ impl NavicoReportReceiver {
                 r = self.data_socket.as_mut().unwrap().recv_buf_from(&mut self.data_buf)  => {
                     match r {
                         Ok(_) => {
-                            self.process_frame();
+                            // Drain the socket but skip decoding while idle
+                            // (Standby + no spoke subscribers). The Navico
+                            // spoke decoder is stateless per frame, so no
+                            // delta-buffer reset is needed on wake-up.
+                            if !self.common.info.is_idle() {
+                                self.process_frame();
+                            }
                             self.data_buf.clear();
                         },
                         Err(e) => {
@@ -860,6 +868,12 @@ impl NavicoReportReceiver {
                 bail!("{}: Unknown radar status {}", self.common.key, status);
             }
         };
+        // An external power-on (another MFD, the radar's own button) must
+        // resume decoding on the next frame rather than waiting for the
+        // periodic idle re-check.
+        if status != Power::Standby {
+            self.common.info.wake_up();
+        }
         self.common
             .set_value(&ControlId::Power, status as i32 as f64);
         Ok(())


### PR DESCRIPTION
## Why

PR #284 found Furuno radars emit spokes continuously even in Standby, so mayara wasted ~2 cores decoding frames nobody was watching. Navico's data loop has the same shape — `process_frame` decodes every frame with no idle gating. If Navico radars also emit in Standby, the same waste applies.

## How

Reuses the brand-agnostic idle gate from #321:
- Gate `process_frame` on the shared `is_idle` flag — drain the data socket but skip decoding while Standby AND no spoke subscribers.
- Refresh the flag on the existing report-request tick.
- Wake on a non-Standby power transition so an external power-on (another MFD, the radar's button) resumes decoding on the next frame. The web layer already wakes on spoke-WS subscribe and control PUT.

The Navico spoke decoder is stateless per frame, so no delta-buffer reset is needed on wake-up.

**Safe by design:** if a Navico radar stops emitting spokes in Standby, the gate never triggers and is a harmless no-op.

## Testing

Builds clean, `cargo test` passes (268 + 15). I do not have a Navico radar to measure idle CPU. **Testers with a Navico (HALO/3G/4G) radar:** please report mayara's CPU with the radar in Standby and no GUI/WS client connected, before and after this change, and confirm the PPI still appears instantly when you open the viewer or start transmitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Skips Navico spoke decoding in idle mode to reduce CPU usage when the radar is in Standby with no active spoke subscribers.

The implementation adds three key changes to `src/lib/brand/navico/report.rs`:

1. **Idle flag refresh**: The periodic timeout branch in `socket_loop` now calls `self.common.info.refresh_idle_flag()` on each timer wake-up to re-evaluate whether the radar is idle (Standby + no spoke subscribers).

2. **Conditional frame decoding**: The data socket receive arm drains incoming UDP frames but skips decoding by only calling `self.process_frame()` when `!self.common.info.is_idle()`. The Navico spoke decoder is stateless per frame, so no delta-buffer reset is required when decoding resumes.

3. **Wake-up on power transition**: The `set_status` method calls `self.common.info.wake_up()` whenever the new power status is not `Power::Standby`, ensuring decoding resumes immediately on external power-on rather than waiting for the next idle re-check.

This reuses the brand-agnostic idle gate from PR `#321` and complements existing wake-on-subscribe and wake-on-control behavior at the web layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->