### PR TITLE
feat(docker): add container healthcheck probing /signalk

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -111,11 +111,14 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        # Force Docker (non-OCI) media types so the image config keeps the
+        # Keep Docker (non-OCI) media types so the image config retains the
         # Dockerfile HEALTHCHECK — the OCI image spec has no healthcheck field,
-        # and buildx defaults multi-platform builds to OCI, which silently
-        # drops it. (Replaces the `push: true` shorthand.)
+        # and buildx defaults multi-platform builds to OCI, dropping it.
+        # `oci-mediatypes=false` sets the manifest format; `provenance: false`
+        # is also required because a provenance attestation forces an OCI image
+        # index regardless, which re-OCIs the whole push. (Replaces `push: true`.)
         outputs: type=image,oci-mediatypes=false,push=true
+        provenance: false
 
     - name: Comment image reference on PR
       uses: actions/github-script@v8

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -109,9 +109,13 @@ jobs:
         context: .
         file: docker/Dockerfile.ci
         platforms: linux/amd64,linux/arm64
-        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        # Force Docker (non-OCI) media types so the image config keeps the
+        # Dockerfile HEALTHCHECK — the OCI image spec has no healthcheck field,
+        # and buildx defaults multi-platform builds to OCI, which silently
+        # drops it. (Replaces the `push: true` shorthand.)
+        outputs: type=image,oci-mediatypes=false,push=true
 
     - name: Comment image reference on PR
       uses: actions/github-script@v8

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,8 +113,11 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        # Force Docker (non-OCI) media types so the image config keeps the
+        # Keep Docker (non-OCI) media types so the image config retains the
         # Dockerfile HEALTHCHECK — the OCI image spec has no healthcheck field,
-        # and buildx defaults multi-platform builds to OCI, which silently
-        # drops it. (Replaces the `push: true` shorthand.)
+        # and buildx defaults multi-platform builds to OCI, dropping it.
+        # `oci-mediatypes=false` sets the manifest format; `provenance: false`
+        # is also required because a provenance attestation forces an OCI image
+        # index regardless, which re-OCIs the whole push. (Replaces `push: true`.)
         outputs: type=image,oci-mediatypes=false,push=true
+        provenance: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,6 +111,10 @@ jobs:
         context: .
         file: docker/Dockerfile.ci
         platforms: linux/amd64,linux/arm64
-        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        # Force Docker (non-OCI) media types so the image config keeps the
+        # Dockerfile HEALTHCHECK — the OCI image spec has no healthcheck field,
+        # and buildx defaults multi-platform builds to OCI, which silently
+        # drops it. (Replaces the `push: true` shorthand.)
+        outputs: type=image,oci-mediatypes=false,push=true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,5 +24,13 @@ RUN apk add --no-cache tini \
 COPY --from=builder /usr/src/mayara-server/target/release/mayara-server /usr/local/bin/mayara-server
 USER mayara
 EXPOSE 6502
+# Probe the always-served, unauthenticated discovery doc so the container
+# reports healthy once mayara's HTTP server is up. Deliberately checks only
+# mayara itself, not the upstream Signal K connection — a boat offline from
+# Signal K still runs a healthy radar server. Uses BusyBox wget (already in
+# the Alpine base; no curl). The in-container port is always 6502 regardless
+# of how Signal K proxies it externally.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD wget -q -O /dev/null http://127.0.0.1:6502/signalk || exit 1
 ENTRYPOINT ["tini", "--"]
 CMD ["mayara-server"]

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -9,5 +9,13 @@ RUN apk add --no-cache tini \
 COPY --chmod=755 build/linux/${TARGETARCH}/mayara-server /usr/local/bin/mayara-server
 USER mayara
 EXPOSE 6502
+# Probe the always-served, unauthenticated discovery doc so the container
+# reports healthy once mayara's HTTP server is up. Deliberately checks only
+# mayara itself, not the upstream Signal K connection — a boat offline from
+# Signal K still runs a healthy radar server. Uses BusyBox wget (already in
+# the Alpine base; no curl). The in-container port is always 6502 regardless
+# of how Signal K proxies it externally.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD wget -q -O /dev/null http://127.0.0.1:6502/signalk || exit 1
 ENTRYPOINT ["tini", "--"]
 CMD ["mayara-server"]


### PR DESCRIPTION
## Summary

The container sits in Podman's `starting` health state forever — `podman ps` shows `Up … (starting)` indefinitely even though the server is fine and serving. Cause: the image declares no `HEALTHCHECK`, but when signalk-container creates it via the docker-compat socket Podman initialises a health state with no probe to advance it, so it never reaches `healthy`.

Add a `HEALTHCHECK` to both Dockerfiles probing the always-served, unauthenticated `/signalk` discovery doc on the in-container port 6502 via BusyBox `wget` (already in the Alpine base — no `curl`, no new dependency). Health reflects mayara's own HTTP server only, **not** the upstream Signal K connection, so a boat offline from Signal K still reports a healthy radar container (upstream nav health is surfaced separately in the GUI).

Works in every topology — standalone serving 6502, or proxied behind Signal K on any port/scheme — because the in-container port is always 6502.

## Tested

- Verified inside the running container: BusyBox `wget` is present and `GET /signalk` returns 200 unauthenticated (exit 0).
- Built the CI image locally in Docker manifest format and confirmed the `HEALTHCHECK` is embedded in the image config (Test/Interval/Timeout/Retries). Note: a plain `podman build` defaults to OCI format and silently drops HEALTHCHECK with a warning — CI's buildx/BuildKit (`docker/build-push-action`) produces a Docker manifest and honors it. Final `starting→healthy` flip to be confirmed on the freshly built PR image.