### PR TITLE
feat(navico): surface radar errors and a Fault power state

### DIFF
--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -150,7 +150,7 @@ impl EmulatorReportReceiver {
                             self.common
                                 .set_value(&ControlId::Power, Power::Off as i32 as f64);
                         }
-                        Ok(Power::Preparing) | Err(_) => {}
+                        Ok(Power::Preparing | Power::Fault) | Err(_) => {}
                     }
                 }
             }

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -2,6 +2,7 @@ use anyhow::{Error, bail};
 use num_traits::FromPrimitive;
 use serde::Deserialize;
 use std::cmp::min;
+use std::collections::BTreeSet;
 use std::io;
 use std::mem::transmute;
 use std::net::SocketAddr;
@@ -185,6 +186,13 @@ pub(crate) struct NavicoReportReceiver {
     reported_unknown: [bool; 256],
     reported_setup_ext_oversize: bool,
     has_use_mode_from_ext: bool,
+
+    /// Active radar error codes (NRP eRadarErrorType) from the 0xC611 report.
+    active_errors: BTreeSet<u32>,
+    /// Power state last reported via the 0xC4xx state-mode report, kept so the
+    /// fault override (active errors -> [`Power::Fault`]) can be lifted once the
+    /// errors clear without waiting for the next state-mode report.
+    reported_power: Power,
 
     // For data (spokes)
     data_buf: Vec<u8>,
@@ -416,6 +424,8 @@ impl NavicoReportReceiver {
             reported_unknown: [false; 256],
             reported_setup_ext_oversize: false,
             has_use_mode_from_ext: false,
+            active_errors: BTreeSet::new(),
+            reported_power: Power::Standby,
             data_buf: Vec::with_capacity(size_of::<RadarFramePkt>()),
             data_socket: None,
             doppler: DopplerMode::None,
@@ -762,11 +772,7 @@ impl NavicoReportReceiver {
             if data[1] == 0xc6 {
                 match data[0] {
                     0x11 => {
-                        if data.len() != 3 || data[2] != 0 {
-                            bail!("Strange content of report 0x0a 0xc6: {:02X?}", data);
-                        }
-                        // this is just a response to the MFD sending 0x0a 0xc2,
-                        // not sure what purpose it serves.
+                        return self.process_radar_errors();
                     }
                     _ => {
                         log::trace!("Unknown report 0x{:02x} 0xc6: {:02X?}", data[0], data);
@@ -828,7 +834,7 @@ impl NavicoReportReceiver {
     }
 
     fn set_status(&mut self, status: u8) -> Result<(), Error> {
-        let status = match status {
+        let power = match status {
             0 => Power::Off,
             1 => Power::Standby,
             2 => Power::Transmit,
@@ -837,9 +843,61 @@ impl NavicoReportReceiver {
                 bail!("{}: Unknown radar status {}", self.common.key, status);
             }
         };
-        self.common
-            .set_value(&ControlId::Power, status as i32 as f64);
+        self.reported_power = power;
+        self.publish_power();
         Ok(())
+    }
+
+    /// Publish the effective power state: [`Power::Fault`] while any radar
+    /// error is active, otherwise the last state reported by the radar.
+    fn publish_power(&mut self) {
+        let power = if self.active_errors.is_empty() {
+            self.reported_power
+        } else {
+            Power::Fault
+        };
+        self.common
+            .set_value(&ControlId::Power, power as i32 as f64);
+    }
+
+    /// Process the 0xC611 active-error list report. An empty list means
+    /// "no active errors".
+    fn process_radar_errors(&mut self) -> Result<(), Error> {
+        let active = parse_radar_errors(&self.report_buf)
+            .map_err(|e| anyhow::anyhow!("{}: {}", self.common.key, e))?;
+        self.apply_radar_errors(active);
+        Ok(())
+    }
+
+    /// Diff the newly reported active-error set against the previous one,
+    /// raise/clear a Signal K notification per changed error, and refresh the
+    /// power state so it reflects [`Power::Fault`] while any error is active.
+    fn apply_radar_errors(&mut self, active: BTreeSet<u32>) {
+        if active == self.active_errors {
+            return;
+        }
+        let controls = &self.common.info.controls;
+        for code in active.difference(&self.active_errors) {
+            let name = error_name(*code);
+            match name {
+                Some(name) => {
+                    log::warn!(
+                        "{}: radar error active: {} ({:#x})",
+                        self.common.key,
+                        name,
+                        code
+                    )
+                }
+                None => log::warn!("{}: radar error active: code {:#x}", self.common.key, code),
+            }
+            controls.send_radar_error_notification(*code, name, true);
+        }
+        for code in self.active_errors.difference(&active) {
+            log::info!("{}: radar error cleared: {:#x}", self.common.key, code);
+            controls.send_radar_error_notification(*code, error_name(*code), false);
+        }
+        self.active_errors = active;
+        self.publish_power();
     }
 
     async fn process_state_setup(&mut self) -> Result<(), Error> {
@@ -1370,5 +1428,114 @@ impl NavicoReportReceiver {
         let heading = extract_heading_value(heading).map(|h| h / 2);
 
         Some((range, angle, heading))
+    }
+}
+
+/// Parse the body of a 0xC611 active-error list report into the set of active
+/// NRP `eRadarErrorType` codes. Layout:
+/// `[0x11 0xc6][u8 count][count x u32 errorType (little-endian)]`.
+fn parse_radar_errors(data: &[u8]) -> Result<BTreeSet<u32>, Error> {
+    if data.len() < 3 {
+        bail!("radar error list too short: {:02X?}", data);
+    }
+    let count = data[2] as usize;
+    let expected = 3 + count * 4;
+    if data.len() != expected {
+        bail!(
+            "bad radar error list (count {}, expected len {}, got {}): {:02X?}",
+            count,
+            expected,
+            data.len(),
+            data
+        );
+    }
+    Ok((0..count)
+        .map(|i| {
+            let off = 3 + i * 4;
+            u32::from_le_bytes(data[off..off + 4].try_into().unwrap())
+        })
+        .collect())
+}
+
+/// Human-readable name for an NRP `eRadarErrorType` code, or `None` when the
+/// code is unrecognised. The enum grows in newer firmware and not every code's
+/// name is known, so callers must handle `None` (the raw code is still
+/// surfaced). See `research/navico/radar-error-reporting.md`.
+fn error_name(code: u32) -> Option<&'static str> {
+    Some(match code {
+        0x0_0001 => "Persistence corrupt",
+        0x1_0001 => "Zero bearing fault",
+        0x1_0002 => "Bearing pulse fault",
+        0x1_0003 => "Motor not running",
+        0x1_0004 => "Comms not active",
+        0x1_0005 => "Magnetron heater voltage",
+        0x1_0006 => "Modulation voltage",
+        0x1_0007 => "Trigger fault",
+        0x1_0008 => "Video fault",
+        0x1_0009 => "Fan fault",
+        0x1_000A => "Scanner config fault",
+        0x1_000B => "Power supply transient",
+        0x1_000C => "Scanner detect fail",
+        0x1_000D => "PA soft overheat",
+        0x1_000E => "PA hard overheat",
+        0x1_000F => "Gateway datapath error",
+        0x1_0010 => "PSU overheat",
+        0x1_0011 => "PSU voltage",
+        0x1_0012 => "PSU power",
+        0x1_0013 => "PSU hardware fault",
+        0x1_0014 => "PSU comms fault",
+        0x1_0015 => "Mechanical fault",
+        0x1_0016 => "LED fault",
+        0x1_0017 => "Scanner fail",
+        0x1_0018 => "Radar interface fault",
+        0x1_0019 => "Low battery",
+        0x1_001A => "Motor stall",
+        0x1_001B => "Safety switch",
+        0x1_001C => "Doppler fail",
+        0x1_001D => "Install cache mismatch",
+        0x1_001E => "Tracking unavailable",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{error_name, parse_radar_errors};
+
+    #[test]
+    fn empty_error_list_is_all_clear() {
+        // The healthy steady state seen in every capture: 0xC611 count 0.
+        let active = parse_radar_errors(&[0x11, 0xc6, 0x00]).unwrap();
+        assert!(active.is_empty());
+    }
+
+    #[test]
+    fn parses_active_error_codes() {
+        // count 2: MotorNotRunning (0x10003) and PSUVoltage (0x10011), LE.
+        let data = [
+            0x11, 0xc6, 0x02, 0x03, 0x00, 0x01, 0x00, 0x11, 0x00, 0x01, 0x00,
+        ];
+        let active = parse_radar_errors(&data).unwrap();
+        assert_eq!(active.len(), 2);
+        assert!(active.contains(&0x1_0003));
+        assert!(active.contains(&0x1_0011));
+    }
+
+    #[test]
+    fn rejects_length_mismatch() {
+        // count says 1 but no record bytes follow.
+        assert!(parse_radar_errors(&[0x11, 0xc6, 0x01]).is_err());
+        // truncated below the count byte.
+        assert!(parse_radar_errors(&[0x11, 0xc6]).is_err());
+    }
+
+    #[test]
+    fn known_and_unknown_error_names() {
+        assert_eq!(error_name(0x1_0003), Some("Motor not running"));
+        assert_eq!(error_name(0x0_0001), Some("Persistence corrupt"));
+        assert_eq!(error_name(0x1_001E), Some("Tracking unavailable"));
+        // Codes beyond the known enum (newer firmware) have no name.
+        assert_eq!(error_name(0x1_001F), None);
+        assert_eq!(error_name(0xDEAD), None);
     }
 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -933,12 +933,13 @@ struct Radars {
     tracker_command_tx: Option<mpsc::Sender<TrackerCommand>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Power {
     Off,
     Standby,
     Transmit,
     Preparing,
+    Fault,
 }
 
 impl fmt::Display for Power {
@@ -955,11 +956,13 @@ impl Power {
                 Some(1) => Ok(Power::Standby),
                 Some(2) => Ok(Power::Transmit),
                 Some(3) => Ok(Power::Preparing),
+                Some(4) => Ok(Power::Fault),
                 _ => match n.as_f64() {
                     Some(0.) => Ok(Power::Off),
                     Some(1.) => Ok(Power::Standby),
                     Some(2.) => Ok(Power::Transmit),
                     Some(3.) => Ok(Power::Preparing),
+                    Some(4.) => Ok(Power::Fault),
                     _ => Err(RadarError::ParseJson(format!("Unknown status: {}", s))),
                 },
             },
@@ -968,6 +971,7 @@ impl Power {
                 "1" | "standby" => Ok(Power::Standby),
                 "2" | "transmit" => Ok(Power::Transmit),
                 "3" | "preparing" => Ok(Power::Preparing),
+                "4" | "fault" => Ok(Power::Fault),
                 _ => Err(RadarError::ParseJson(format!("Unknown status: {}", s))),
             },
             _ => Err(RadarError::ParseJson(format!("Unknown status: {}", s))),
@@ -2049,5 +2053,40 @@ mod tests {
         pub(super) fn dummy_is_idle_field() -> Arc<AtomicBool> {
             Arc::new(AtomicBool::new(false))
         }
+    }
+
+    // ----- Power::from_value -----
+
+    #[test]
+    fn power_from_value_parses_fault_variants() {
+        assert_eq!(
+            Power::from_value(&serde_json::json!(4)).unwrap(),
+            Power::Fault
+        );
+        assert_eq!(
+            Power::from_value(&serde_json::json!(4.0)).unwrap(),
+            Power::Fault
+        );
+        assert_eq!(
+            Power::from_value(&serde_json::json!("fault")).unwrap(),
+            Power::Fault
+        );
+        // Case-insensitive matching.
+        assert_eq!(
+            Power::from_value(&serde_json::json!("Fault")).unwrap(),
+            Power::Fault
+        );
+        // Numeric string form, same as the non-Fault states.
+        assert_eq!(
+            Power::from_value(&serde_json::json!("4")).unwrap(),
+            Power::Fault
+        );
+    }
+
+    #[test]
+    fn power_from_value_rejects_unknown_status() {
+        assert!(Power::from_value(&serde_json::json!("faulty")).is_err());
+        assert!(Power::from_value(&serde_json::json!(5)).is_err());
+        assert!(Power::from_value(&serde_json::json!(-1)).is_err());
     }
 }

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -758,7 +758,7 @@ impl SharedControls {
         // All radars must have the same Status control
         new_list(
             ControlId::Power,
-            &["Off", "Standby", "Transmit", "Preparing"],
+            &["Off", "Standby", "Transmit", "Preparing", "Fault"],
         )
         //.send_always()
         .set_valid_values([1, 2].to_vec())
@@ -1151,6 +1151,49 @@ impl SharedControls {
                     cnt
                 );
             }
+        }
+    }
+
+    /// Emit a Signal K `notifications.radar.<id>.error.<code>` alarm for a
+    /// radar-reported error. `active` raises it (Alarm); otherwise it clears
+    /// the prior notification (Normal). `name` is the human-readable error
+    /// name when the code is recognised.
+    pub(crate) fn send_radar_error_notification(
+        &self,
+        code: u32,
+        name: Option<&str>,
+        active: bool,
+    ) {
+        use crate::stream::{NotificationMethod, NotificationState, NotificationValue};
+
+        let locked = self.controls.read().unwrap();
+        let path = format!("notifications.radar.{}.error.{:#x}", locked.radar_id, code);
+        let (state, method, message) = if active {
+            let message = match name {
+                Some(name) => format!("Radar error: {}", name),
+                None => format!("Radar error code {:#x}", code),
+            };
+            (
+                NotificationState::Alarm,
+                vec![NotificationMethod::Visual, NotificationMethod::Sound],
+                message,
+            )
+        } else {
+            (
+                NotificationState::Normal,
+                Vec::new(),
+                format!("Radar error {:#x} cleared", code),
+            )
+        };
+        let value = NotificationValue {
+            state,
+            method,
+            message,
+        };
+        let mut delta = SignalKDelta::new();
+        delta.add_notification_update(&path, value, "mayara");
+        if let Err(e) = locked.sk_client_tx.send(delta) {
+            log::trace!("Failed to broadcast radar error notification: {}", e);
         }
     }
 


### PR DESCRIPTION
## Why

mayara already receives the Navico `0xC611` report — the radar's **active-error list** — but the handler asserted its count byte was always `0` and `bail!`ed otherwise, discarding the one fault report it already sees. A faulting radar was therefore invisible (and noisy in the log).

Background: `research/navico/radar-error-reporting.md` (RE of the NRP protocol, ZEUS SRX `libAndroidRadarService`).

## How

- Parse `0xC611` as `[count][count × u32 errorType]` (`parse_radar_errors`).
- Map each NRP `eRadarErrorType` to an **optional** name — unknown/newer codes pass through with no name, surfaced by their raw code.
- Raise/clear a Signal K `notifications.radar.<id>.error.<code>` per error, mirroring the existing guard-zone notification.
- Add a single `Power::Fault` state (a failed self-test is still a fault), shown while any error is active and lifted when they clear.

Out of scope: Navico SRT `0xC82x` self-test/diagnostics telemetry — no genuine SRT packet appears in any capture, so it's deferred until a real capture exists.

## Test plan

- [x] `cargo test` — 283 pass, incl. new unit tests for `0xC611` parsing (empty/active/malformed) and the code→name lookup.

closes #345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Implements correct parsing and surfacing of Navico NRP active-error report 0xC611, which the prior handler effectively discarded when the report includes active errors. The receiver now extracts the active error set, publishes Signal K notifications per error code, and forces the radar power state into a new Fault power state while any error is active.

## Changes in `src/lib/brand/navico/report.rs`

`NavicoReportReceiver` tracks `active_errors: BTreeSet<u32>` (the current active error codes) and `reported_power: Power` (the last power value reported by the radar). During normal status handling (`set_status`), it:
- maps the radar status byte to a `Power`
- stores it in `reported_power`
- publishes `ControlId::Power` as `Power::Fault` whenever `active_errors` is non-empty; otherwise it publishes `reported_power`

When a 0xC611 packet is received (identified by `data[0] == 0x11` and the radar report subtype already gating `data[1] == 0xc6`), `process_report` routes it to `process_radar_errors()`, which:
- parses the payload via `parse_radar_errors()` using the `[0x11 0xc6][u8 count][count × u32 LE]` layout
- diffs the newly parsed set against the previous `active_errors`
- emits Signal K notifications for newly-active vs cleared codes via `controls.send_radar_error_notification()`
- updates `active_errors` and refreshes the effective power state via `publish_power()`

`parse_radar_errors()` validates the expected structure and length, and `error_name()` maps known NRP error codes to human-readable names while returning `None` for unknown/newer codes so raw codes can still be surfaced.

Unit tests cover 0xC611 parsing for empty lists, active/multi-error lists, malformed/length-mismatch cases, and known-vs-unknown code-to-name mapping.

## Changes in `src/lib/radar/mod.rs`

`Power` gains a new `Fault` variant and derives `Clone`/`Copy`. `Power::from_value` accepts fault values in both numeric and string forms (including `4` and `"fault"`-style inputs).

## Changes in `src/lib/radar/settings.rs`

`ControlId::Power` now accepts `"Fault"`. A new `Controls::send_radar_error_notification(code, name, active)` method emits:
- `Alarm` notifications with visual+sound methods and an error message derived from `name` (or hex code if `name` is unknown) when `active == true`
- `Normal` notifications clearing the prior alarm (with a cleared message and no methods) when `active == false`
- broadcasts the notification deltas via the Signal K client transaction

## Changes in `src/lib/brand/emulator/report.rs`

The emulator treats both `Power::Preparing` and `Power::Fault` as “no-op” power updates in `EmulatorReportReceiver::handle_control_update`, matching the previous behavior for `Preparing`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->