### PR TITLE
feat: surface upstream nav/token/AIS status in the radar GUI

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -264,6 +264,11 @@ impl Web {
 struct Endpoints {
     endpoints: HashMap<String, Endpoint>,
     server: Server,
+    /// mayara-specific upstream-navigation health, so a GUI can surface why
+    /// own-ship position / AIS may be missing. Not part of the Signal K spec;
+    /// ignored by standard clients.
+    #[schema(value_type = Object)]
+    nav: mayara::navdata::NavStatus,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -544,6 +549,7 @@ async fn endpoints(State(state): State<Web>, headers: hyper::header::HeaderMap) 
             version: VERSION,
             id: PACKAGE,
         },
+        nav: mayara::navdata::nav_status(&state.args),
     };
     endpoints.endpoints.insert(
         "v2".to_string(),

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -43,6 +43,29 @@ static SOG: AtomicF64 = AtomicF64::new(f64::NAN);
 /// Broadcast sender for navigation updates to GUI clients
 static NAV_BROADCAST_TX: OnceLock<tokio::sync::broadcast::Sender<SignalKDelta>> = OnceLock::new();
 
+/// Wall-clock-ish timestamp (a process `Instant`) of the last own-ship
+/// navigation update (heading or position) received from the upstream. Used
+/// to report freshness on `/signalk` so a GUI can tell a live heading from a
+/// frozen last-known value left behind when the upstream connection dropped
+/// (e.g. a revoked token). `None` until the first own-ship nav arrives.
+static LAST_OWN_SHIP_NAV: OnceLock<std::sync::Mutex<Option<std::time::Instant>>> = OnceLock::new();
+
+fn mark_own_ship_nav_fresh() {
+    let lock = LAST_OWN_SHIP_NAV.get_or_init(|| std::sync::Mutex::new(None));
+    if let Ok(mut guard) = lock.lock() {
+        *guard = Some(std::time::Instant::now());
+    }
+}
+
+/// Seconds since the last own-ship nav update, or `None` if none has ever
+/// arrived. A large value means the upstream stopped delivering (frozen nav).
+pub fn own_ship_nav_age_secs() -> Option<u64> {
+    LAST_OWN_SHIP_NAV
+        .get()
+        .and_then(|lock| lock.lock().ok())
+        .and_then(|guard| guard.map(|t| t.elapsed().as_secs()))
+}
+
 /// Initialize the navigation broadcast sender (called once at startup)
 pub fn init_nav_broadcast(tx: tokio::sync::broadcast::Sender<SignalKDelta>) {
     let _ = NAV_BROADCAST_TX.set(tx);
@@ -145,12 +168,24 @@ pub struct NavStatus {
     /// A Signal K bearer token is configured (so the AIS REST snapshot can be
     /// fetched). Only meaningful for `ws`/`wss`/`mdns` transports.
     pub token_present: bool,
-    /// Own-ship position has been received from the upstream — the clearest
-    /// signal that navigation deltas are actually flowing.
+    /// Own-ship position is currently known. Cleared when the upstream
+    /// disconnects, so this reflects live state, not "ever seen".
     pub have_position: bool,
+    /// Seconds since the last own-ship nav update, or `null` if none has
+    /// arrived (or it was cleared on disconnect). A large value paired with
+    /// `have_position: false` is the signature of a dropped/revoked upstream.
+    pub nav_age_seconds: Option<u64>,
+    /// Whether own-ship nav is considered live (fresh within
+    /// `NAV_STALE_AFTER_SECS`). `false` means the GUI is showing — or has
+    /// dropped — a frozen value because the upstream stopped delivering.
+    pub nav_live: bool,
     /// Number of AIS targets currently held in the store.
     pub ais_count: usize,
 }
+
+/// Own-ship nav older than this is considered stale. Upstream nav normally
+/// arrives every 0.2–1 s; a multi-second gap means the source stopped.
+const NAV_STALE_AFTER_SECS: u64 = 10;
 
 /// Assemble the current navigation status from process-wide state. Lives in
 /// the library so it can read the crate-private token accessor; the binary
@@ -176,10 +211,13 @@ pub fn nav_status(args: &Cli) -> NavStatus {
     };
 
     let (lat, lon) = get_position();
+    let nav_age_seconds = own_ship_nav_age_secs();
     NavStatus {
         transport,
         token_present: crate::signalk::get_signalk_token().is_some(),
         have_position: lat.is_some() && lon.is_some(),
+        nav_age_seconds,
+        nav_live: nav_age_seconds.is_some_and(|age| age < NAV_STALE_AFTER_SECS),
         ais_count: get_ais_store()
             .map(|s| s.get_all_active().len())
             .unwrap_or(0),
@@ -366,6 +404,7 @@ pub(crate) fn set_heading_true(heading: Option<f64>, source: &str) {
         }
         let h = h.rem_euclid(TAU);
 
+        mark_own_ship_nav_fresh();
         let old = HEADING_TRUE.swap(h, Ordering::AcqRel);
         // Only broadcast if value changed significantly (> 0.001 rad ~ 0.06 deg)
         if (old - h).abs() > 0.001 || old.is_nan() {
@@ -476,6 +515,7 @@ pub fn get_position() -> (Option<f64>, Option<f64>) {
 pub(crate) fn set_position(lat: Option<f64>, lon: Option<f64>, source: &str) {
     if let (Some(lat), Some(lon)) = (lat, lon) {
         log::trace!("navdata::set_position(lat={}, lon={})", lat, lon);
+        mark_own_ship_nav_fresh();
         let old_lat = POSITION_LAT.swap(lat, Ordering::AcqRel);
         let old_lon = POSITION_LON.swap(lon, Ordering::AcqRel);
         let was_valid = POSITION_VALID.swap(true, Ordering::AcqRel);
@@ -491,6 +531,28 @@ pub(crate) fn set_position(lat: Option<f64>, lon: Option<f64>, source: &str) {
     } else {
         POSITION_VALID.store(false, Ordering::Release);
         return;
+    }
+}
+
+/// Drop the last-known own-ship heading and position when the upstream
+/// navigation source disconnects, so the GUI shows "no data" rather than a
+/// frozen value that silently drifts from reality (e.g. after a revoked
+/// token kills the WS). Only own-ship nav is cleared; AIS targets age out on
+/// their own timeout. Resets the freshness clock too. Skips the clear when no
+/// own-ship nav was ever received, so a transport that never carried nav
+/// (e.g. anonymous tcp on a hidden-vessels server) doesn't churn broadcasts.
+pub(crate) fn clear_own_ship_nav() {
+    if own_ship_nav_age_secs().is_none() {
+        return;
+    }
+    set_heading_true(None, "disconnect");
+    set_position(None, None, "disconnect");
+    set_cog(None);
+    set_sog(None);
+    if let Some(lock) = LAST_OWN_SHIP_NAV.get() {
+        if let Ok(mut guard) = lock.lock() {
+            *guard = None;
+        }
     }
 }
 
@@ -776,6 +838,11 @@ impl NavigationData {
         if matches!(result, Err(RadarError::Shutdown)) {
             return;
         }
+        // The upstream dropped (network drop, server restart, or a revoked
+        // token rejected on reconnect). Drop the last-known own-ship heading
+        // and position so the GUI shows "no data" instead of a frozen value
+        // that keeps drifting from reality until the connection comes back.
+        clear_own_ship_nav();
         let delivered = SIGNALK_DELIVERED_DATA.swap(false, std::sync::atomic::Ordering::SeqCst);
         let own_ship = SIGNALK_OWN_SHIP_NAV_SEEN.swap(false, std::sync::atomic::Ordering::SeqCst);
         if own_ship {
@@ -1685,6 +1752,41 @@ mod tests {
             assert!(parsed_ok, "ConnectionType::parse changed for {scheme}");
             // ...and nav_status must map it to the matching string.
             assert_eq!(nav_status(&cli(&["-n", &arg])).transport, expected);
+        }
+    }
+
+    // ----- nav freshness / staleness (revoked-token / dropped upstream) -----
+
+    // These exercise process-global nav state. nav_status reads shared atomics
+    // that other tests also write, so assertions are kept to facts that hold
+    // regardless of parallel writers (freshness is monotonic right after a set;
+    // a clear drops the freshness clock) rather than global absence.
+
+    #[test]
+    fn marking_nav_fresh_makes_it_live() {
+        // Receiving own-ship nav stamps the freshness clock: age is small and
+        // nav_live is true. (Safe under parallelism: a set can only make nav
+        // *fresher*, never staler, between the set and the read.)
+        set_heading_true(Some(1.0), "test");
+        let age = own_ship_nav_age_secs();
+        assert!(
+            age.is_some_and(|a| a < NAV_STALE_AFTER_SECS),
+            "age should be fresh right after a set, got {age:?}"
+        );
+        assert!(
+            nav_status(&cli(&["-n", "ws:127.0.0.1:80"])).nav_live,
+            "nav should be live right after an update"
+        );
+    }
+
+    #[test]
+    fn nav_status_includes_freshness_fields() {
+        // The /signalk contract: nav_age_seconds + nav_live are always present.
+        // nav_live must be false whenever age is unknown or beyond the cutoff.
+        let s = nav_status(&cli(&["-n", "tcp:127.0.0.1:8375"]));
+        match s.nav_age_seconds {
+            None => assert!(!s.nav_live, "no age must mean not live"),
+            Some(age) => assert_eq!(s.nav_live, age < NAV_STALE_AFTER_SECS),
         }
     }
 

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -1663,6 +1663,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn nav_transport_stays_in_sync_with_connection_type() {
+        // nav_status derives its transport string independently of
+        // ConnectionType::parse (deliberately — parse() panics on an unknown
+        // scheme, which a status endpoint must not do). This guard pins the
+        // two scheme sets together so adding a scheme to one without the other
+        // fails here. ConnectionType variant -> expected nav_status string.
+        let addr = "127.0.0.1:80";
+        for (scheme, expected) in [("tcp", "tcp"), ("udp", "udp"), ("ws", "ws"), ("wss", "wss")] {
+            let arg = format!("{scheme}:{addr}");
+            // parse() must accept the scheme (it would panic otherwise)...
+            let parsed = ConnectionType::parse(&Some(arg.clone()));
+            let parsed_ok = matches!(
+                (scheme, &parsed),
+                ("tcp", ConnectionType::Tcp(_))
+                    | ("udp", ConnectionType::Udp(_))
+                    | ("ws", ConnectionType::Ws(_, false))
+                    | ("wss", ConnectionType::Ws(_, true))
+            );
+            assert!(parsed_ok, "ConnectionType::parse changed for {scheme}");
+            // ...and nav_status must map it to the matching string.
+            assert_eq!(nav_status(&cli(&["-n", &arg])).transport, expected);
+        }
+    }
+
     // ----- reconnect backoff (issue #274 companion to PR #284) -----
 
     #[test]

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -133,6 +133,59 @@ pub fn get_ais_store() -> Option<&'static std::sync::Arc<AisVesselStore>> {
     AIS_STORE.get()
 }
 
+/// Health of mayara's upstream navigation source, surfaced on `/signalk` so a
+/// GUI can tell the operator why own-ship position / AIS may be missing
+/// (most often: an unapproved Signal K device token, so the authenticated
+/// AIS REST seed never runs and the overlay stays empty).
+#[derive(serde::Serialize)]
+pub struct NavStatus {
+    /// Configured upstream transport: `mdns`, `tcp`, `udp`, `ws`, `wss`,
+    /// `nmea0183`, or `static`. Mirrors how the navigation address is parsed.
+    pub transport: &'static str,
+    /// A Signal K bearer token is configured (so the AIS REST snapshot can be
+    /// fetched). Only meaningful for `ws`/`wss`/`mdns` transports.
+    pub token_present: bool,
+    /// Own-ship position has been received from the upstream — the clearest
+    /// signal that navigation deltas are actually flowing.
+    pub have_position: bool,
+    /// Number of AIS targets currently held in the store.
+    pub ais_count: usize,
+}
+
+/// Assemble the current navigation status from process-wide state. Lives in
+/// the library so it can read the crate-private token accessor; the binary
+/// only serializes the result.
+pub fn nav_status(args: &Cli) -> NavStatus {
+    let transport = if args.nmea0183 {
+        "nmea0183"
+    } else if args.static_position.is_some() {
+        "static"
+    } else {
+        match &args.navigation_address {
+            None => "mdns",
+            Some(addr) => match addr.split_once(':') {
+                // Same scheme set ConnectionType::parse accepts; an interface
+                // name (no scheme) restricts mDNS, so it's still discovery.
+                Some(("tcp", _)) => "tcp",
+                Some(("udp", _)) => "udp",
+                Some(("ws", _)) => "ws",
+                Some(("wss", _)) => "wss",
+                _ => "mdns",
+            },
+        }
+    };
+
+    let (lat, lon) = get_position();
+    NavStatus {
+        transport,
+        token_present: crate::signalk::get_signalk_token().is_some(),
+        have_position: lat.is_some() && lon.is_some(),
+        ais_count: get_ais_store()
+            .map(|s| s.get_all_active().len())
+            .unwrap_or(0),
+    }
+}
+
 /// Update AIS vessel data from Signal K message
 fn update_ais_vessel(context: &str, updates: &Value) {
     if let Some(store) = AIS_STORE.get() {
@@ -1563,6 +1616,52 @@ fn signalk_connection_to_stream(conn: crate::signalk::Connection) -> Stream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    fn cli(args: &[&str]) -> Cli {
+        let mut full = vec!["mayara-server"];
+        full.extend_from_slice(args);
+        Cli::parse_from(full)
+    }
+
+    // ----- nav_status transport derivation -----
+
+    #[test]
+    fn nav_transport_defaults_to_mdns() {
+        assert_eq!(nav_status(&cli(&[])).transport, "mdns");
+    }
+
+    #[test]
+    fn nav_transport_reads_scheme_from_navigation_address() {
+        assert_eq!(
+            nav_status(&cli(&["-n", "tcp:127.0.0.1:8375"])).transport,
+            "tcp"
+        );
+        assert_eq!(nav_status(&cli(&["-n", "ws:127.0.0.1:80"])).transport, "ws");
+        assert_eq!(
+            nav_status(&cli(&["-n", "wss:127.0.0.1:443"])).transport,
+            "wss"
+        );
+        assert_eq!(
+            nav_status(&cli(&["-n", "udp:0.0.0.0:2000"])).transport,
+            "udp"
+        );
+    }
+
+    #[test]
+    fn nav_transport_interface_name_is_discovery() {
+        // A bare interface name (no scheme) restricts mDNS, so it's discovery.
+        assert_eq!(nav_status(&cli(&["-n", "eth0"])).transport, "mdns");
+    }
+
+    #[test]
+    fn nav_transport_nmea0183_and_static() {
+        assert_eq!(nav_status(&cli(&["--nmea0183"])).transport, "nmea0183");
+        assert_eq!(
+            nav_status(&cli(&["--static-position", "52.3", "4.9", "45.0"])).transport,
+            "static"
+        );
+    }
 
     // ----- reconnect backoff (issue #274 companion to PR #284) -----
 

--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -133,6 +133,30 @@ div.myr_ppi {
   text-align: center;
 }
 
+/* Non-blocking banner across the top of the PPI, shown when mayara reports
+   its upstream SignalK nav/AIS is unavailable (e.g. an unapproved device
+   token). Auto-clears once the condition resolves. Amber so it reads as a
+   notice, not a hard error, over the green radar aesthetic. */
+.myr_status_banner {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 90%;
+  padding: 8px 14px;
+  background: rgba(60, 40, 0, 0.85);
+  color: #ffcc44;
+  border: 1px solid #ffcc44;
+  border-radius: 6px;
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1.4;
+  text-align: center;
+  z-index: 150;
+  pointer-events: none;
+}
+
 .myr_position_box .myr_pos_label {
   color: #88ff88;
   font-size: 10px;

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -410,7 +410,6 @@ function subscribeToHeading() {
 // that auto-clears once the condition resolves.
 // ---------------------------------------------------------------------------
 
-let statusPollAttempts = 0;
 const STATUS_POLL_OK_MS = 30000; // healthy: re-check occasionally
 const STATUS_POLL_WAIT_MS = 5000; // a banner is showing: re-check sooner
 
@@ -422,6 +421,9 @@ function ensureStatusBanner() {
     banner = document.createElement("div");
     banner.id = "myr_status_banner";
     banner.className = "myr_status_banner";
+    // Announce the message to screen readers when it appears/changes.
+    banner.setAttribute("role", "status");
+    banner.setAttribute("aria-live", "polite");
     banner.style.display = "none";
     container.appendChild(banner);
   }
@@ -473,30 +475,32 @@ function navStatusMessage(nav) {
 }
 
 async function pollUpstreamStatus() {
+  let reachable = false;
   let message = null;
   try {
     const res = await fetch(apiBase("/signalk"), {
       headers: { Accept: "application/json" },
     });
     if (res.ok) {
+      reachable = true;
       const data = await res.json();
       message = navStatusMessage(data?.nav);
     }
   } catch {
-    // Network blip — leave the banner as-is and retry on the next tick.
+    // Network blip — often the same trouble the banner is reporting. Leave
+    // any existing banner as-is rather than clearing it on a failed fetch.
   }
 
-  if (message) {
-    showStatusBanner(message);
-    statusPollAttempts += 1;
-  } else {
-    hideStatusBanner();
-    statusPollAttempts = 0;
+  // Only mutate the banner when we actually heard back from mayara, so a
+  // transient fetch failure doesn't drop an active warning.
+  if (reachable) {
+    if (message) showStatusBanner(message);
+    else hideStatusBanner();
   }
 
-  // Re-check sooner while something is wrong so the banner clears promptly
-  // once the operator approves the request; back off when all is well.
-  const delay = message ? STATUS_POLL_WAIT_MS : STATUS_POLL_OK_MS;
+  // Re-check sooner while something is wrong (or unreachable) so the banner
+  // clears promptly once resolved; back off only when all is well.
+  const delay = message || !reachable ? STATUS_POLL_WAIT_MS : STATUS_POLL_OK_MS;
   setTimeout(pollUpstreamStatus, delay);
 }
 

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -228,6 +228,10 @@ window.onload = async function () {
   // Subscribe to SignalK heading delta (only in SignalK mode)
   subscribeToHeading();
 
+  // Poll mayara's upstream-nav status and surface a banner when own-ship
+  // position / AIS are unavailable (most often an unapproved SignalK token).
+  pollUpstreamStatus();
+
   // Create hamburger menu button and setup controls toggle
   createHamburgerMenu();
 
@@ -392,6 +396,100 @@ function subscribeToHeading() {
     );
     setTimeout(subscribeToHeading, delay);
   };
+}
+
+// ---------------------------------------------------------------------------
+// Upstream-navigation status banner
+//
+// Own-ship position and AIS reach the GUI through mayara's own `/signalk`
+// stream, which mayara relays from its upstream Signal K `-n` connection.
+// When that upstream needs an unapproved device token, mayara runs anonymous
+// (`tcp:`) — nav still flows but the authenticated AIS REST seed is skipped,
+// so the overlay stays empty with no on-screen explanation. We poll the
+// `nav` block mayara reports on `/signalk` and surface a non-blocking banner
+// that auto-clears once the condition resolves.
+// ---------------------------------------------------------------------------
+
+let statusPollAttempts = 0;
+const STATUS_POLL_OK_MS = 30000; // healthy: re-check occasionally
+const STATUS_POLL_WAIT_MS = 5000; // a banner is showing: re-check sooner
+
+function ensureStatusBanner() {
+  let banner = document.getElementById("myr_status_banner");
+  if (!banner) {
+    const container = document.querySelector(".myr_ppi");
+    if (!container) return null;
+    banner = document.createElement("div");
+    banner.id = "myr_status_banner";
+    banner.className = "myr_status_banner";
+    banner.style.display = "none";
+    container.appendChild(banner);
+  }
+  return banner;
+}
+
+function showStatusBanner(message) {
+  const banner = ensureStatusBanner();
+  if (!banner) return;
+  banner.textContent = `⚠ ${message}`;
+  banner.style.display = "block";
+}
+
+function hideStatusBanner() {
+  const banner = document.getElementById("myr_status_banner");
+  if (banner) banner.style.display = "none";
+}
+
+// Map mayara's reported `nav` block to a banner message, or null when nothing
+// needs surfacing. `transport` of `static`/`nmea0183`/`udp` is a deliberate
+// non-Signal-K nav source, so we never nag about a missing token/AIS there.
+function navStatusMessage(nav) {
+  if (!nav) return null;
+  const skTransport =
+    nav.transport === "ws" ||
+    nav.transport === "wss" ||
+    nav.transport === "mdns" ||
+    nav.transport === "tcp";
+  if (!skTransport) return null;
+
+  if (!nav.have_position) {
+    return "No SignalK navigation yet — own-ship position & AIS unavailable.";
+  }
+  // Position is flowing but the authenticated AIS seed needs a token. `tcp:`
+  // can't carry one, and ws/wss without a token means the request is still
+  // pending or was denied.
+  if (!nav.token_present && nav.ais_count === 0) {
+    return "Waiting for SignalK token approval — open Security → Access Requests to enable AIS.";
+  }
+  return null;
+}
+
+async function pollUpstreamStatus() {
+  let message = null;
+  try {
+    const res = await fetch(apiBase("/signalk"), {
+      headers: { Accept: "application/json" },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      message = navStatusMessage(data?.nav);
+    }
+  } catch {
+    // Network blip — leave the banner as-is and retry on the next tick.
+  }
+
+  if (message) {
+    showStatusBanner(message);
+    statusPollAttempts += 1;
+  } else {
+    hideStatusBanner();
+    statusPollAttempts = 0;
+  }
+
+  // Re-check sooner while something is wrong so the banner clears promptly
+  // once the operator approves the request; back off when all is well.
+  const delay = message ? STATUS_POLL_WAIT_MS : STATUS_POLL_OK_MS;
+  setTimeout(pollUpstreamStatus, delay);
 }
 
 // Subscribe to vessels.* on Signal K and aggregate per-MMSI updates into the

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -452,6 +452,14 @@ function navStatusMessage(nav) {
     nav.transport === "tcp";
   if (!skTransport) return null;
 
+  // Upstream nav was once flowing but has gone stale (no fresh deltas) — the
+  // connection dropped or the device token was revoked. mayara clears the
+  // frozen value, so have_position is false; nav_age_seconds being set (not
+  // null) is what distinguishes "we had it and lost it" from "never had it".
+  if (!nav.nav_live && nav.token_present && nav.nav_age_seconds != null) {
+    return "SignalK navigation lost — connection dropped or token revoked. Re-approve in Security → Access Requests.";
+  }
+
   if (!nav.have_position) {
     return "No SignalK navigation yet — own-ship position & AIS unavailable.";
   }


### PR DESCRIPTION
## Summary

A user on an auth-enabled SignalK server (http, port 80) saw the radar render but **no own-ship position and no AIS**, with no on-screen explanation. Root cause: the GUI gets position/AIS from mayara's own `/signalk` stream, which mayara relays from its upstream `-n` connection. With no approved SignalK device token, mayara runs anonymous (`tcp:`) — nav deltas flow but the authenticated AIS REST seed is skipped, so the overlay stays empty. The pending access request sat invisibly in Security → Access Requests.

This makes the condition self-diagnosing (formerly two stacked PRs, now combined per review since they're one logical change):

- **Server (`/signalk`):** adds a `nav` block reporting `transport` (`mdns`/`tcp`/`udp`/`ws`/`wss`/`nmea0183`/`static`), `token_present`, `have_position`, and `ais_count`. Read from existing process-wide state; additive and ignored by standard SignalK clients.
- **GUI:** the viewer polls that `nav` block and shows a non-blocking amber banner — "Waiting for SignalK token approval — open Security → Access Requests to enable AIS" or "No SignalK navigation yet". It auto-clears once position/AIS arrive (5s poll while shown, 30s when healthy) and stays silent for non-SignalK nav sources (`static`/`nmea0183`/`udp`) so standalone setups see no false warning. All URLs go through `apiBase()`, so it works proxied and direct.

The plugin-side auto-recover (re-request the token without a restart) is a separate PR in the plugin repo (#63 there).

## Tested

- `cargo build` + `cargo test --features pcap-replay` (282 lib tests, incl. 5 `nav_status` cases and a drift-guard pinning the transport mapping to `ConnectionType::parse`).
- `node --check` on viewer.js; the built binary embeds and serves the updated GUI; `navStatusMessage` decision logic checked across tcp/ws/static/nmea0183 + healthy/seeding states.
- Ran the binary in `tcp:` mode → `/signalk` reports `nav:{transport:tcp, token_present:false, have_position:false, ais_count:0}`, matching the real unapproved-token state, which maps to the "No SignalK navigation yet" banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds upstream navigation/AIS/token status reporting to mayara's /signalk discovery endpoint. The GUI polls this status block and surfaces non-blocking amber banners when upstream navigation or AIS data is missing or stale (e.g., missing/denied SignalK token, no navigation yet, or stale own-ship nav), and auto-clears when conditions resolve. This exposes a previously silent failure mode where mayara running without an approved SignalK device token skipped AIS REST seeding and left the radar overlay empty with no user-facing explanation.

## Changes

**Backend (src/bin/mayara-server/web/mod.rs)**
- Extends the /signalk endpoints response type to include a new nav field populated from mayara::navdata::nav_status(&state.args).

**Navigation status tracking (src/lib/navdata.rs)**
- Adds pub struct NavStatus (serde-serializable) and pub fn nav_status(&Cli) -> NavStatus to produce a small mayara-specific upstream nav snapshot.
- Fields: transport (mdns/tcp/udp/ws/wss/nmea0183/static), token_present, have_position, ais_count, nav_age_seconds and nav_live (freshness flag).
- Tracks own-ship navigation freshness by stamping on heading/position updates and exposes pub fn own_ship_nav_age_secs() -> Option<u64>.
- Clears freshness on upstream disconnects when appropriate.
- Unit tests cover transport derivation (mdns default, tcp/udp/ws/wss parsing, nmea0183/static overrides), freshness behavior, and nav_status logic.

**Frontend styling (web/gui/layout.css)**
- Adds .myr_status_banner for an absolutely positioned, centered, top-of-viewport amber banner with high z-index and non-interactive styling; includes role=status and aria-live=polite for screen-reader announcement.

**GUI polling and display (web/gui/viewer.js)**
- Polls /signalk to read the nav block and renders context-specific, non-blocking warning banners (examples: "Waiting for SignalK token approval — open Security → Access Requests to enable AIS", "No SignalK navigation yet").
- Uses adaptive polling: rapid checks while a warning or fetch failure exists (5s), slower cadence when healthy (30s). Ensures banner is not hidden on fetch failures.
- Silences banners for non-SignalK sources (static/nmea0183/udp). All URLs use apiBase() to work behind proxies.

## Testing
- cargo build and cargo test --features pcap-replay (tests include nav_status cases and transport-parsing guard).
- JavaScript checked with node --check; manual runs verify /signalk reports expected nav states (e.g., nav:{transport:"tcp", token_present:false, have_position:false, ais_count:0}).

## Compatibility
- The nav block is additive to the /signalk response and is ignored by standard SignalK clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->