### PR TITLE
feat(gui): show radar notifications and a fault power state

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1730,10 +1730,14 @@ function connectStateStream(streamUrl, radarIdParam) {
               path: `radars.${radarIdParam}.targets.*`,
               policy: "instant",
             },
+            {
+              path: `notifications.radar.${radarIdParam}.*`,
+              policy: "instant",
+            },
           ],
         };
 
-        console.log("Subscribing to radar controls and targets:", subscription);
+        console.log("Subscribing to radar controls, targets and notifications:", subscription);
         ws.send(JSON.stringify(subscription));
       }
     } catch (err) {

--- a/web/gui/layout.css
+++ b/web/gui/layout.css
@@ -266,6 +266,56 @@ div.myr_ppi {
   stroke: #ff4d4d;
 }
 
+.myr_power_lozenge.myr_power_fault .myr_power_lozenge_button {
+  background: #5a1a1a;
+}
+
+.myr_power_lozenge.myr_power_fault .myr_power_icon {
+  stroke: #ff8800;
+}
+
+/* Notification banner (radar errors, guard-zone alarms) */
+.myr_notification_banner {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 100;
+  max-width: 60%;
+  pointer-events: none;
+}
+
+.myr_notification {
+  background: rgba(0, 0, 0, 0.8);
+  border: 2px solid #886;
+  border-radius: 8px;
+  padding: 4px 12px;
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 13px;
+  font-weight: bold;
+  color: #fff;
+  text-align: center;
+}
+
+.myr_notification_alert {
+  border-color: #ffff4d;
+  color: #ffff99;
+}
+
+.myr_notification_warn {
+  border-color: #ffaa33;
+  color: #ffcc66;
+}
+
+.myr_notification_alarm,
+.myr_notification_emergency {
+  border-color: #ff4d4d;
+  color: #ff8888;
+}
+
 /* User name display */
 .myr_power_lozenge_name {
   display: flex;

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -244,6 +244,9 @@ window.onload = async function () {
   // Create power lozenge
   createPowerLozenge();
 
+  // Create the notification banner (radar errors, guard-zone alarms)
+  createNotificationBanner();
+
   // Create speaker lozenge (audio alerts toggle)
   createSpeakerLozenge();
 
@@ -1114,6 +1117,7 @@ function updatePowerLozenge(powerState, userName) {
       "myr_power_standby",
       "myr_power_off",
       "myr_power_disconnected",
+      "myr_power_fault",
     );
     if (powerState === "transmit") {
       lozenge.classList.add("myr_power_transmit");
@@ -1121,6 +1125,8 @@ function updatePowerLozenge(powerState, userName) {
       lozenge.classList.add("myr_power_standby");
     } else if (powerState === "disconnected") {
       lozenge.classList.add("myr_power_disconnected");
+    } else if (powerState === "fault") {
+      lozenge.classList.add("myr_power_fault");
     } else {
       lozenge.classList.add("myr_power_off");
     }
@@ -1131,6 +1137,63 @@ function updatePowerLozenge(powerState, userName) {
     if (nameDisplay) {
       nameDisplay.textContent = userName || "Radar";
     }
+  }
+}
+
+// Active Signal K notifications, keyed by their full path. Each value is
+// { state, message }; an entry exists only while the alarm is active.
+const activeNotifications = new Map();
+
+// Create the notification banner (top-centre of the viewer).
+function createNotificationBanner() {
+  const container = document.querySelector(".myr_ppi");
+  if (!container) return;
+
+  const banner = document.createElement("div");
+  banner.id = "myr_notification_banner";
+  banner.className = "myr_notification_banner";
+  banner.style.display = "none";
+  container.appendChild(banner);
+}
+
+// Drop every active notification and hide the banner. Called on disconnect
+// and on radar (re)selection so stale alarms from a prior context never
+// leak into a fresh one.
+function clearNotifications() {
+  activeNotifications.clear();
+  updateNotificationBanner();
+}
+
+// Update the active-notification set from a Signal K notification delta and
+// redraw the banner. A missing value or `state === "normal"` clears the entry.
+function handleNotification(path, value) {
+  if (!value || value.state === undefined || value.state === "normal") {
+    activeNotifications.delete(path);
+  } else {
+    activeNotifications.set(path, {
+      state: value.state,
+      message: value.message || path,
+    });
+  }
+  updateNotificationBanner();
+}
+
+function updateNotificationBanner() {
+  const banner = document.getElementById("myr_notification_banner");
+  if (!banner) return;
+
+  banner.replaceChildren();
+  if (activeNotifications.size === 0) {
+    banner.style.display = "none";
+    return;
+  }
+
+  banner.style.display = "flex";
+  for (const { state, message } of activeNotifications.values()) {
+    const item = document.createElement("div");
+    item.className = `myr_notification myr_notification_${state}`;
+    item.textContent = message;
+    banner.appendChild(item);
   }
 }
 
@@ -1534,6 +1597,7 @@ var pendingRadarData = null;
 
 // r contains id, name, capabilities and spokeDataUrl
 function radarLoaded(r) {
+  clearNotifications();
   capabilities = r.capabilities;
   let maxSpokeLength = capabilities.maxSpokeLength;
   let spokesPerRevolution = capabilities.spokesPerRevolution;
@@ -1662,6 +1726,7 @@ function controlUpdate(controlId, value) {
     let powerState;
     if (value.value === "disconnected") {
       powerState = "disconnected";
+      clearNotifications();
       for (const targetId of knownTargets) {
         ppi.removeTarget(targetId);
       }
@@ -1718,6 +1783,13 @@ const knownTargets = new Set();
 
 // Handle stream messages (targets, navigation, etc.)
 function handleStreamMessage(path, value) {
+  // Handle Signal K notifications: notifications.radar.{id}.{kind}.{n}
+  // (radar errors, guard-zone alarms). state "normal" clears the entry.
+  if (path.startsWith("notifications.")) {
+    handleNotification(path, value);
+    return;
+  }
+
   // Handle target updates: radars.{id}.targets.{targetId}
   if (path.includes(".targets.")) {
     const parts = path.split(".");


### PR DESCRIPTION
## Why

The viewer subscribed only to `radars.<id>.controls.*` and `…targets.*`, so Signal K `notifications.*` deltas — radar errors (#345) and the existing guard-zone alarms — were delivered to Signal K but never shown in mayara's own GUI.

## How

- Subscribe to `notifications.radar.<id>.*` on the state stream.
- Track active alarms by path (an entry is cleared when its `state` becomes `normal`) and render them in a severity-coloured banner at the top of the viewer.
- Give the power lozenge a distinct `fault` style so the `Power::Fault` state added in #346 reads as a fault, not "off".

This stands alone: guard-zone alarms surface in the GUI immediately; radar-error alarms follow once #346 merges. Relates to #345.

## Test plan

- [x] `cargo build` re-embeds the GUI; `cargo test` — 279 pass.
- [x] `node --check` on the changed JS.

Manual verification against a live/replayed radar (banner appears on a guard-zone alarm, clears on normal; lozenge turns fault-coloured) still to be done on hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds radar notification display to the GUI viewer and introduces a distinct visual state for power faults.

## Changes

### Notification subscription & handling
- Extends the Signal K WebSocket subscription in `web/gui/control.js` to include `notifications.radar.<radarId>.*` (with `policy: "instant"`) alongside the existing radar controls and targets subscriptions.
- Adds a notifications subsystem in `web/gui/viewer.js` that tracks active alarms in a `Map` keyed by notification path, updates/clears entries via `handleNotification(path, value)` when `state` is missing or becomes `"normal"`, and re-renders via `updateNotificationBanner()` (hiding the banner when empty).
- Routes incoming `notifications.*` deltas through `handleNotification()` before other stream handling logic.

### UI rendering
- Renders a top-centre notification banner in `web/gui/viewer.js` during `window.onload` using `createNotificationBanner()`, with severity-based styling for active alarms.
- Updates the power lozenge logic to support a `"fault"` state by applying the `myr_power_fault` CSS class.

## CSS additions

- Adds power fault styling in `web/gui/layout.css`:
  - `.myr_power_lozenge.myr_power_fault .myr_power_lozenge_button`
  - `.myr_power_lozenge.myr_power_fault .myr_power_icon`
- Introduces notification banner styles:
  - `.myr_notification_banner`, `.myr_notification`
  - Severity variants: `.myr_notification_alert`, `.myr_notification_warn`, `.myr_notification_alarm`, `.myr_notification_emergency`

## Notes

Guard-zone alarms render immediately; radar-error notifications appear once PR `#346` merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->