### PR TITLE
feat(raymarine): send WiFi wake nudge to idle Quantum radars

### DIFF
--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -2,6 +2,8 @@ use anyhow::{Error, bail};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use std::{fmt, io};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
 
@@ -205,10 +207,33 @@ struct RadarState {
     model: BaseModel,
 }
 
+/// Witness for "another controller is on the beacon group right now".
+/// Cloned (Arc-shared) into the locator and every Quantum report receiver
+/// so the WiFi wake nudge can stay silent when an MFD (or another mayara)
+/// is already managing the radar. See radar-wakeup-analysis.md path A.
+#[derive(Debug, Default)]
+pub(crate) struct ExternalControllerWitness {
+    last_seen: Mutex<Option<Instant>>,
+}
+
+impl ExternalControllerWitness {
+    pub(crate) fn mark(&self) {
+        *self.last_seen.lock().unwrap() = Some(Instant::now());
+    }
+
+    pub(crate) fn quiet_for(&self, window: Duration) -> bool {
+        match *self.last_seen.lock().unwrap() {
+            None => true,
+            Some(t) => t.elapsed() >= window,
+        }
+    }
+}
+
 #[derive(Clone)]
 struct RaymarineLocator {
     args: Cli,
     ids: HashMap<LinkId, RadarState>,
+    external_seen: Arc<ExternalControllerWitness>,
 }
 
 impl RaymarineLocator {
@@ -216,6 +241,7 @@ impl RaymarineLocator {
         RaymarineLocator {
             args,
             ids: HashMap::new(),
+            external_seen: Arc::new(ExternalControllerWitness::default()),
         }
     }
 
@@ -490,8 +516,13 @@ impl RaymarineLocator {
                 },
             ));
 
-            let report_receiver =
-                report::RaymarineReportReceiver::new(&self.args, info, radars.clone(), base_model);
+            let report_receiver = report::RaymarineReportReceiver::new(
+                &self.args,
+                info,
+                radars.clone(),
+                base_model,
+                self.external_seen.clone(),
+            );
 
             subsys.start(SubsystemBuilder::new(
                 report_name,
@@ -521,6 +552,15 @@ impl RadarLocator for RaymarineLocator {
             report.len()
         );
         log::trace!("{}: printable:     {}", from, PrintableSlice::new(report));
+
+        if from.ip() != nic_addr && is_external_controller_signal(report) {
+            log::debug!(
+                "{}: external Raymarine controller observed (len {})",
+                from,
+                report.len()
+            );
+            self.external_seen.mark();
+        }
 
         match report.len() {
             protocol::beacon36::LEN => {
@@ -555,6 +595,24 @@ impl RadarLocator for RaymarineLocator {
 
     fn clone(&self) -> Box<dyn RadarLocator> {
         Box::new(Clone::clone(self))
+    }
+}
+
+/// True if `report` looks like a packet another Raymarine controller (MFD or
+/// another mayara) would emit on the beacon group: the 16-byte `ABCDEFGHIJKLMNOP`
+/// wake literal, the 102-byte WOL signature, or a 56-byte beacon with the
+/// MFD subtype. Caller is responsible for the "not us" filter on source IP.
+fn is_external_controller_signal(report: &[u8]) -> bool {
+    match report.len() {
+        16 => report == RAYMARINE_WAKE_RADAR,
+        102 => report == RAYMARINE_WOL_RADAR,
+        protocol::beacon56::LEN => {
+            // beacon_type at 0, subtype at 4 (both u32 LE)
+            let beacon_type = u32::from_le_bytes(report[0..4].try_into().unwrap());
+            let subtype = u32::from_le_bytes(report[4..8].try_into().unwrap());
+            beacon_type == 1 && subtype == protocol::beacon56::MFD
+        }
+        _ => false,
     }
 }
 
@@ -858,6 +916,53 @@ mod tests {
             }
         }
         panic!("No radar was created from the pelagia fixture beacons");
+    }
+
+    #[test]
+    fn wake_signals_recognized() {
+        use super::{
+            RAYMARINE_MFD_BEACON, RAYMARINE_WAKE_RADAR, RAYMARINE_WOL_RADAR,
+            is_external_controller_signal,
+        };
+
+        assert!(
+            is_external_controller_signal(&RAYMARINE_WAKE_RADAR),
+            "ABCDEFGHIJKLMNOP should be flagged as an external-controller signal"
+        );
+        assert!(
+            is_external_controller_signal(&RAYMARINE_WOL_RADAR),
+            "WOL signature should be flagged as an external-controller signal"
+        );
+        assert!(
+            is_external_controller_signal(&RAYMARINE_MFD_BEACON),
+            "MFD announcement beacon should be flagged"
+        );
+    }
+
+    #[test]
+    fn radar_beacon_is_not_a_controller_signal() {
+        use super::is_external_controller_signal;
+
+        // A Quantum radar identity beacon (subtype 0x66) must not be confused
+        // with an MFD announcement — only the MFD subtype should mark.
+        let mut radar_beacon = [0u8; protocol::beacon56::LEN];
+        radar_beacon[0..4].copy_from_slice(&1u32.to_le_bytes());
+        radar_beacon[4..8].copy_from_slice(&(protocol::beacon56::QUANTUM).to_le_bytes());
+        assert!(!is_external_controller_signal(&radar_beacon));
+    }
+
+    #[test]
+    fn witness_quiet_until_marked() {
+        use super::ExternalControllerWitness;
+        use std::time::Duration;
+
+        let witness = ExternalControllerWitness::default();
+        assert!(witness.quiet_for(Duration::from_secs(60)));
+        witness.mark();
+        // Just after marking it should not be quiet for any non-zero window.
+        assert!(!witness.quiet_for(Duration::from_secs(60)));
+        // A zero-window query treats "just marked" as already-elapsed and quiet.
+        assert!(witness.quiet_for(Duration::from_secs(0)));
     }
 
     #[test]

--- a/src/lib/brand/raymarine/protocol.rs
+++ b/src/lib/brand/raymarine/protocol.rs
@@ -201,6 +201,14 @@ pub(crate) const HEARTBEAT_QUANTUM_5S: [u8; 36] = [
     0x00, 0x00, 0x00, 0x00,
 ];
 
+/// WiFi-path wake nudge: unicast `10 00 28 00 00 00 00 00` to the radar's
+/// command socket. Derived from `CLNetQuantumRadarSource::SetRadarMode(0)` in
+/// the Axiom MFD firmware (path A in research/raymarine/radar-wakeup-analysis.md).
+/// Byte-identical to `ControlId::Power` → Standby — sending it to a discovered
+/// but idle radar nudges it from sleep into standby without disturbing a radar
+/// that's already in standby. Must NOT be sent to a transmitting radar.
+pub(crate) const WAKE_WIFI: [u8; 8] = [0x10, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00];
+
 /// 1-second keep-alive for RD/E120 (12 bytes, contains "RADAR").
 pub(crate) const HEARTBEAT_RD_1S: [u8; 12] = [
     0x00, 0x80, 0x01, 0x00, 0x52, 0x41, 0x44, 0x41, 0x52, 0x00, 0x00, 0x00,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -1,6 +1,7 @@
 use anyhow::{Error, bail};
 use std::collections::HashMap;
 use std::io;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{Instant, sleep, sleep_until};
 use tokio_graceful_shutdown::SubsystemHandle;
@@ -13,7 +14,7 @@ use crate::radar::range::Ranges;
 use crate::radar::{BYTE_LOOKUP_LENGTH, CommonRadar, Legend, RadarError, RadarInfo, SharedRadars};
 
 // use super::command::Command;
-use super::BaseModel;
+use super::{BaseModel, ExternalControllerWitness};
 use super::command::Command;
 
 mod quantum;
@@ -23,6 +24,21 @@ mod rd;
 // Send the 1-second keep-alive every second, and the 5-second extended
 // keep-alive every 5th cycle.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1000);
+
+// WiFi wake nudge (`10 00 28 00 00 00 00 00`, == Power::Standby) — see
+// research/raymarine/radar-wakeup-analysis.md path A. Sent unicast to the
+// radar's command socket while we have a Quantum discovered but no status
+// report has arrived yet, on WAKE_INTERVAL cadence. Three gates keep us
+// from fighting another controller: base_model == Quantum (only family that
+// uses this id), state == Initial (closes the instant the first status
+// report arrives, so we never push a transmitting radar to standby), and
+// external_seen quiet for EXTERNAL_QUIET_WINDOW (closes the instant an MFD
+// / another mayara announces itself on the beacon group). The initial
+// OBSERVATION_WINDOW delay gives external controllers a chance to be heard
+// before our first nudge.
+const WAKE_INTERVAL: Duration = Duration::from_secs(3);
+const OBSERVATION_WINDOW: Duration = Duration::from_secs(5);
+const EXTERNAL_QUIET_WINDOW: Duration = Duration::from_secs(60);
 
 // The LookupSpokeEnum is an index into an array, really
 enum LookupDoppler {
@@ -102,9 +118,12 @@ pub(crate) struct RaymarineReportReceiver {
     report_socket: Option<RadarSocket>,
     state: ReceiverState,
     model: Option<RaymarineModel>,
+    base_model: BaseModel,
     command_sender: Option<Command>,
     heartbeat_deadline: Instant,
     heartbeat_counter: u32,
+    wake_deadline: Instant,
+    external_seen: Arc<ExternalControllerWitness>,
     reported_unknown: HashMap<u32, bool>,
     features: FeatureFlags,
     features_seen: bool,
@@ -120,6 +139,7 @@ impl RaymarineReportReceiver {
         info: RadarInfo, // Quick access to our own RadarInfo
         radars: SharedRadars,
         base_model: BaseModel,
+        external_seen: Arc<ExternalControllerWitness>,
     ) -> RaymarineReportReceiver {
         let key = info.key();
 
@@ -163,9 +183,12 @@ impl RaymarineReportReceiver {
             report_socket: None,
             state: ReceiverState::Initial,
             model: None, // We don't know this yet, it will be set when we receive the first info report
+            base_model,
             command_sender,
             heartbeat_deadline: now + HEARTBEAT_INTERVAL,
             heartbeat_counter: 0,
+            wake_deadline: now + OBSERVATION_WINDOW,
+            external_seen,
             reported_unknown: HashMap::new(),
             features: FeatureFlags::default(),
             features_seen: false,
@@ -211,6 +234,7 @@ impl RaymarineReportReceiver {
 
         loop {
             let heartbeat_deadline = self.heartbeat_deadline;
+            let wake_deadline = self.wake_deadline;
             tokio::select! {
                 _ = subsys.on_shutdown_requested() => {
                     log::debug!("{}: shutdown", self.common.key);
@@ -218,6 +242,9 @@ impl RaymarineReportReceiver {
                 },
                 _ = sleep_until(heartbeat_deadline) => {
                     self.send_heartbeat().await?;
+                },
+                _ = sleep_until(wake_deadline) => {
+                    self.maybe_send_wake_nudge().await?;
                 },
 
                 r = self.report_socket.as_mut().unwrap().recv_buf_from(&mut buf)  => {
@@ -247,6 +274,35 @@ impl RaymarineReportReceiver {
                 }
             }
         }
+    }
+
+    /// Fire of the wake-nudge timer. Sends the WiFi wake (`10 00 28 00 00…`)
+    /// unicast to the radar's command socket only if:
+    ///   - this is a Quantum (the RD family does not use this command id),
+    ///   - no status report has ever been received (state == Initial),
+    ///   - no external Raymarine controller has been observed within
+    ///     EXTERNAL_QUIET_WINDOW — see [`ExternalControllerWitness`].
+    /// Both base_model and the receiver state are monotonic, so once either
+    /// disqualifies us we silence the arm for the receiver's lifetime; the
+    /// witness gate can re-open and stays on the WAKE_INTERVAL cadence.
+    async fn maybe_send_wake_nudge(&mut self) -> Result<(), RadarError> {
+        if self.base_model != BaseModel::Quantum || self.state != ReceiverState::Initial {
+            self.wake_deadline = Instant::now() + Duration::from_secs(3600);
+            return Ok(());
+        }
+        self.wake_deadline += WAKE_INTERVAL;
+        if !self.external_seen.quiet_for(EXTERNAL_QUIET_WINDOW) {
+            log::debug!(
+                "{}: WiFi wake nudge suppressed — external controller seen recently",
+                self.common.key
+            );
+            return Ok(());
+        }
+        if let Some(ref mut cs) = self.command_sender {
+            log::info!("{}: sending WiFi wake nudge", self.common.key);
+            cs.send(&super::protocol::WAKE_WIFI).await?;
+        }
+        Ok(())
     }
 
     async fn send_heartbeat(&mut self) -> Result<(), RadarError> {


### PR DESCRIPTION
## Summary

Implements path A from `research/raymarine/radar-wakeup-analysis.md`: the unicast `10 00 28 00 00 00 00 00` wake nudge the Axiom MFD sends to discovered-but-idle Quantum radars. The multicast path B (`ABCDEFGHIJKLMNOP` + WOL signature) was already in place via the locator's periodic loop.

## How

A new `ExternalControllerWitness` lives on the `RaymarineLocator` and is cloned into each `RaymarineReportReceiver`. The locator marks the witness whenever it sees a 16-byte `ABCDEFGHIJKLMNOP`, a 102-byte WOL signature, or a 56-byte beacon with the MFD subtype from a source IP that isn't the receiving NIC.

A new timer arm in the receiver's `socket_loop` fires every 3 s after an initial 5 s observation window. It sends `WAKE_WIFI` only when **all** of these hold:

- `base_model == BaseModel::Quantum` (monotonic — if not, silence the arm for life)
- `state == ReceiverState::Initial` (monotonic — closes the instant the first status report arrives, so a transmitting radar is never pushed back to standby)
- witness has been quiet for ≥ 60 s

## Test plan

- [x] `cargo test` — all 11 raymarine tests pass (8 existing + 3 new covering signal detection and witness behaviour)
- [x] Wire-capture cross-check against `hibernat.pcap`: `WAKE_WIFI` const byte-for-byte matches the firmware-derived frame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Implements WiFi wake nudge functionality for idle Quantum radars via unicast transmission. Adds external controller detection to prevent disrupting other active controllers, with a timer-based wake mechanism that respects the device's operational state.

## Implementation

### External Controller Witness (mod.rs)

Introduces `ExternalControllerWitness` to track when other Raymarine controllers manage the radar group. The witness provides:
- `mark()`: Records the current timestamp when an external controller signal is detected
- `quiet_for()`: Checks if no external signals have been observed within a specified window

`RaymarineLocator` initializes a shared witness instance and updates it during packet processing when detecting external controller signatures (wake literal `10 00 28 00 00 00 00 00`, 102-byte WOL signature, or 56-byte MFD-type beacon) from non-local source IPs.

### Wake Command Protocol (protocol.rs)

Defines `WAKE_WIFI` as the 8-byte unicast payload (`10 00 28 00 00 00 00 00`) for nudging sleeping Quantum radars into standby mode.

### Receiver Wake Timer (report.rs)

`RaymarineReportReceiver` implements conditional wake nudge transmission with:
- Initial 5-second observation window before first send
- 3-second interval for subsequent sends
- Send suppression when external controller was active within 60 seconds
- Permanent silencing if radar is not Quantum or transitions out of `ReceiverState::Initial`

Timer integration via `tokio::select!` in the receive loop invokes `maybe_send_wake_nudge()` to evaluate conditions and transmit via the command socket when all criteria are met.

## Testing

All 11 raymarine tests pass (8 existing + 3 new), covering external controller signal detection, witness quiet-window semantics, and verification that non-Quantum beacons are not misclassified. Wire-capture validation against hibernat.pcap confirms payload byte-for-byte accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->