### PR TITLE
feat(raymarine): skip spoke decode in idle mode to free CPU at idle

### DIFF
--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -290,6 +290,12 @@ impl RaymarineReportReceiver {
         }
         log::trace!("{}: UDP report {:02X?}", self.common.key, data);
 
+        // Spokes and status share this socket, so refresh idle state here
+        // (reports arrive regularly) and gate only the spoke arms below —
+        // status reports must keep flowing so control state stays current.
+        self.common.info.refresh_idle_flag();
+        let idle = self.common.info.is_idle();
+
         let id = u32::from_le_bytes(data[0..4].try_into().unwrap());
         match id {
             // RD (magnetron) messages
@@ -299,8 +305,12 @@ impl RaymarineReportReceiver {
             0x010002 => {
                 rd::process_fixed_report(self, data);
             }
-            0x010003 => {
+            0x010003 if !idle => {
                 rd::process_frame(self, data);
+            }
+            0x010003 => {
+                // Idle: drain the RD spoke frame without decoding. The decoder
+                // is stateless per frame, so no buffer reset is needed on wake.
             }
             0x010006 => {
                 rd::process_info_report(self, data);
@@ -312,8 +322,11 @@ impl RaymarineReportReceiver {
             0x280002 => {
                 quantum::process_status_report(self, data);
             }
-            0x280003 => {
+            0x280003 if !idle => {
                 quantum::process_frame(self, data);
+            }
+            0x280003 => {
+                // Idle: drain the Quantum spoke frame without decoding.
             }
             0x288942 => {
                 // Database report — not spoke data. Ignore.

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -215,6 +215,11 @@ pub(super) fn process_status_report(receiver: &mut RaymarineReportReceiver, data
             Power::Standby // Default to Standby if unknown
         }
     };
+    // Resume decoding immediately on an external power-on rather than waiting
+    // for the next idle re-check.
+    if status != Power::Standby {
+        receiver.common.info.wake_up();
+    }
     receiver
         .common
         .set_value(&ControlId::Power, status as i32 as f64);

--- a/src/lib/brand/raymarine/report/rd.rs
+++ b/src/lib/brand/raymarine/report/rd.rs
@@ -387,6 +387,11 @@ pub(super) fn process_status_report(receiver: &mut RaymarineReportReceiver, data
             Power::Standby // Default to Standby if unknown
         }
     };
+    // Resume decoding immediately on an external power-on rather than waiting
+    // for the next idle re-check.
+    if status != Power::Standby {
+        receiver.common.info.wake_up();
+    }
     receiver
         .common
         .set_value(&ControlId::Power, status as i32 as f64);


### PR DESCRIPTION
## Why

PR #284 found Furuno radars emit spokes continuously even in Standby, wasting CPU decoding frames nobody watches. Raymarine RD and Quantum decode every spoke frame with no idle gating, so the same waste likely applies.

## How

Reuses the brand-agnostic idle gate from #321. Unlike the other brands, Raymarine multiplexes spokes and status reports on the **same** socket, so the gate sits **inside** `process_report`'s spoke arms (`0x010003` RD, `0x280003` Quantum) rather than around the socket recv — status/info reports keep flowing so control state stays current.

- Refresh the idle flag at the top of `process_report` (reports arrive regularly).
- Skip the two spoke arms while idle (Standby AND no spoke subscribers).
- Wake on a non-Standby power transition in both the RD and Quantum `process_status_report` paths. The web layer already wakes on spoke-WS subscribe and control PUT.

Both decoders are stateless per frame, so no delta-buffer reset is needed on wake-up.

**Safe by design:** if a Raymarine radar stops emitting spokes in Standby, the gate never triggers and is a harmless no-op.

## Testing

Builds clean, `cargo test` passes (268 + 15). I do not have a Raymarine radar to measure idle CPU. **Testers with a Raymarine (RD/HD or Quantum) radar:** please report mayara's CPU with the radar in Standby and no GUI/WS client connected, before and after this change, and confirm the PPI still appears instantly when you open the viewer or start transmitting, and that controls still update in Standby.