### PR TITLE
docs: correct and expand the server description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,15 @@
 # Mayara Server
 
-Mayara Server is the reference implementation of a [Signal K](https://signalk.org/) radar API server. 
+Mayara Server is the reference implementation of a [Signal K](https://signalk.org/) radar API server.
+
+It is a Rust HTTP/WebSocket server that discovers marine radars (e.g. Navico, Furuno, Raymarine,
+Garmin, Koden) on the network, decodes their proprietary protocols, and exposes them through the Signal K Radar API
+(`/signalk/v2/api/vessels/self/radars/*`), a binary spoke WebSocket per radar, and an embedded
+hand-written JS GUI.
 
 Key components:
 
-- **Core server**: Express-based HTTP/WebSocket server (Rust and JS for the GUI)
+- **Core server**: multi-brand radar discovery and Signal K API exposure (Rust HTTP/WebSocket), with the embedded JS GUI
 
 ## Web GUI (`web/gui/`)
 


### PR DESCRIPTION
Anyone landing in the repo cold reads the AGENTS.md intro first. It called the server "Express-based" — wrong; mayara is an Axum (Rust) server. This corrects that and adds a short orientation paragraph (what it discovers, which brands, which endpoints, the embedded GUI).

Docs only; no code changes.

Per review feedback, the original "Radar status model" section has been split out — it was design intent, not current state, so it belongs in a design doc rather than AGENTS.md. It now lives in #410 (`docs/internals/radar-status.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Corrects AGENTS.md to describe Mayara Server as an Axum (Rust) HTTP/WebSocket service. Adds an orientation paragraph that explains how it discovers and decodes multiple marine radar brands on the network (Navico, Furuno, Raymarine, Garmin), how it exposes them through the Signal K Radar API endpoints (`/signalk/v2/api/vessels/self/radars/*`), how it uses a per-radar WebSocket “spoke,” and how the embedded hand-written JS GUI fits into the system. Updates the “Core server” bullet to match the Axum-based technology wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->