### PR TITLE
fix(raymarine): correct Quantum interference-rejection byte and gain-value id

### DIFF
--- a/src/lib/brand/raymarine/command/quantum.rs
+++ b/src/lib/brand/raymarine/command/quantum.rs
@@ -62,9 +62,9 @@ pub async fn set_control(
             if auto == 0 {
                 command.send(&cmd).await?;
                 cmd.clear();
-                // Gain value is SetGainValue_t, lead 0x02 0x03 (firmware-verified
-                // against the Axiom MFD). Earlier code used 0x02 0x83, a radar_pi
-                // heritage value that is not a recognised message id.
+                // SetGainValue_t lead is 0x02 0x03 (value in wire byte 5).
+                // Axiom v4.09.167 libSystemFunctions SetThresholdValue@0x1cb4bdc
+                // sends id 02 03 28 00; radar_pi's 0x02 0x83 is not a valid id.
                 one_byte_command(&mut cmd, &[0x02, 0x03], v);
             }
         }
@@ -97,9 +97,10 @@ pub async fn set_control(
         }
         ControlId::InterferenceRejection => {
             // SetInterferenceRejection_t has no channel byte: the level is wire
-            // byte 4, not byte 5. `two_byte_command` writes the value little-endian
-            // so it lands in byte 4 (`one_byte_command` would put it in byte 5,
-            // leaving byte 4 = 0, i.e. always "off").
+            // byte 4. Axiom v4.09.167 libSystemFunctions SetInterferenceRejection
+            // @0x1cb50ac stores it at msg+12 (byte 4); IsValid@0x1cbbe10 bounds
+            // byte 4 < 6. two_byte_command writes the value LE into byte 4
+            // (one_byte_command would leave byte 4 = 0, i.e. always "off").
             two_byte_command(&mut cmd, &[0x11, 0x03], v as u16);
         }
         ControlId::Mode => {

--- a/src/lib/brand/raymarine/command/quantum.rs
+++ b/src/lib/brand/raymarine/command/quantum.rs
@@ -62,7 +62,10 @@ pub async fn set_control(
             if auto == 0 {
                 command.send(&cmd).await?;
                 cmd.clear();
-                one_byte_command(&mut cmd, &[0x02, 0x83], v);
+                // Gain value is SetGainValue_t, lead 0x02 0x03 (firmware-verified
+                // against the Axiom MFD). Earlier code used 0x02 0x83, a radar_pi
+                // heritage value that is not a recognised message id.
+                one_byte_command(&mut cmd, &[0x02, 0x03], v);
             }
         }
         ControlId::ColorGain => {
@@ -93,7 +96,11 @@ pub async fn set_control(
             one_byte_command(&mut cmd, &[0x0f, 0x03], v);
         }
         ControlId::InterferenceRejection => {
-            one_byte_command(&mut cmd, &[0x11, 0x03], v);
+            // SetInterferenceRejection_t has no channel byte: the level is wire
+            // byte 4, not byte 5. `two_byte_command` writes the value little-endian
+            // so it lands in byte 4 (`one_byte_command` would put it in byte 5,
+            // leaving byte 4 = 0, i.e. always "off").
+            two_byte_command(&mut cmd, &[0x11, 0x03], v as u16);
         }
         ControlId::Mode => {
             one_byte_command(&mut cmd, &[0x14, 0x03], v);
@@ -168,4 +175,28 @@ async fn send_no_transmit_cmd(
     cmd.extend_from_slice(&[sector]);
 
     Ok(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{one_byte_command, two_byte_command};
+
+    // Channel commands (gain, sea, rain, range, ...) carry channel in wire byte 4
+    // and the value in byte 5. `one_byte_command` must therefore place the value
+    // in byte 5 (byte 4 = 0).
+    #[test]
+    fn one_byte_command_puts_value_in_byte5() {
+        let mut cmd = Vec::new();
+        one_byte_command(&mut cmd, &[0x05, 0x03], 0x42);
+        assert_eq!(cmd, vec![0x05, 0x03, 0x28, 0x00, 0x00, 0x42, 0x00, 0x00]);
+    }
+
+    // SetInterferenceRejection_t has no channel byte: the level is wire byte 4.
+    // `two_byte_command` writes the value little-endian so it lands in byte 4.
+    #[test]
+    fn two_byte_command_puts_value_in_byte4() {
+        let mut cmd = Vec::new();
+        two_byte_command(&mut cmd, &[0x11, 0x03], 0x05);
+        assert_eq!(cmd, vec![0x11, 0x03, 0x28, 0x00, 0x05, 0x00, 0x00, 0x00]);
+    }
 }

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -394,7 +394,8 @@ pub(super) fn process_info_report(receiver: &mut RaymarineReportReceiver, data: 
 }
 
 pub(super) fn process_doppler_report(receiver: &mut RaymarineReportReceiver, data: &[u8]) {
-    if data.len() < 1 {
+    // The doppler status byte is at offset 4, so we need at least 5 bytes.
+    if data.len() < 5 {
         log::warn!(
             "{}: Invalid data length for quantum doppler report: {}",
             receiver.common.key,


### PR DESCRIPTION
Two firmware-verified fixes to the Quantum command mapping, plus a defensive bound. All three were found by auditing `command/quantum.rs` / `report/quantum.rs` against the Axiom MFD firmware (`libSystemFunctions_armeabi-v7a.so`, v4.09.167), using each `CQuantumMsg<T>::IsValid()` id/payload check and the corresponding sender methods.

Wire layout reminder: `msg+8` = id (`[lead1 lead2 28 00]`), `msg+12` = wire **byte4**, `msg+13` = wire **byte5**.

## 1. Bug: Interference Rejection level in the wrong byte
`SetInterferenceRejection_t` is the only value command with **no channel byte** — its level lives in wire **byte4** (`IsValid` reads `msg+12 < 6`; the MFD sender `SetInterferenceRejection` stores the level at `msg+12`). Every other value command is `byte4 = channel, byte5 = value`, so the generic `one_byte_command` (which writes byte5, leaving byte4 = 0) was wrong here: the radar always received **level 0 (Off)** and the control never stuck (the radar reports its real level back, so it snapped back). Fixed by using `two_byte_command`, which writes the value little-endian into byte4.

## 2. Deviation: gain value used lead `0x02 0x83`
The Axiom MFD sends the user-visible Gain value as `SetGainValue_t` with lead **`0x02 0x03`** (`SetThresholdValue` → `SetGainValue_t`; the "Gain == Threshold" naming quirk). The constant `0x02 0x83 28 00` does not occur anywhere in the firmware. The `0x83` value is radar_pi heritage that happens to work (the radar appears to ignore the high bit), but it doesn't match the MFD. Switched to the firmware-verified `0x02 0x03`.

## 3. Defensive bound: doppler report
`process_doppler_report` reads `data[4]` but only guarded `len >= 1`, so a 1–4 byte packet would panic. Guard raised to `len >= 5`.

## Tests
Added unit tests pinning the byte layout that the IR fix depends on:
- `one_byte_command` → value in byte5 (channel commands)
- `two_byte_command` → value in byte4 (interference rejection)

All existing raymarine tests still pass; `cargo build` clean.

Background analysis: see the firmware reverse-engineering notes in the research repo (radar-wakeup-analysis.md, mayara-command-mapping-review.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Quantum Radar Command and Report Fixes

**Command encoding corrections** (`command/quantum.rs`):
- Gain control now sends with lead bytes `0x02 0x03` (firmware-verified against Axiom MFD) instead of `0x02 0x83`, which was a legacy radar_pi value not recognized by the firmware.
- InterferenceRejection control switches from `one_byte_command` to `two_byte_command`, placing the level value in wire byte 4 rather than byte 5. The `one_byte_command` variant left byte 4 as zero, always sending interference rejection level 0.

**Unit tests** added that verify:
- `one_byte_command` places the value in byte 5 with byte 4 = 0 (for channel commands like gain, sea, rain)
- `two_byte_command` places the value in byte 4 (for interference rejection, which has no channel byte)

**Doppler report validation** (`report/quantum.rs`):
- `process_doppler_report` now validates that incoming data contains at least 5 bytes before reading the doppler status byte at offset 4, preventing potential out-of-bounds access on short packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->