### PR TITLE
feat(gui): surface upstream nav/AIS status as a banner

### DIFF
--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -133,6 +133,30 @@ div.myr_ppi {
   text-align: center;
 }
 
+/* Non-blocking banner across the top of the PPI, shown when mayara reports
+   its upstream SignalK nav/AIS is unavailable (e.g. an unapproved device
+   token). Auto-clears once the condition resolves. Amber so it reads as a
+   notice, not a hard error, over the green radar aesthetic. */
+.myr_status_banner {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 90%;
+  padding: 8px 14px;
+  background: rgba(60, 40, 0, 0.85);
+  color: #ffcc44;
+  border: 1px solid #ffcc44;
+  border-radius: 6px;
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1.4;
+  text-align: center;
+  z-index: 150;
+  pointer-events: none;
+}
+
 .myr_position_box .myr_pos_label {
   color: #88ff88;
   font-size: 10px;

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -228,6 +228,10 @@ window.onload = async function () {
   // Subscribe to SignalK heading delta (only in SignalK mode)
   subscribeToHeading();
 
+  // Poll mayara's upstream-nav status and surface a banner when own-ship
+  // position / AIS are unavailable (most often an unapproved SignalK token).
+  pollUpstreamStatus();
+
   // Create hamburger menu button and setup controls toggle
   createHamburgerMenu();
 
@@ -392,6 +396,100 @@ function subscribeToHeading() {
     );
     setTimeout(subscribeToHeading, delay);
   };
+}
+
+// ---------------------------------------------------------------------------
+// Upstream-navigation status banner
+//
+// Own-ship position and AIS reach the GUI through mayara's own `/signalk`
+// stream, which mayara relays from its upstream Signal K `-n` connection.
+// When that upstream needs an unapproved device token, mayara runs anonymous
+// (`tcp:`) — nav still flows but the authenticated AIS REST seed is skipped,
+// so the overlay stays empty with no on-screen explanation. We poll the
+// `nav` block mayara reports on `/signalk` and surface a non-blocking banner
+// that auto-clears once the condition resolves.
+// ---------------------------------------------------------------------------
+
+let statusPollAttempts = 0;
+const STATUS_POLL_OK_MS = 30000; // healthy: re-check occasionally
+const STATUS_POLL_WAIT_MS = 5000; // a banner is showing: re-check sooner
+
+function ensureStatusBanner() {
+  let banner = document.getElementById("myr_status_banner");
+  if (!banner) {
+    const container = document.querySelector(".myr_ppi");
+    if (!container) return null;
+    banner = document.createElement("div");
+    banner.id = "myr_status_banner";
+    banner.className = "myr_status_banner";
+    banner.style.display = "none";
+    container.appendChild(banner);
+  }
+  return banner;
+}
+
+function showStatusBanner(message) {
+  const banner = ensureStatusBanner();
+  if (!banner) return;
+  banner.textContent = `⚠ ${message}`;
+  banner.style.display = "block";
+}
+
+function hideStatusBanner() {
+  const banner = document.getElementById("myr_status_banner");
+  if (banner) banner.style.display = "none";
+}
+
+// Map mayara's reported `nav` block to a banner message, or null when nothing
+// needs surfacing. `transport` of `static`/`nmea0183`/`udp` is a deliberate
+// non-Signal-K nav source, so we never nag about a missing token/AIS there.
+function navStatusMessage(nav) {
+  if (!nav) return null;
+  const skTransport =
+    nav.transport === "ws" ||
+    nav.transport === "wss" ||
+    nav.transport === "mdns" ||
+    nav.transport === "tcp";
+  if (!skTransport) return null;
+
+  if (!nav.have_position) {
+    return "No SignalK navigation yet — own-ship position & AIS unavailable.";
+  }
+  // Position is flowing but the authenticated AIS seed needs a token. `tcp:`
+  // can't carry one, and ws/wss without a token means the request is still
+  // pending or was denied.
+  if (!nav.token_present && nav.ais_count === 0) {
+    return "Waiting for SignalK token approval — open Security → Access Requests to enable AIS.";
+  }
+  return null;
+}
+
+async function pollUpstreamStatus() {
+  let message = null;
+  try {
+    const res = await fetch(apiBase("/signalk"), {
+      headers: { Accept: "application/json" },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      message = navStatusMessage(data?.nav);
+    }
+  } catch {
+    // Network blip — leave the banner as-is and retry on the next tick.
+  }
+
+  if (message) {
+    showStatusBanner(message);
+    statusPollAttempts += 1;
+  } else {
+    hideStatusBanner();
+    statusPollAttempts = 0;
+  }
+
+  // Re-check sooner while something is wrong so the banner clears promptly
+  // once the operator approves the request; back off when all is well.
+  const delay = message ? STATUS_POLL_WAIT_MS : STATUS_POLL_OK_MS;
+  setTimeout(pollUpstreamStatus, delay);
 }
 
 // Subscribe to vessels.* on Signal K and aggregate per-MMSI updates into the


### PR DESCRIPTION
## Summary

Stacked on #326 (base is that branch, so this diff is just the GUI change).

When mayara's upstream SignalK connection has no own-ship position, or no approved device token (so the authenticated AIS REST seed is skipped), the radar viewer showed an empty overlay with no explanation — the exact symptom a user hit on an auth-enabled port-80 server with a pending access request.

The viewer now polls the `nav` block #326 adds to `/signalk` and shows a non-blocking amber banner:

- no own-ship position yet → "No SignalK navigation yet — own-ship position & AIS unavailable."
- position flowing but token pending/denied and no AIS → "Waiting for SignalK token approval — open Security → Access Requests to enable AIS."

The banner auto-clears once position/AIS arrive (it polls every 5s while a banner is up, 30s when healthy), and stays silent for non-SignalK nav sources (`static`/`nmea0183`/`udp`) so standalone setups never see a false warning. All URLs go through `apiBase()` so it works both proxied and direct.

## Tested

- `node --check` on viewer.js; `cargo build` embeds the updated GUI (confirmed the banner code is served at `/gui/viewer.js`).
- Decision logic (`navStatusMessage`) unit-checked across tcp/ws/static/nmea0183 + healthy/seeding states — all correct, including no false banner in standalone mode.
- Ran the built binary in `tcp:` mode; `/signalk` reports `nav:{transport:tcp,token_present:false,have_position:false}`, which maps to the "No SignalK navigation yet" banner.