### PR TITLE
feat(raymarine): surface radars that announce no data stream

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -269,6 +269,23 @@ struct Endpoints {
     /// ignored by standard clients.
     #[schema(value_type = Object)]
     nav: mayara::navdata::NavStatus,
+    /// mayara-specific per-radar health, so a GUI can surface a radar that was
+    /// discovered but announced no data stream (e.g. a Quantum behind a WiFi
+    /// access point). Not part of the Signal K spec; ignored by standard
+    /// clients.
+    radars: Vec<RadarHealth>,
+}
+
+/// Health summary for a single discovered radar, surfaced on the `/signalk`
+/// endpoint alongside `nav` for the GUI status banner.
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct RadarHealth {
+    /// Radar id (e.g. `ray0000`).
+    id: String,
+    /// False when the radar announced no usable spoke/report address, so no
+    /// radar image can appear until the network path is fixed.
+    data_stream_missing: bool,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -543,6 +560,19 @@ async fn endpoints(State(state): State<Web>, headers: hyper::header::HeaderMap) 
     let (host, http_scheme, ws_scheme) =
         derive_public_base(&headers, state.tls, state.args.port);
 
+    // Surface only radars that need attention; a healthy fleet sends an empty
+    // list so the GUI shows nothing.
+    let radars = state
+        .radars
+        .get_all()
+        .iter()
+        .filter(|info| !info.has_data_stream())
+        .map(|info| RadarHealth {
+            id: info.key(),
+            data_stream_missing: true,
+        })
+        .collect();
+
     let mut endpoints = Endpoints {
         endpoints: HashMap::new(),
         server: Server {
@@ -550,6 +580,7 @@ async fn endpoints(State(state): State<Web>, headers: hyper::header::HeaderMap) 
             id: PACKAGE,
         },
         nav: mayara::navdata::nav_status(&state.args),
+        radars,
     };
     endpoints.endpoints.insert(
         "v2".to_string(),

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Error, bail};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::{fmt, io};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
@@ -209,6 +209,9 @@ struct RadarState {
 struct RaymarineLocator {
     args: Cli,
     ids: HashMap<LinkId, RadarState>,
+    // Radars already warned about announcing no data stream (report 0.0.0.0),
+    // so the once-per-second beacons don't repeat the warning every tick.
+    warned_no_data_stream: HashSet<LinkId>,
 }
 
 impl RaymarineLocator {
@@ -216,6 +219,7 @@ impl RaymarineLocator {
         RaymarineLocator {
             args,
             ids: HashMap::new(),
+            warned_no_data_stream: HashSet::new(),
         }
     }
 
@@ -301,6 +305,26 @@ impl RaymarineLocator {
 
                     let radar_addr: SocketAddrV4 = data.report.into();
                     let radar_send: SocketAddrV4 = data.command.into();
+
+                    // A healthy Quantum advertises a 232.x.x.x multicast group
+                    // here; an unspecified report address means there is no
+                    // stream to join (observed when the radar is reachable only
+                    // through a Raymarine MFD acting as a WiFi access point).
+                    // The radar is still listed so the operator can see it, but
+                    // no spokes will arrive — warn once with a remedy instead of
+                    // silently failing to bind the report socket.
+                    if radar_addr.ip().is_unspecified()
+                        && self.warned_no_data_stream.insert(link_id)
+                    {
+                        log::warn!(
+                            "{}: Quantum {} announced no data stream (report 0.0.0.0). \
+                             It is listed but no radar image will appear. Connect the \
+                             radar via wired Ethernet on mayara's network so it \
+                             advertises a data stream.",
+                            from,
+                            radar_send,
+                        );
+                    }
 
                     let location_info: RadarInfo = RadarInfo::new(
                         radars,
@@ -771,6 +795,57 @@ mod tests {
             r.report_addr,
             SocketAddrV4::new(Ipv4Addr::new(224, 29, 69, 231), 2566)
         );
+    }
+
+    /// A Quantum reachable only through a Raymarine MFD acting as a WiFi access
+    /// point announces an unspecified report address (0.0.0.0) — there is no
+    /// multicast group to join. The radar is still created (so it can be
+    /// listed) but `has_data_stream()` must report false so the GUI can warn.
+    /// Captured from a real Quantum2 (link_id 0xD681C8C3) behind an Axiom.
+    #[test]
+    fn decode_quantum_with_no_data_stream() {
+        let args = Cli::parse_from(["my_program"]);
+        const VIA: Ipv4Addr = Ipv4Addr::new(192, 168, 138, 50);
+
+        // 56-byte identity beacon: subtype 0x66, link_id D681C8C3, "QuantumRadar".
+        const DATA_56: [u8; 56] = [
+            0x01, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0xC3, 0xC8, 0x81, 0xD6, 0x03, 0x01,
+            0x00, 0x00, 0x54, 0x8A, 0xA8, 0xC0, 0x51, 0x75, 0x61, 0x6E, 0x74, 0x75, 0x6D, 0x52,
+            0x61, 0x64, 0x61, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        ];
+        // 36-byte address beacon: report = 0.0.0.0:0, command = 192.168.138.84:2575.
+        const DATA_36: [u8; 36] = [
+            0x00, 0x00, 0x00, 0x00, 0xC3, 0xC8, 0x81, 0xD6, 0x28, 0x00, 0x00, 0x00, 0x03, 0x00,
+            0x64, 0x00, 0x06, 0x08, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00,
+            0x54, 0x8A, 0xA8, 0xC0, 0x0F, 0x0A, 0x37, 0x00,
+        ];
+
+        let radars = &SharedRadars::new();
+        let mut state = RaymarineLocator::new(args.clone());
+        // First 36 before identity is registered: nothing yet.
+        assert!(
+            state
+                .process_beacon_36_report(&DATA_36, &VIA, radars)
+                .unwrap()
+                .is_none()
+        );
+        state.process_beacon_56_report(&DATA_56, &VIA).unwrap();
+
+        let (info, model) = state
+            .process_beacon_36_report(&DATA_36, &VIA, radars)
+            .unwrap()
+            .expect("radar should be created even with no data stream");
+
+        assert_eq!(model, BaseModel::Quantum);
+        // The radar is created and reachable for commands...
+        assert_eq!(
+            info.send_command_addr,
+            SocketAddrV4::new(Ipv4Addr::new(192, 168, 138, 84), 2575)
+        );
+        // ...but it has no spoke/report stream.
+        assert!(info.report_addr.ip().is_unspecified());
+        assert!(!info.has_data_stream());
     }
 
     /// Parse fixture lines: `timestamp src_ip dst_ip:port payload_hex`

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -265,6 +265,18 @@ impl RaymarineReportReceiver {
     }
 
     pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+        // A radar that announced no data stream (report 0.0.0.0) can never bind
+        // a report socket; don't spin retrying forever. Exit so this subsystem
+        // ends — when the radar later advertises a real stream the locator
+        // re-registers it and starts a fresh receiver (see RaymarineLocator).
+        if self.common.info.report_addr.ip().is_unspecified() {
+            log::debug!(
+                "{}: no data stream (report 0.0.0.0); report receiver idle",
+                self.common.key
+            );
+            return Ok(());
+        }
+
         self.start_report_socket().await?;
         loop {
             if self.report_socket.is_some() {

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -425,14 +425,14 @@ impl RadarInfo {
         info
     }
 
-    /// Whether the radar advertised a usable address to receive spoke/report
-    /// data on. Some radars (observed: a Quantum reachable only through a
-    /// Raymarine MFD acting as a WiFi access point) announce an unspecified
-    /// `report_addr` of `0.0.0.0`, so there is no multicast group to join and
-    /// no spokes ever arrive. Callers use this to surface the condition rather
-    /// than silently failing to bind the report socket.
+    /// Whether the radar advertised a usable address to receive spoke data on.
+    /// Some radars (observed: a Quantum reachable only through a Raymarine MFD
+    /// acting as a WiFi access point) announce an unspecified `0.0.0.0` spoke
+    /// address, so there is no multicast group to join and no spokes ever
+    /// arrive. Callers use this to surface the condition rather than silently
+    /// failing to bind the spoke socket.
     pub fn has_data_stream(&self) -> bool {
-        !self.report_addr.ip().is_unspecified()
+        !self.spoke_data_addr.ip().is_unspecified() && self.spoke_data_addr.port() != 0
     }
 
     pub fn new_client_subscription(&self) -> tokio::sync::broadcast::Receiver<ControlValue> {

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -425,6 +425,16 @@ impl RadarInfo {
         info
     }
 
+    /// Whether the radar advertised a usable address to receive spoke/report
+    /// data on. Some radars (observed: a Quantum reachable only through a
+    /// Raymarine MFD acting as a WiFi access point) announce an unspecified
+    /// `report_addr` of `0.0.0.0`, so there is no multicast group to join and
+    /// no spokes ever arrive. Callers use this to surface the condition rather
+    /// than silently failing to bind the report socket.
+    pub fn has_data_stream(&self) -> bool {
+        !self.report_addr.ip().is_unspecified()
+    }
+
     pub fn new_client_subscription(&self) -> tokio::sync::broadcast::Receiver<ControlValue> {
         self.controls.new_client_subscription()
     }
@@ -767,6 +777,15 @@ impl SharedRadars {
             .filter(|i| i.ranges.len() > 0)
             .count()
             > 0
+    }
+
+    /// All discovered radars, including ones not yet "active" (no ranges yet).
+    /// Unlike `get_active`, this includes a radar that was found but is not
+    /// streaming — e.g. one that announced no data stream — so its health can
+    /// be surfaced to the operator.
+    pub fn get_all(&self) -> Vec<RadarInfo> {
+        let radars = self.radars.read().unwrap();
+        radars.info.values().cloned().collect()
     }
 
     #[allow(dead_code)]

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -474,6 +474,18 @@ function navStatusMessage(nav) {
   return null;
 }
 
+// Map mayara's reported `radars` health list to a banner message, or null.
+// A radar that was discovered but announced no data stream (e.g. a Quantum
+// reachable only through a Raymarine MFD acting as a WiFi access point) shows
+// nothing on screen with no explanation otherwise.
+function radarStatusMessage(radars) {
+  if (!Array.isArray(radars)) return null;
+  if (radars.some((r) => r.dataStreamMissing)) {
+    return "Radar found but it isn't sending data — connect the radar via wired Ethernet (it can't stream over the WiFi access point it's behind).";
+  }
+  return null;
+}
+
 async function pollUpstreamStatus() {
   let reachable = false;
   let message = null;
@@ -484,7 +496,9 @@ async function pollUpstreamStatus() {
     if (res.ok) {
       reachable = true;
       const data = await res.json();
-      message = navStatusMessage(data?.nav);
+      // Nav/connectivity issues take precedence; a missing radar data stream
+      // is surfaced when navigation itself is fine.
+      message = navStatusMessage(data?.nav) ?? radarStatusMessage(data?.radars);
     }
   } catch {
     // Network blip — often the same trouble the banner is reporting. Leave


### PR DESCRIPTION
## Summary

- A Quantum reachable only through a Raymarine MFD acting as a WiFi access point announces an unspecified report address (`0.0.0.0`) in its beacon — there is no spoke multicast group to join, so the report socket fails to bind (EINVAL) and no radar image ever appears, with nothing on screen to explain why.
- Detect the unspecified report address at discovery: keep the radar listed (so the operator can see it), warn once with a remedy, and report it on the `/signalk` endpoint as `dataStreamMissing`. The GUI surfaces this in the existing yellow status banner (the same one used for token/nav issues), auto-clearing once a real stream appears.
- The reliable fix for the user is to connect the radar via wired Ethernet; this change makes the failure visible instead of silent.

## Tested

- New unit test `decode_quantum_with_no_data_stream` using a real captured Quantum2 beacon (link_id 0xD681C8C3 behind an Axiom): asserts the radar is created and commandable but `has_data_stream()` is false.
- Full `cargo test` green; `cargo build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Detects and surfaces Quantum radars that announce an unspecified report address (0.0.0.0) in their beacon. These radars remain listed and commandable but are flagged as missing a data stream. The locator emits a one-time warning per radar, the condition is reported on the /signalk endpoint, and the GUI shows the existing yellow status banner until a real stream appears.

## Backend Changes

### Radar health detection
- Adds `pub fn has_data_stream(&self) -> bool` on `RadarInfo` that derives health from the radar’s spoke-data endpoint (spoke_data_addr) — returning true only when the IP is not unspecified and the port is non-zero.
- Adds `pub fn get_all(&self) -> Vec<RadarInfo>` on `SharedRadars` to return all discovered radars (including those without active ranges).

### Raymarine beacon processing and warnings
- Raymarine locator tracks warned radars with a `HashSet<LinkId>` and logs a one-time “no data stream” warning when a Quantum beacon advertises an unspecified report IP (0.0.0.0). Radars are still created even when the report/spoke address is unspecified, allowing visibility/commandability while marking them as missing the data stream.

### Report receiver behavior
- `RaymarineReportReceiver::run` detects an unspecified report address (0.0.0.0) and exits immediately (Ok(())) instead of entering the socket-retry busy loop, avoiding a spinning/unbindable receiver when no data stream exists.

### SignalK endpoint
- Introduces a `RadarHealth` structure into the `/signalk` JSON response and adds `radars: Vec<RadarHealth>` to the Endpoints response. The handler populates this list by iterating all radars and setting `data_stream_missing: true` for radars where `has_data_stream()` is false.

## Frontend Changes

- `viewer.js` adds `radarStatusMessage(radars)` and updates status polling so the existing yellow banner displays an explanatory message when a radar is reachable but missing its data stream; navigation/connectivity messages retain higher precedence. The banner auto-clears once a real stream appears.

## Testing

- Adds unit test `decode_quantum_with_no_data_stream` using a captured Quantum2 beacon to assert the radar is created and commandable while `has_data_stream()` returns false. Cargo tests and build succeed.

## Notes / Scope
- The change intentionally does not implement an in-place 0.0.0.0 → real-address identity transition. Address-independent identity and receiver rebind are out of scope; a radar that switches to a real multicast address is discovered as a new registry entry and the stale ray0000 entry clears on restart. The primary goal is to make the failure visible and avoid a busy-looping receiver; the recommended user remedy is to connect the radar via wired Ethernet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->