### PR TITLE
feat(garmin): skip spoke decode in idle mode to free CPU at idle

### DIFF
--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -418,6 +418,15 @@ impl GarminReportReceiver {
             bail!("Report too short: {} bytes", data.len());
         }
 
+        // Reports arrive regularly, so refresh idle state here rather than on a
+        // separate timer. The web layer wakes us on spoke subscribe, so a late
+        // entry into idle only wastes a little CPU briefly — never blanks a
+        // viewer.
+        self.common.info.refresh_idle_flag();
+        if let Some(ref cb) = self.common_b {
+            cb.info.refresh_idle_flag();
+        }
+
         let packet_type = u32::from_le_bytes(data[0..4].try_into().unwrap());
         let len = u32::from_le_bytes(data[4..8].try_into().unwrap());
 
@@ -614,9 +623,28 @@ impl GarminReportReceiver {
         Ok(())
     }
 
+    /// True when every range is idle (Standby + no spoke subscribers), so the
+    /// data loop can drain the socket without decoding. An active Range B keeps
+    /// the radar non-idle even if Range A is idle.
+    fn both_ranges_idle(&self) -> bool {
+        self.common.info.is_idle()
+            && self
+                .common_b
+                .as_ref()
+                .map(|cb| cb.info.is_idle())
+                .unwrap_or(true)
+    }
+
     fn process_data(&mut self, data: &[u8]) -> Result<(), Error> {
         if data.len() < SPOKE_HEADER_SIZE {
             bail!("Data too short: {} bytes", data.len());
+        }
+
+        // Drain the socket but skip decoding while every range is idle. The
+        // Garmin spoke decoder is stateless per frame, so no delta-buffer
+        // reset is needed on wake-up.
+        if self.both_ranges_idle() {
+            return Ok(());
         }
 
         // In dual-range mode, the range indicator at data[24] selects
@@ -639,6 +667,11 @@ impl GarminReportReceiver {
     }
 
     fn process_hd_spoke(&mut self, data: &[u8]) -> Result<(), Error> {
+        // HD radars carry spokes on the report port, so this is gated here
+        // rather than in process_data. Skip decoding while idle.
+        if self.both_ranges_idle() {
+            return Ok(());
+        }
         if data.len() < HD_SPOKE_HEADER_SIZE + 4 {
             bail!("HD spoke packet too short: {} bytes", data.len());
         }
@@ -815,6 +848,9 @@ impl GarminReportReceiver {
             HD_STATE_SPINNING_UP => Power::Preparing,
             _ => Power::Off,
         };
+        if power != Power::Standby {
+            self.common.info.wake_up();
+        }
         self.common
             .set_value(&ControlId::Power, power as i32 as f64);
 
@@ -863,6 +899,9 @@ impl GarminReportReceiver {
         } else {
             Power::Standby
         };
+        if power != Power::Standby {
+            self.common.info.wake_up();
+        }
         self.common
             .set_value(&ControlId::Power, power as i32 as f64);
         Ok(())


### PR DESCRIPTION
## Why

PR #284 found Furuno radars emit spokes continuously even in Standby, wasting CPU decoding frames nobody watches. Garmin's data path decodes every spoke with no idle gating, so the same waste likely applies.

## How

Reuses the brand-agnostic idle gate from #321:
- Gate both spoke paths — `process_data` (xHD) and `process_hd_spoke` (HD, which arrives on the report port) — on a `both_ranges_idle()` check.
- Refresh the per-range idle flags from `process_report` (reports arrive regularly, so no separate timer is needed).
- Wake on a non-Standby power transition in both `process_transmit_state` (xHD) and `process_hd_status` (HD). The web layer already wakes on spoke-WS subscribe and control PUT.

The spoke decoder is stateless per frame, so no delta-buffer reset is needed. In dual-range mode the radar stays non-idle unless **both** ranges report Standby — the conservative, correct default.

**Safe by design:** if a Garmin radar stops emitting spokes in Standby, the gate never triggers and is a harmless no-op.

## Testing

Builds clean, `cargo test` passes (268 + 15). I do not have a Garmin radar to measure idle CPU. **Testers with a Garmin (xHD/HD/Fantom) radar:** please report mayara's CPU with the radar in Standby and no GUI/WS client connected, before and after this change, and confirm the PPI still appears instantly when you open the viewer or start transmitting.