### PR TITLE
fix(raymarine): listen unicast when Quantum announces no report multicast

### DIFF
--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -17,6 +17,11 @@ pub(crate) struct Command {
     info: RadarInfo,
     model: BaseModel,
     sock: Option<Arc<UdpSocket>>,
+    /// Whether this sender may open its own command socket. False in the
+    /// unicast-stream topology, where it must share the report socket — see
+    /// `disable_own_socket`. Opening its own socket there would bind the same
+    /// host:port as the report socket and steal the radar's replies.
+    own_socket_allowed: bool,
 }
 
 impl Command {
@@ -26,15 +31,23 @@ impl Command {
             info,
             model,
             sock: None,
+            own_socket_allowed: true,
         }
     }
 
     /// Use a caller-provided, already-connected socket for sending instead
     /// of opening our own. Used by the unicast-stream topology so commands
     /// and the radar's replies share one socket (and one source port).
-    pub(crate) fn with_shared_socket(mut self, sock: Arc<UdpSocket>) -> Self {
+    pub(crate) fn set_shared_socket(&mut self, sock: Arc<UdpSocket>) {
         self.sock = Some(sock);
-        self
+        self.own_socket_allowed = false;
+    }
+
+    /// Forbid opening an own command socket while no shared socket is set
+    /// yet (unicast topology, socket creation pending a retry). Sends are
+    /// dropped until `set_shared_socket` supplies the shared socket.
+    pub(crate) fn disable_own_socket(&mut self) {
+        self.own_socket_allowed = false;
     }
 
     pub(crate) fn set_ranges(&mut self, ranges: Ranges) {
@@ -69,6 +82,12 @@ impl Command {
 
     pub async fn send(&mut self, message: &[u8]) -> Result<(), RadarError> {
         if self.sock.is_none() {
+            if !self.own_socket_allowed {
+                // Unicast topology, shared socket not yet available: drop the
+                // command rather than open a colliding own socket. The report
+                // loop retries socket creation and will supply the shared one.
+                return Ok(());
+            }
             self.start_socket().await?;
         }
         if let Some(sock) = &self.sock {

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::sync::Arc;
 use tokio::net::UdpSocket;
 
 use super::BaseModel;
@@ -15,7 +16,7 @@ pub(crate) struct Command {
     key: String,
     info: RadarInfo,
     model: BaseModel,
-    sock: Option<UdpSocket>,
+    sock: Option<Arc<UdpSocket>>,
 }
 
 impl Command {
@@ -26,6 +27,14 @@ impl Command {
             model,
             sock: None,
         }
+    }
+
+    /// Use a caller-provided, already-connected socket for sending instead
+    /// of opening our own. Used by the unicast-stream topology so commands
+    /// and the radar's replies share one socket (and one source port).
+    pub(crate) fn with_shared_socket(mut self, sock: Arc<UdpSocket>) -> Self {
+        self.sock = Some(sock);
+        self
     }
 
     pub(crate) fn set_ranges(&mut self, ranges: Ranges) {
@@ -41,7 +50,7 @@ impl Command {
                     &self.info.send_command_addr,
                     &self.info.nic_addr
                 );
-                self.sock = Some(sock);
+                self.sock = Some(Arc::new(sock));
 
                 Ok(())
             }

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -17,21 +17,22 @@ pub(crate) struct Command {
     info: RadarInfo,
     model: BaseModel,
     sock: Option<Arc<UdpSocket>>,
-    /// Whether this sender may open its own command socket. False in the
-    /// unicast-stream topology, where it must share the report socket — see
-    /// `disable_own_socket`. Opening its own socket there would bind the same
-    /// host:port as the report socket and steal the radar's replies.
-    own_socket_allowed: bool,
+    /// Whether this sender is in the unicast-stream topology, where it must
+    /// share the report socket. True means the sender must not open its own
+    /// command socket — doing so would bind the same host:port as the report
+    /// socket and steal the radar's replies. False is the normal multicast
+    /// topology, where this sender owns its command socket.
+    unicast_mode: bool,
 }
 
 impl Command {
-    pub(crate) fn new(info: RadarInfo, model: BaseModel) -> Self {
+    pub(crate) fn new(info: RadarInfo, model: BaseModel, unicast: bool) -> Self {
         Command {
             key: info.key(),
             info,
             model,
             sock: None,
-            own_socket_allowed: true,
+            unicast_mode: unicast,
         }
     }
 
@@ -39,15 +40,8 @@ impl Command {
     /// of opening our own. Used by the unicast-stream topology so commands
     /// and the radar's replies share one socket (and one source port).
     pub(crate) fn set_shared_socket(&mut self, sock: Arc<UdpSocket>) {
+        assert!(self.unicast_mode);
         self.sock = Some(sock);
-        self.own_socket_allowed = false;
-    }
-
-    /// Forbid opening an own command socket while no shared socket is set
-    /// yet (unicast topology, socket creation pending a retry). Sends are
-    /// dropped until `set_shared_socket` supplies the shared socket.
-    pub(crate) fn disable_own_socket(&mut self) {
-        self.own_socket_allowed = false;
     }
 
     pub(crate) fn set_ranges(&mut self, ranges: Ranges) {
@@ -55,6 +49,7 @@ impl Command {
     }
 
     async fn start_socket(&mut self) -> Result<(), RadarError> {
+        assert!(!self.unicast_mode);
         match create_multicast_send(&self.info.send_command_addr, &self.info.nic_addr) {
             Ok(sock) => {
                 log::debug!(
@@ -82,10 +77,14 @@ impl Command {
 
     pub async fn send(&mut self, message: &[u8]) -> Result<(), RadarError> {
         if self.sock.is_none() {
-            if !self.own_socket_allowed {
+            if self.unicast_mode {
                 // Unicast topology, shared socket not yet available: drop the
                 // command rather than open a colliding own socket. The report
                 // loop retries socket creation and will supply the shared one.
+                log::warn!(
+                    "{}: Dropping command in unicast mode when shared socket is not available",
+                    self.key
+                );
                 return Ok(());
             }
             self.start_socket().await?;

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -367,9 +367,17 @@ impl RaymarineLocator {
                     // reports and spokes unicast back to whoever sends it commands.
                     // The command socket sends from the NIC on the command port,
                     // so the radar replies to that port: listen unicast there.
+                    //
+                    // In that topology the radar streams reports and spokes back
+                    // on the same connected socket we send commands on — there
+                    // is no separate listen address or multicast group. All four
+                    // addresses on RadarInfo collapse onto the radar's command
+                    // address; the report.rs code only reads report_addr.port()
+                    // (with nic_addr) to bind our local end of the connected
+                    // socket.
                     let beacon_report: SocketAddrV4 = data.report.into();
                     let radar_addr: SocketAddrV4 = if beacon_report.ip().is_unspecified() {
-                        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, radar_send.port())
+                        radar_send
                     } else {
                         beacon_report
                     };
@@ -1043,19 +1051,18 @@ mod tests {
             .unwrap()
             .expect("radar should be created");
 
+        // In the unicast topology all four addresses on RadarInfo collapse
+        // onto the radar's command address — there is no separate listen
+        // address or multicast group.
+        let radar = SocketAddrV4::new(Ipv4Addr::new(192, 168, 143, 84), 2575);
         assert_eq!(model, BaseModel::Quantum);
+        assert_eq!(info.addr, radar);
+        assert_eq!(info.send_command_addr, radar);
         assert_eq!(
-            info.send_command_addr,
-            SocketAddrV4::new(Ipv4Addr::new(192, 168, 143, 84), 2575),
+            info.report_addr, radar,
+            "unicast topology: report_addr collapses onto the radar's command address"
         );
-        // The null report address falls back to a unicast listen on the
-        // command port, so the report receiver binds a real socket.
-        assert_eq!(
-            info.report_addr,
-            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 2575),
-            "unspecified beacon report should fall back to unicast on the command port"
-        );
-        assert_eq!(info.spoke_data_addr, info.report_addr);
+        assert_eq!(info.spoke_data_addr, radar);
     }
 
     #[test]

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -360,8 +360,19 @@ impl RaymarineLocator {
                         ),
                     };
 
-                    let radar_addr: SocketAddrV4 = data.report.into();
                     let radar_send: SocketAddrV4 = data.command.into();
+
+                    // Behind an MFD acting as WiFi AP, the Quantum advertises an
+                    // unspecified report address (0.0.0.0:0) and instead streams
+                    // reports and spokes unicast back to whoever sends it commands.
+                    // The command socket sends from the NIC on the command port,
+                    // so the radar replies to that port: listen unicast there.
+                    let beacon_report: SocketAddrV4 = data.report.into();
+                    let radar_addr: SocketAddrV4 = if beacon_report.ip().is_unspecified() {
+                        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, radar_send.port())
+                    } else {
+                        beacon_report
+                    };
 
                     let location_info: RadarInfo = RadarInfo::new(
                         radars,
@@ -998,6 +1009,53 @@ mod tests {
         assert!(!witness.quiet_for(Duration::from_secs(60)));
         // A zero-window query treats "just marked" as already-elapsed and quiet.
         assert!(witness.quiet_for(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn quantum_behind_mfd_ap_uses_unicast_report_stream() {
+        // A Quantum behind an Axiom MFD acting as WiFi AP advertises an
+        // unspecified report address (0.0.0.0:0) in its 36-byte beacon and
+        // streams reports/spokes unicast back to the controller instead.
+        // Real beacons from research capture Q2_with_Axiom_as_wifi_AP
+        // (link_id 0xD681C8C3, "QuantumRadar", radar at 192.168.143.84).
+        let args = Cli::parse_from(["mayara-server"]);
+        let mut locator = RaymarineLocator::new(args);
+        let radars = &SharedRadars::new();
+        const SRC: Ipv4Addr = Ipv4Addr::new(192, 168, 143, 84);
+
+        // 56-byte identity beacon: subtype 0x66, model "QuantumRadar".
+        const BEACON_56: [u8; 56] = [
+            0x01, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0xC3, 0xC8, 0x81, 0xD6, 0x03, 0x01,
+            0x00, 0x00, 0x54, 0x8F, 0xA8, 0xC0, 0x51, 0x75, 0x61, 0x6E, 0x74, 0x75, 0x6D, 0x52,
+            0x61, 0x64, 0x61, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        ];
+        // 36-byte address beacon: report=0.0.0.0:0, command=192.168.143.84:2575.
+        const BEACON_36: [u8; 36] = [
+            0x00, 0x00, 0x00, 0x00, 0xC3, 0xC8, 0x81, 0xD6, 0x28, 0x00, 0x00, 0x00, 0x03, 0x00,
+            0x64, 0x00, 0x06, 0x08, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00,
+            0x54, 0x8F, 0xA8, 0xC0, 0x0F, 0x0A, 0x37, 0x00,
+        ];
+
+        locator.process_beacon_56_report(&BEACON_56, &SRC).unwrap();
+        let (info, model) = locator
+            .process_beacon_36_report(&BEACON_36, &SRC, radars)
+            .unwrap()
+            .expect("radar should be created");
+
+        assert_eq!(model, BaseModel::Quantum);
+        assert_eq!(
+            info.send_command_addr,
+            SocketAddrV4::new(Ipv4Addr::new(192, 168, 143, 84), 2575),
+        );
+        // The null report address falls back to a unicast listen on the
+        // command port, so the report receiver binds a real socket.
+        assert_eq!(
+            info.report_addr,
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 2575),
+            "unspecified beacon report should fall back to unicast on the command port"
+        );
+        assert_eq!(info.spoke_data_addr, info.report_addr);
     }
 
     #[test]

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -362,7 +362,8 @@ impl RaymarineLocator {
 
                     let radar_send: SocketAddrV4 = data.command.into();
 
-                    // Behind an MFD acting as WiFi AP, the Quantum advertises an
+                    // Quantum WiFi radars connect to a well-known SSID and password,
+                    // and the Quantum advertises an
                     // unspecified report address (0.0.0.0:0) and instead streams
                     // reports and spokes unicast back to whoever sends it commands.
                     // The command socket sends from the NIC on the command port,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -1,6 +1,5 @@
 use anyhow::{Error, bail};
 use std::collections::HashMap;
-use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
@@ -257,7 +256,7 @@ impl RaymarineReportReceiver {
         }
     }
 
-    async fn start_report_socket(&mut self) -> io::Result<()> {
+    async fn start_report_socket(&mut self) {
         // Unicast topology (report address non-multicast): the report loop and
         // the command sender share one connected socket. Create it on demand
         // here — this is the receiver's retry point — and hand a clone to the
@@ -277,9 +276,9 @@ impl RaymarineReportReceiver {
                         self.unicast_socket = Some(sock);
                     }
                     Err(e) => {
-                        // Leave report_socket None so run() retries; never
-                        // fall back to a separate command socket (collision).
-                        sleep(Duration::from_millis(1000)).await;
+                        // Leave report_socket None so run() retries (it
+                        // owns the back-off); never fall back to a separate
+                        // command socket (collision).
                         log::debug!(
                             "{}: {} via {}: unicast report socket failed: {}",
                             self.common.key,
@@ -287,7 +286,7 @@ impl RaymarineReportReceiver {
                             &self.common.info.nic_addr,
                             e
                         );
-                        return Ok(());
+                        return;
                     }
                 }
             }
@@ -299,33 +298,32 @@ impl RaymarineReportReceiver {
                 &self.common.info.report_addr,
                 &self.common.info.nic_addr
             );
-            return Ok(());
-        }
-        match network::create_udp_listen(
-            &self.common.info.report_addr,
-            &self.common.info.nic_addr,
-            network::SocketType::Any,
-        ) {
-            Ok(socket) => {
-                self.report_socket = Some(socket);
-                log::debug!(
-                    "{}: {} via {}: listening for reports",
-                    self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr
-                );
-                Ok(())
-            }
-            Err(e) => {
-                sleep(Duration::from_millis(1000)).await;
-                log::debug!(
-                    "{}: {} via {}: create multicast failed: {}",
-                    self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr,
-                    e
-                );
-                Ok(())
+        } else {
+            // Multicast mode
+            match network::create_udp_listen(
+                &self.common.info.report_addr,
+                &self.common.info.nic_addr,
+                network::SocketType::Any,
+            ) {
+                Ok(socket) => {
+                    self.report_socket = Some(socket);
+                    log::debug!(
+                        "{}: {} via {}: listening for reports",
+                        self.common.key,
+                        &self.common.info.report_addr,
+                        &self.common.info.nic_addr
+                    );
+                }
+                Err(e) => {
+                    // Back-off and shutdown observation live in run().
+                    log::debug!(
+                        "{}: {} via {}: create multicast failed: {}",
+                        self.common.key,
+                        &self.common.info.report_addr,
+                        &self.common.info.nic_addr,
+                        e
+                    );
+                }
             }
         }
     }
@@ -440,21 +438,15 @@ impl RaymarineReportReceiver {
     }
 
     pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
-        self.start_report_socket().await?;
         loop {
-            if self.report_socket.is_some() {
-                match self.socket_loop(subsys).await {
-                    Err(RadarError::Shutdown) => {
-                        return Ok(());
-                    }
-                    _ => {
-                        // Ignore, reopen socket
-                    }
-                }
-                self.report_socket = None;
-            } else {
+            self.start_report_socket().await;
+            if self.report_socket.is_none() {
                 sleep(Duration::from_millis(1000)).await;
-                self.start_report_socket().await?;
+                continue;
+            }
+            match self.socket_loop(subsys).await {
+                Err(RadarError::Shutdown) => return Ok(()),
+                _ => self.report_socket = None,
             }
         }
     }

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -277,8 +277,9 @@ impl RaymarineReportReceiver {
                     }
                     Err(e) => {
                         // Leave report_socket None so run() retries (it
-                        // owns the back-off); never fall back to a separate
-                        // command socket (collision).
+                        // owns the back-off and observes shutdown while
+                        // sleeping); never fall back to a separate command
+                        // socket (collision).
                         log::debug!(
                             "{}: {} via {}: unicast report socket failed: {}",
                             self.common.key,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -143,6 +143,7 @@ impl FeatureFlags {
 
 pub(crate) struct RaymarineReportReceiver {
     common: CommonRadar,
+    unicast_mode: bool,
     report_socket: Option<RadarSocket>,
     // When the radar streams unicast back to the command source port (MFD
     // acting as WiFi AP, report address unspecified), this is the single
@@ -196,6 +197,7 @@ impl RaymarineReportReceiver {
             args
         );
 
+        // Quantum WiFi:
         // When the radar advertised no report multicast group, the locator
         // set report_addr to an unspecified unicast address (MFD-as-WiFi-AP
         // topology). The radar streams reports/spokes unicast back to the
@@ -204,7 +206,7 @@ impl RaymarineReportReceiver {
         // command socket wins delivery of the replies and starves the listen
         // socket (same host:port). start_report_socket() creates that shared
         // socket (with retry) and hands it to the command sender.
-        let needs_unicast = !replay && !info.report_addr.ip().is_multicast();
+        let unicast_mode = !replay && !info.report_addr.ip().is_multicast();
 
         // Quantum wired radars (and some RD variants) won't send the
         // 0x280001 info-report until they have received a host keep-alive
@@ -218,11 +220,7 @@ impl RaymarineReportReceiver {
         // start_report_socket() supplies the shared one. The normal multicast
         // topology lets it open its own socket as usual.
         let command_sender = if !replay {
-            let mut cmd = Command::new(info.clone(), base_model);
-            if needs_unicast {
-                cmd.disable_own_socket();
-            }
-            Some(cmd)
+            Some(Command::new(info.clone(), base_model, unicast_mode))
         } else {
             None
         };
@@ -237,6 +235,7 @@ impl RaymarineReportReceiver {
         let now = Instant::now();
         RaymarineReportReceiver {
             common,
+            unicast_mode,
             report_socket: None,
             unicast_socket: None,
             state: ReceiverState::Initial,
@@ -263,9 +262,7 @@ impl RaymarineReportReceiver {
         // the command sender share one connected socket. Create it on demand
         // here — this is the receiver's retry point — and hand a clone to the
         // command sender so it stops dropping commands.
-        let needs_unicast =
-            !self.common.replay && !self.common.info.report_addr.ip().is_multicast();
-        if needs_unicast {
+        if self.unicast_mode {
             if self.unicast_socket.is_none() {
                 match network::create_connected_unicast(
                     &self.common.info.nic_addr,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -236,7 +236,7 @@ impl RaymarineReportReceiver {
         match network::create_udp_listen(
             &self.common.info.report_addr,
             &self.common.info.nic_addr,
-            network::SocketType::Multicast,
+            network::SocketType::Any,
         ) {
             Ok(socket) => {
                 self.report_socket = Some(socket);

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::net::UdpSocket;
 use tokio::time::{Instant, sleep, sleep_until};
 use tokio_graceful_shutdown::SubsystemHandle;
 
@@ -143,6 +144,11 @@ impl FeatureFlags {
 pub(crate) struct RaymarineReportReceiver {
     common: CommonRadar,
     report_socket: Option<RadarSocket>,
+    // When the radar streams unicast back to the command source port (MFD
+    // acting as WiFi AP, report address unspecified), this is the single
+    // connected socket shared with the command sender. The report loop
+    // listens on it; `None` for the normal multicast topology.
+    unicast_socket: Option<Arc<UdpSocket>>,
     state: ReceiverState,
     model: Option<RaymarineModel>,
     base_model: BaseModel,
@@ -190,6 +196,30 @@ impl RaymarineReportReceiver {
             args
         );
 
+        // When the radar advertised no report multicast group, the locator
+        // set report_addr to an unspecified unicast address (MFD-as-WiFi-AP
+        // topology). The radar streams reports/spokes unicast back to the
+        // command source port, so a single connected socket must both send
+        // commands and receive replies — otherwise a separate connected
+        // command socket wins delivery of the replies and starves the listen
+        // socket (same host:port). Build that shared socket here so the
+        // command sender uses it instead of opening its own.
+        let unicast_socket = if !replay && !info.report_addr.ip().is_multicast() {
+            match network::create_connected_unicast(
+                &info.nic_addr,
+                info.report_addr.port(),
+                &info.send_command_addr,
+            ) {
+                Ok(sock) => Some(Arc::new(sock)),
+                Err(e) => {
+                    log::warn!("{}: unicast report socket failed: {}", key, e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // Quantum wired radars (and some RD variants) won't send the
         // 0x280001 info-report until they have received a host keep-alive
         // first — see issue #228. Create the command_sender now with the
@@ -197,7 +227,11 @@ impl RaymarineReportReceiver {
         // starts priming the radar immediately. process_info_report() will
         // not overwrite this once the radar replies.
         let command_sender = if !replay {
-            Some(Command::new(info.clone(), base_model))
+            let cmd = Command::new(info.clone(), base_model);
+            Some(match &unicast_socket {
+                Some(sock) => cmd.with_shared_socket(sock.clone()),
+                None => cmd,
+            })
         } else {
             None
         };
@@ -213,6 +247,7 @@ impl RaymarineReportReceiver {
         RaymarineReportReceiver {
             common,
             report_socket: None,
+            unicast_socket,
             state: ReceiverState::Initial,
             model: None, // We don't know this yet, it will be set when we receive the first info report
             base_model,
@@ -233,6 +268,19 @@ impl RaymarineReportReceiver {
     }
 
     async fn start_report_socket(&mut self) -> io::Result<()> {
+        // Unicast topology: listen on the shared connected socket so the
+        // report loop receives the replies the command sender's heartbeats
+        // elicit. Falls through to the normal listener otherwise.
+        if let Some(sock) = &self.unicast_socket {
+            self.report_socket = Some(RadarSocket::Udp(sock.clone()));
+            log::debug!(
+                "{}: {} via {}: listening for unicast reports",
+                self.common.key,
+                &self.common.info.report_addr,
+                &self.common.info.nic_addr
+            );
+            return Ok(());
+        }
         match network::create_udp_listen(
             &self.common.info.report_addr,
             &self.common.info.nic_addr,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -350,7 +350,16 @@ impl RaymarineReportReceiver {
                     return Err(RadarError::Shutdown);
                 },
                 _ = sleep_until(heartbeat_deadline) => {
-                    self.send_heartbeat().await?;
+                    // A heartbeat send failure must not tear down the report
+                    // loop. With the unicast (MFD-as-AP) topology the command
+                    // socket is connected to the radar, so a send can fail with
+                    // a routing error (e.g. the radar briefly unreachable);
+                    // killing the loop here would drop the report socket and
+                    // busy-respin once per second, never recovering. Log and
+                    // keep listening; the next heartbeat retries.
+                    if let Err(e) = self.send_heartbeat().await {
+                        log::debug!("{}: heartbeat send failed: {}", self.common.key, e);
+                    }
                 },
                 _ = sleep_until(wake_deadline) => {
                     self.maybe_send_wake_nudge().await?;
@@ -416,6 +425,10 @@ impl RaymarineReportReceiver {
     }
 
     async fn send_heartbeat(&mut self) -> Result<(), RadarError> {
+        // Advance the deadline first so a send failure below can't leave it in
+        // the past — otherwise the caller's sleep_until fires immediately and
+        // busy-loops. The next tick retries the heartbeat a second later.
+        self.heartbeat_deadline += HEARTBEAT_INTERVAL;
         if let Some(ref mut cs) = self.command_sender {
             cs.send_heartbeat().await?;
 
@@ -426,7 +439,6 @@ impl RaymarineReportReceiver {
                 cs.send_heartbeat_5s().await?;
             }
         }
-        self.heartbeat_deadline += HEARTBEAT_INTERVAL;
         Ok(())
     }
 

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -202,23 +202,9 @@ impl RaymarineReportReceiver {
         // command source port, so a single connected socket must both send
         // commands and receive replies — otherwise a separate connected
         // command socket wins delivery of the replies and starves the listen
-        // socket (same host:port). Build that shared socket here so the
-        // command sender uses it instead of opening its own.
-        let unicast_socket = if !replay && !info.report_addr.ip().is_multicast() {
-            match network::create_connected_unicast(
-                &info.nic_addr,
-                info.report_addr.port(),
-                &info.send_command_addr,
-            ) {
-                Ok(sock) => Some(Arc::new(sock)),
-                Err(e) => {
-                    log::warn!("{}: unicast report socket failed: {}", key, e);
-                    None
-                }
-            }
-        } else {
-            None
-        };
+        // socket (same host:port). start_report_socket() creates that shared
+        // socket (with retry) and hands it to the command sender.
+        let needs_unicast = !replay && !info.report_addr.ip().is_multicast();
 
         // Quantum wired radars (and some RD variants) won't send the
         // 0x280001 info-report until they have received a host keep-alive
@@ -226,12 +212,17 @@ impl RaymarineReportReceiver {
         // base model the locator already determined, so the heartbeat loop
         // starts priming the radar immediately. process_info_report() will
         // not overwrite this once the radar replies.
+        //
+        // In the unicast topology the command sender must never open its own
+        // socket (that is the collision this fixes); it stays socketless until
+        // start_report_socket() supplies the shared one. The normal multicast
+        // topology lets it open its own socket as usual.
         let command_sender = if !replay {
-            let cmd = Command::new(info.clone(), base_model);
-            Some(match &unicast_socket {
-                Some(sock) => cmd.with_shared_socket(sock.clone()),
-                None => cmd,
-            })
+            let mut cmd = Command::new(info.clone(), base_model);
+            if needs_unicast {
+                cmd.disable_own_socket();
+            }
+            Some(cmd)
         } else {
             None
         };
@@ -247,7 +238,7 @@ impl RaymarineReportReceiver {
         RaymarineReportReceiver {
             common,
             report_socket: None,
-            unicast_socket,
+            unicast_socket: None,
             state: ReceiverState::Initial,
             model: None, // We don't know this yet, it will be set when we receive the first info report
             base_model,
@@ -268,11 +259,43 @@ impl RaymarineReportReceiver {
     }
 
     async fn start_report_socket(&mut self) -> io::Result<()> {
-        // Unicast topology: listen on the shared connected socket so the
-        // report loop receives the replies the command sender's heartbeats
-        // elicit. Falls through to the normal listener otherwise.
-        if let Some(sock) = &self.unicast_socket {
-            self.report_socket = Some(RadarSocket::Udp(sock.clone()));
+        // Unicast topology (report address non-multicast): the report loop and
+        // the command sender share one connected socket. Create it on demand
+        // here — this is the receiver's retry point — and hand a clone to the
+        // command sender so it stops dropping commands.
+        let needs_unicast =
+            !self.common.replay && !self.common.info.report_addr.ip().is_multicast();
+        if needs_unicast {
+            if self.unicast_socket.is_none() {
+                match network::create_connected_unicast(
+                    &self.common.info.nic_addr,
+                    self.common.info.report_addr.port(),
+                    &self.common.info.send_command_addr,
+                ) {
+                    Ok(sock) => {
+                        let sock = Arc::new(sock);
+                        if let Some(cs) = &mut self.command_sender {
+                            cs.set_shared_socket(sock.clone());
+                        }
+                        self.unicast_socket = Some(sock);
+                    }
+                    Err(e) => {
+                        // Leave report_socket None so run() retries; never
+                        // fall back to a separate command socket (collision).
+                        sleep(Duration::from_millis(1000)).await;
+                        log::debug!(
+                            "{}: {} via {}: unicast report socket failed: {}",
+                            self.common.key,
+                            &self.common.info.report_addr,
+                            &self.common.info.nic_addr,
+                            e
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+            let sock = self.unicast_socket.as_ref().unwrap().clone();
+            self.report_socket = Some(RadarSocket::Udp(sock));
             log::debug!(
                 "{}: {} via {}: listening for unicast reports",
                 self.common.key,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -292,7 +292,7 @@ impl RaymarineReportReceiver {
                 }
             }
             let sock = self.unicast_socket.as_ref().unwrap().clone();
-            self.report_socket = Some(RadarSocket::Udp(sock));
+            self.report_socket = Some(RadarSocket::SharedUdp(sock));
             log::debug!(
                 "{}: {} via {}: listening for unicast reports",
                 self.common.key,
@@ -318,7 +318,7 @@ impl RaymarineReportReceiver {
                 Err(e) => {
                     // Back-off and shutdown observation live in run().
                     log::debug!(
-                        "{}: {} via {}: create multicast failed: {}",
+                        "{}: {} via {}: create UDP listen socket failed: {}",
                         self.common.key,
                         &self.common.info.report_addr,
                         &self.common.info.nic_addr,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -441,8 +441,13 @@ impl RaymarineReportReceiver {
         loop {
             self.start_report_socket().await;
             if self.report_socket.is_none() {
-                sleep(Duration::from_millis(1000)).await;
-                continue;
+                // Bind keeps failing: back off, but race the sleep against
+                // a shutdown request so a graceful shutdown can't hang on
+                // a long network outage.
+                tokio::select! {
+                    _ = sleep(Duration::from_millis(1000)) => continue,
+                    _ = subsys.on_shutdown_requested() => return Ok(()),
+                }
             }
             match self.socket_loop(subsys).await {
                 Err(RadarError::Shutdown) => return Ok(()),

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -427,8 +427,11 @@ pub(super) fn process_info_report(receiver: &mut RaymarineReportReceiver, data: 
             // keep the existing sender rather than recreating it.
             if receiver.command_sender.is_none() && !receiver.common.replay {
                 log::debug!("{}: Starting command sender", receiver.common.key);
-                receiver.command_sender =
-                    Some(Command::new(receiver.common.info.clone(), model.model));
+                receiver.command_sender = Some(Command::new(
+                    receiver.common.info.clone(),
+                    model.model,
+                    receiver.unicast_mode,
+                ));
             }
             receiver.model = Some(model);
             receiver.state = ReceiverState::InfoRequestReceived;

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -270,7 +270,7 @@ pub(crate) fn create_udp_listen(
     }
 
     let socket = UdpSocket::from_std(socket.into())?;
-    Ok(crate::replay::RadarSocket::Udp(std::sync::Arc::new(socket)))
+    Ok(crate::replay::RadarSocket::Udp(socket))
 }
 
 /// Create a unicast UDP socket bound to `nic_addr` on `port` and connected to

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -270,7 +270,34 @@ pub(crate) fn create_udp_listen(
     }
 
     let socket = UdpSocket::from_std(socket.into())?;
-    Ok(crate::replay::RadarSocket::Udp(socket))
+    Ok(crate::replay::RadarSocket::Udp(std::sync::Arc::new(socket)))
+}
+
+/// Create a unicast UDP socket bound to `nic_addr` on `port` and connected to
+/// `peer`. A single connected socket both sends commands to the radar and
+/// receives the radar's unicast replies on the same source port.
+///
+/// This exists for the Raymarine "MFD as WiFi AP" topology, where the radar
+/// streams reports/spokes unicast back to the command source port. Sharing one
+/// connected socket avoids a same-port collision between a separate listen and
+/// command socket (the connected command socket would otherwise win delivery
+/// of the replies, starving the listen socket).
+pub(crate) fn create_connected_unicast(
+    nic_addr: &Ipv4Addr,
+    port: u16,
+    peer: &SocketAddrV4,
+) -> io::Result<UdpSocket> {
+    let socket: socket2::Socket = new_socket()?;
+    let bind_addr = SocketAddr::new(IpAddr::V4(*nic_addr), port);
+    socket.bind(&socket2::SockAddr::from(bind_addr))?;
+    socket.connect(&socket2::SockAddr::from(SocketAddr::V4(*peer)))?;
+    log::trace!(
+        "Binding unicast socket to {} connected to {}",
+        bind_addr,
+        peer
+    );
+
+    UdpSocket::from_std(socket.into())
 }
 
 pub(crate) fn create_multicast_send(

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -291,7 +291,7 @@ pub(crate) fn create_connected_unicast(
     let bind_addr = SocketAddr::new(IpAddr::V4(*nic_addr), port);
     socket.bind(&socket2::SockAddr::from(bind_addr))?;
     socket.connect(&socket2::SockAddr::from(SocketAddr::V4(*peer)))?;
-    log::trace!(
+    log::debug!(
         "Binding unicast socket to {} connected to {}",
         bind_addr,
         peer

--- a/src/lib/replay.rs
+++ b/src/lib/replay.rs
@@ -18,8 +18,9 @@ use std::io;
 use std::net::{SocketAddr, SocketAddrV4};
 #[cfg(feature = "pcap-replay")]
 use std::path::Path;
+use std::sync::Arc;
 #[cfg(feature = "pcap-replay")]
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock};
 #[cfg(feature = "pcap-replay")]
 use std::time::Duration;
 use tokio::net::UdpSocket;
@@ -35,8 +36,10 @@ use crate::pcap::{self, PcapPacket};
 /// socket or from the pcap replay dispatcher. Receivers use this
 /// instead of `tokio::net::UdpSocket` directly.
 pub(crate) enum RadarSocket {
-    /// Real network UDP socket.
-    Udp(UdpSocket),
+    /// Real network UDP socket. `Arc` so a connected unicast socket can be
+    /// shared with a command sender (Raymarine MFD-as-AP topology); the
+    /// multicast/broadcast listen path simply holds the sole reference.
+    Udp(Arc<UdpSocket>),
     /// Pcap replay channel.
     Replay(ReplayReceiver),
 }

--- a/src/lib/replay.rs
+++ b/src/lib/replay.rs
@@ -36,10 +36,16 @@ use crate::pcap::{self, PcapPacket};
 /// socket or from the pcap replay dispatcher. Receivers use this
 /// instead of `tokio::net::UdpSocket` directly.
 pub(crate) enum RadarSocket {
-    /// Real network UDP socket. `Arc` so a connected unicast socket can be
-    /// shared with a command sender (Raymarine MFD-as-AP topology); the
-    /// multicast/broadcast listen path simply holds the sole reference.
-    Udp(Arc<UdpSocket>),
+    /// Real network UDP socket — sole owner of its file descriptor. This
+    /// is the normal multicast / broadcast / unicast listen path used by
+    /// every brand.
+    Udp(UdpSocket),
+    /// Real network UDP socket shared with another sender (currently only
+    /// the Raymarine MFD-as-WiFi-AP unicast topology, where the command
+    /// sender and the report receiver have to hold the same connected
+    /// socket so the radar's replies don't get stolen by a separate
+    /// command socket bound to the same host:port).
+    SharedUdp(Arc<UdpSocket>),
     /// Pcap replay channel.
     Replay(ReplayReceiver),
 }
@@ -49,6 +55,7 @@ impl RadarSocket {
     pub async fn recv_buf_from(&mut self, buf: &mut Vec<u8>) -> io::Result<(usize, SocketAddr)> {
         match self {
             RadarSocket::Udp(sock) => sock.recv_buf_from(buf).await,
+            RadarSocket::SharedUdp(sock) => sock.recv_buf_from(buf).await,
             RadarSocket::Replay(rx) => rx.recv_buf_from(buf).await,
         }
     }


### PR DESCRIPTION
## What changes for you

If you have a Raymarine Quantum radar **and** you connect to it through an Axiom MFD that's acting as the WiFi access point — i.e., your mayara host joins the Axiom's WiFi network rather than the radar's own — mayara should now successfully discover the radar, populate its controls, and render the live image. Before this change, that setup failed in one of three ways depending on how far you got: the radar might not be discovered at all, it might appear in mayara but never produce an image, or commands sent from the GUI would silently get nowhere.

The fix is automatic — no new settings or flags. Direct-to-radar WiFi (where mayara joins the radar's own AP) and all other brands continue to behave exactly as before.

## Technical detail

A Quantum behind an MFD-as-WiFi-AP advertises `0.0.0.0:0` for its report group and streams reports/spokes back unicast to whichever host sent it a command. Getting that to work surfaced three sequential bugs, each found from real-hardware captures:

1. **Discovery / address.** The unspecified report address caused the receiver to try joining multicast `0.0.0.0:0`, which fails — no data arrives, the radar stays hidden. Now falls back to a unicast listen on the command port.
2. **Socket collision.** With (1) fixed, the report listener and the command sender both opened sockets on the same `host:port`; the connected command socket won delivery of the radar's replies, starving the listen socket. Share one connected `Arc<UdpSocket>` between the report loop (recv) and the command sender (send) so commands and replies travel on one source port.
3. **Fatal heartbeat send.** The shared connected socket means a heartbeat `send` can fail with a routing error (seen in a container where multicast binds also fail with `EADDRNOTAVAIL`). The report loop propagated that via `?`, dropping the report socket and respinning once per second forever, so no heartbeat ever left and the radar never streamed. Heartbeat-send failures are now non-fatal: log, advance the deadline, and keep listening.

The unicast path is gated on `report_addr` being non-multicast, so the standard multicast topology and every other brand are unchanged. The connected-socket bind log is at `debug` so `-v` shows the unicast path without trace-level noise.

## Tested

- Real hardware: Raymarine Quantum behind an Axiom MFD as WiFi AP (Raspberry Pi running this build via the Signal K container plugin, `--allow-wifi`). Radar discovered, controls populate, **radar echoes render** in the GUI.
- Unit test `quantum_behind_mfd_ap_uses_unicast_report_stream` (real beacons) asserts the unspecified report address falls back to `0.0.0.0:<command-port>`.
- `cargo test --lib` clean (310 tests pass, rebased onto current main).
- `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D warnings` clean.
- Builds verified: default, `--features pcap-replay`, and each brand alone.