### PR TITLE
feat(gui): add Network Diagnostics download button

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["radar", "marine", "server", "websocket", "rest-api"]
 categories = ["network-programming", "web-programming::http-server"]
 
 [package.metadata]
-api-version = "3.2.0"
+api-version = "3.3.0"
 
 [lib]
 name = "mayara"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ garmin = []
 koden = []
 raymarine = []
 emulator = []
-pcap-replay = ["dep:flate2"]
+pcap-replay = []
 # default = ["navico", "furuno", "raymarine"]
 default = ["navico", "furuno", "garmin", "koden", "raymarine", "emulator"]
 
@@ -44,7 +44,7 @@ crossbeam = "0.8.4"
 directories = "6.0.0"
 enum-primitive-derive = "0.3.0"
 env_logger = { version = "0.11", default-features = false, features = ["humantime", "auto-color"] }
-flate2 = { version = "1", optional = true }
+flate2 = "1"
 futures = "0.3.32"
 futures-util = "0.3.32"
 headers = "0.4.1"

--- a/Makefile
+++ b/Makefile
@@ -45,21 +45,21 @@ mpi:
 	cargo build --release --target aarch64-unknown-linux-musl
 	ssh merrimac-pi killall -9 mayara-server || :
 	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
-	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server --pass-ais
+	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server
 
 mpid:
 	@echo "Building and running with debug log on merrimac-pi..."
 	cargo build --release --target aarch64-unknown-linux-musl
 	ssh merrimac-pi killall -9 mayara-server || :
 	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
-	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v --transmit --pass-ais
+	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v --transmit
 
 mpit:
 	@echo "Building and running with trace log on merrimac-pi..."
 	cargo build --release --target aarch64-unknown-linux-musl
 	ssh merrimac-pi killall -9 mayara-server || :
 	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
-	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v -v --transmit --pass-ais
+	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v -v --transmit
 
 # Build and run the server
 run: release

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -32,6 +32,7 @@ mayara-server --openapi
 | ------ | ------------------------------------------------------------ | -------------------------------------------------- |
 | GET    | `/signalk/v2/api/vessels/self/radars`                        | List all detected radars                           |
 | GET    | `/signalk/v2/api/vessels/self/radars/interfaces`             | List network interfaces and radar discovery status |
+| GET    | `/signalk/v2/api/vessels/self/radars/diagnostics`            | Download a gzipped JSON network diagnostics snapshot |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/capabilities`      | Get radar capabilities and legend                  |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/controls`          | Get all control values                             |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/controls/{cid}`    | Get specific control value                         |

--- a/src/bin/mayara-server/web/signalk/diagnostics.rs
+++ b/src/bin/mayara-server/web/signalk/diagnostics.rs
@@ -134,12 +134,29 @@ fn config_summary(args: &mayara::Cli) -> Value {
     Value::Object(obj)
 }
 
+/// Upper bound on how long we wait for the locator subsystem to reply
+/// with its `InterfaceApi` snapshot. The reply is normally back in a few
+/// milliseconds; if the locator is wedged (e.g. mid-shutdown or stuck
+/// in `reply_with_interface_state`) we'd rather return a partial dump
+/// than hang the HTTP request indefinitely.
+const INTERFACE_API_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 async fn fetch_interface_api(state: &Web) -> InterfaceApi {
     let (tx, mut rx) = mpsc::channel(1);
     if state.tx_interface_request.send(Some(tx)).is_err() {
         return InterfaceApi::default();
     }
-    rx.recv().await.unwrap_or_default()
+    match tokio::time::timeout(INTERFACE_API_FETCH_TIMEOUT, rx.recv()).await {
+        Ok(Some(api)) => api,
+        Ok(None) => InterfaceApi::default(),
+        Err(_) => {
+            log::warn!(
+                "diagnostics: locator did not reply with InterfaceApi within {:?}",
+                INTERFACE_API_FETCH_TIMEOUT
+            );
+            InterfaceApi::default()
+        }
+    }
 }
 
 fn radars_summary(state: &Web) -> Vec<Value> {

--- a/src/bin/mayara-server/web/signalk/diagnostics.rs
+++ b/src/bin/mayara-server/web/signalk/diagnostics.rs
@@ -15,11 +15,15 @@ use axum::{
 use chrono::Utc;
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use mayara::network::devices::{self, Device};
 use mayara::{InterfaceApi, PACKAGE, VERSION};
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use serde::Serialize;
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::io::Write;
+use std::net::Ipv4Addr;
+use std::str::FromStr;
 use tokio::sync::mpsc;
 
 use super::super::Web;
@@ -158,7 +162,15 @@ fn radars_summary(state: &Web) -> Vec<Value> {
         .collect()
 }
 
-fn build_diagnostics(state: &Web, locator: InterfaceApi) -> Value {
+fn build_diagnostics(
+    state: &Web,
+    locator: InterfaceApi,
+    devices_by_nic: HashMap<Ipv4Addr, Vec<Device>>,
+) -> Value {
+    let mut locator_value =
+        serde_json::to_value(&locator).expect("InterfaceApi is always serializable");
+    inject_devices(&mut locator_value, &devices_by_nic);
+
     json!({
         "schema": "mayara-network-diagnostics-v1",
         "generated_at": Utc::now().to_rfc3339(),
@@ -175,9 +187,35 @@ fn build_diagnostics(state: &Web, locator: InterfaceApi) -> Value {
         "host": {
             "interfaces": enumerate_host_interfaces(),
         },
-        "locator": locator,
+        "locator": locator_value,
         "radars": radars_summary(state),
     })
+}
+
+/// Walk `locator.interfaces` (serialized as a map keyed by `"name (ip)"`)
+/// and, for any entry whose `ip` field matches a key in `devices_by_nic`,
+/// inject a `devices` array next to the existing `listeners` block.
+fn inject_devices(locator: &mut Value, devices_by_nic: &HashMap<Ipv4Addr, Vec<Device>>) {
+    let Some(interfaces) = locator.get_mut("interfaces").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for entry in interfaces.values_mut() {
+        let Some(obj) = entry.as_object_mut() else {
+            continue;
+        };
+        let ip = obj
+            .get("ip")
+            .and_then(Value::as_str)
+            .and_then(|s| Ipv4Addr::from_str(s).ok());
+        let Some(ip) = ip else { continue };
+        let Some(devices) = devices_by_nic.get(&ip) else {
+            continue;
+        };
+        obj.insert(
+            "devices".into(),
+            serde_json::to_value(devices).expect("Device is always serializable"),
+        );
+    }
 }
 
 fn gzip_json(body: &Value) -> std::io::Result<Vec<u8>> {
@@ -189,7 +227,8 @@ fn gzip_json(body: &Value) -> std::io::Result<Vec<u8>> {
 
 pub(crate) async fn get_diagnostics(State(state): State<Web>) -> Response {
     let locator = fetch_interface_api(&state).await;
-    let body = build_diagnostics(&state, locator);
+    let devices_by_nic = devices::collect_per_interface(&locator).await;
+    let body = build_diagnostics(&state, locator, devices_by_nic);
 
     let gz = match gzip_json(&body) {
         Ok(bytes) => bytes,

--- a/src/bin/mayara-server/web/signalk/diagnostics.rs
+++ b/src/bin/mayara-server/web/signalk/diagnostics.rs
@@ -1,0 +1,221 @@
+//! Network diagnostics endpoint.
+//!
+//! Produces a gzipped JSON dump describing how the mayara process sees the
+//! network: host interfaces, per-interface locator/listener status, and any
+//! radars that did get detected. The dump is meant to be attached to a GitHub
+//! issue so support can reproduce a "radar not detected" report without
+//! needing remote access to the user's network.
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use chrono::Utc;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use mayara::{InterfaceApi, PACKAGE, VERSION};
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::io::Write;
+use tokio::sync::mpsc;
+
+use super::super::Web;
+
+pub(crate) const DIAGNOSTICS_URI: &str =
+    "/signalk/v2/api/vessels/self/radars/diagnostics";
+
+#[derive(Serialize)]
+struct HostAddress {
+    family: &'static str,
+    ip: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    netmask: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    broadcast: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HostInterface {
+    name: String,
+    index: u32,
+    internal: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mac: Option<String>,
+    addresses: Vec<HostAddress>,
+}
+
+fn enumerate_host_interfaces() -> Vec<HostInterface> {
+    match NetworkInterface::show() {
+        Ok(interfaces) => interfaces
+            .into_iter()
+            .map(|itf| HostInterface {
+                name: itf.name,
+                index: itf.index,
+                internal: itf.internal,
+                mac: itf.mac_addr,
+                addresses: itf
+                    .addr
+                    .into_iter()
+                    .map(|a| match a {
+                        Addr::V4(v4) => HostAddress {
+                            family: "v4",
+                            ip: v4.ip.to_string(),
+                            netmask: v4.netmask.map(|n| n.to_string()),
+                            broadcast: v4.broadcast.map(|b| b.to_string()),
+                        },
+                        Addr::V6(v6) => HostAddress {
+                            family: "v6",
+                            ip: v6.ip.to_string(),
+                            netmask: v6.netmask.map(|n| n.to_string()),
+                            broadcast: v6.broadcast.map(|b| b.to_string()),
+                        },
+                    })
+                    .collect(),
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn compiled_features() -> Vec<&'static str> {
+    let mut features = Vec::new();
+    #[cfg(feature = "navico")]
+    features.push("navico");
+    #[cfg(feature = "furuno")]
+    features.push("furuno");
+    #[cfg(feature = "garmin")]
+    features.push("garmin");
+    #[cfg(feature = "koden")]
+    features.push("koden");
+    #[cfg(feature = "raymarine")]
+    features.push("raymarine");
+    #[cfg(feature = "emulator")]
+    features.push("emulator");
+    #[cfg(feature = "pcap-replay")]
+    features.push("pcap-replay");
+    features
+}
+
+/// Serialize the parts of the CLI configuration that influence radar
+/// discovery, excluding any secrets (Signal K bearer token paths and values).
+fn config_summary(args: &mayara::Cli) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("port".into(), json!(args.port));
+    obj.insert("tls_enabled".into(), json!(args.tls_cert.is_some()));
+    obj.insert("interface".into(), json!(args.interface));
+    obj.insert("brand".into(), json!(args.brand.map(|b| b.to_string())));
+    obj.insert("allow_wifi".into(), json!(args.allow_wifi));
+    obj.insert("multiple_radar".into(), json!(args.multiple_radar));
+    obj.insert("transmit".into(), json!(args.transmit));
+    obj.insert("stationary".into(), json!(args.stationary));
+    obj.insert("emulator".into(), json!(args.emulator));
+    obj.insert("replay".into(), json!(args.replay));
+    obj.insert("nmea0183".into(), json!(args.nmea0183));
+    obj.insert(
+        "navigation_address".into(),
+        json!(args.navigation_address),
+    );
+    obj.insert(
+        "targets".into(),
+        json!(format!("{:?}", args.targets).to_lowercase()),
+    );
+    #[cfg(feature = "pcap-replay")]
+    obj.insert("pcap".into(), json!(args.pcap));
+    Value::Object(obj)
+}
+
+async fn fetch_interface_api(state: &Web) -> InterfaceApi {
+    let (tx, mut rx) = mpsc::channel(1);
+    if state.tx_interface_request.send(Some(tx)).is_err() {
+        return InterfaceApi::default();
+    }
+    rx.recv().await.unwrap_or_default()
+}
+
+fn radars_summary(state: &Web) -> Vec<Value> {
+    state
+        .radars
+        .get_active()
+        .into_iter()
+        .map(|info| {
+            json!({
+                "id": info.key(),
+                "brand": info.brand.to_string(),
+                "model": info.controls.model_name(),
+                "name": info.controls.user_name(),
+                "serial_no": info.serial_no,
+                "address": info.addr.to_string(),
+                "via_nic": info.nic_addr.to_string(),
+                "spoke_data_address": info.spoke_data_addr.to_string(),
+                "report_address": info.report_addr.to_string(),
+                "send_command_address": info.send_command_addr.to_string(),
+                "replay": info.replay(),
+            })
+        })
+        .collect()
+}
+
+fn build_diagnostics(state: &Web, locator: InterfaceApi) -> Value {
+    json!({
+        "schema": "mayara-network-diagnostics-v1",
+        "generated_at": Utc::now().to_rfc3339(),
+        "server": {
+            "package": PACKAGE,
+            "version": VERSION,
+            "api_version": mayara::SIGNALK_RADAR_API_VERSION,
+            "compiled_features": compiled_features(),
+            "os": std::env::consts::OS,
+            "family": std::env::consts::FAMILY,
+            "arch": std::env::consts::ARCH,
+        },
+        "config": config_summary(&state.args),
+        "host": {
+            "interfaces": enumerate_host_interfaces(),
+        },
+        "locator": locator,
+        "radars": radars_summary(state),
+    })
+}
+
+fn gzip_json(body: &Value) -> std::io::Result<Vec<u8>> {
+    let json_bytes = serde_json::to_vec_pretty(body).expect("Value is always serializable");
+    let mut encoder = GzEncoder::new(Vec::with_capacity(json_bytes.len() / 4), Compression::default());
+    encoder.write_all(&json_bytes)?;
+    encoder.finish()
+}
+
+pub(crate) async fn get_diagnostics(State(state): State<Web>) -> Response {
+    let locator = fetch_interface_api(&state).await;
+    let body = build_diagnostics(&state, locator);
+
+    let gz = match gzip_json(&body) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log::error!("Failed to gzip diagnostics: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to compress diagnostics: {}", e),
+            )
+                .into_response();
+        }
+    };
+
+    let filename = format!(
+        "mayara-network-diagnostics-{}.json.gz",
+        Utc::now().format("%Y%m%dT%H%M%SZ")
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/gzip")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(Body::from(gz))
+        .expect("static headers cannot fail")
+}

--- a/src/bin/mayara-server/web/signalk/diagnostics.rs
+++ b/src/bin/mayara-server/web/signalk/diagnostics.rs
@@ -245,6 +245,29 @@ fn gzip_json(body: &Value) -> std::io::Result<Vec<u8>> {
     encoder.finish()
 }
 
+#[utoipa::path(
+    get,
+    path = "/signalk/v2/api/vessels/self/radars/diagnostics",
+    summary = "Download a network diagnostics snapshot (gzipped JSON)",
+    description = "Returns a gzipped JSON document describing how mayara sees the network. \
+                   Intended to be attached to a GitHub issue when reporting that a radar is \
+                   not being detected. The payload includes: server build metadata, sanitized \
+                   CLI config, host network interfaces, per-interface locator/listener status \
+                   with skip reasons, and the list of detected radars. For each interface where \
+                   at least one radar locator is actively listening, the response also lists \
+                   devices observed on that subnet — sourced from the host ARP cache, a \
+                   short scoped mDNS browse, and a passive multicast snoop on mDNS/SSDP/LLMNR. \
+                   No request body or query parameters. Response is `application/gzip` with a \
+                   `Content-Disposition: attachment` header; the wall-clock latency is bounded \
+                   by the passive snoop window (~5 s) when any interface qualifies, or returns \
+                   immediately otherwise.",
+    responses(
+        (status = 200, description = "Gzipped JSON diagnostics snapshot",
+         content_type = "application/gzip"),
+        (status = 500, description = "Failed to compress the diagnostics payload")
+    ),
+    tag = "Configuration"
+)]
 pub(crate) async fn get_diagnostics(State(state): State<Web>) -> Response {
     let locator = fetch_interface_api(&state).await;
     let devices_by_nic = devices::collect_per_interface(&locator).await;

--- a/src/bin/mayara-server/web/signalk/diagnostics.rs
+++ b/src/bin/mayara-server/web/signalk/diagnostics.rs
@@ -80,7 +80,10 @@ fn enumerate_host_interfaces() -> Vec<HostInterface> {
                     .collect(),
             })
             .collect(),
-        Err(_) => Vec::new(),
+        Err(e) => {
+            log::warn!("diagnostics: NetworkInterface::show() failed: {}", e);
+            Vec::new()
+        }
     }
 }
 

--- a/src/bin/mayara-server/web/signalk/mod.rs
+++ b/src/bin/mayara-server/web/signalk/mod.rs
@@ -1,1 +1,2 @@
+pub mod diagnostics;
 pub mod v2;

--- a/src/bin/mayara-server/web/signalk/mod.rs
+++ b/src/bin/mayara-server/web/signalk/mod.rs
@@ -1,2 +1,2 @@
-pub mod diagnostics;
+pub(crate) mod diagnostics;
 pub mod v2;

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -69,6 +69,7 @@ const RADAR_TARGET_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/t
     paths(
         get_radars,
         get_interfaces,
+        diagnostics::get_diagnostics,
         get_radar,
         get_control_values,
         get_control_value,

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -23,7 +23,7 @@ use utoipa::OpenApi;
 use utoipa::ToSchema;
 use utoipa_swagger_ui::{Config as SwaggerConfig, SwaggerUi};
 
-use crate::web::{derive_public_base, spokes_handler};
+use crate::web::{derive_public_base, signalk::diagnostics, spokes_handler};
 
 use super::super::{Message, Web, WebSocket, WebSocketUpgrade};
 use mayara::{
@@ -99,6 +99,10 @@ struct ApiDoc;
 pub(crate) fn routes(axum: axum::Router<Web>) -> axum::Router<Web> {
     axum.route(BASE_URI, get(get_radars))
         .route(INTERFACES_URI, get(get_interfaces))
+        .route(
+            diagnostics::DIAGNOSTICS_URI,
+            get(diagnostics::get_diagnostics),
+        )
         .route(CONTROL_URI, get(control_stream_handler))
         .route(SPOKES_URI, get(spokes_handler))
         .route(RADAR_CAPABILITIES_URI, get(get_radar))

--- a/src/lib/network/arp.rs
+++ b/src/lib/network/arp.rs
@@ -1,0 +1,334 @@
+//! Read the host's IPv4 ARP cache.
+//!
+//! Used by [`super::devices::collect_per_interface`] to seed the
+//! per-interface device list with hosts the kernel has recently exchanged
+//! traffic with. ARP only sees devices the host has actually talked to in
+//! the last ~10-20 minutes (entries are aged out by the kernel), so it
+//! misses silent radars that haven't responded to anything yet — but it's
+//! a free snapshot with no network I/O.
+
+use std::net::Ipv4Addr;
+
+#[derive(Debug, Clone)]
+pub struct ArpEntry {
+    pub ip: Ipv4Addr,
+    /// Lowercase colon-separated MAC, e.g. `aa:bb:cc:dd:ee:ff`. Incomplete
+    /// entries (no resolved MAC yet) are filtered out by the per-platform
+    /// readers, so this is always populated.
+    pub mac: String,
+    pub ifname: Option<String>,
+}
+
+/// Read the host ARP cache. Returns an empty vec rather than an error if
+/// the cache cannot be read — this is best-effort diagnostic data, not
+/// authoritative.
+pub fn list() -> Vec<ArpEntry> {
+    #[cfg(target_os = "linux")]
+    {
+        return linux::list();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return unix_arp::list();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return windows_arp::list();
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        Vec::new()
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::{ArpEntry, normalize_mac};
+    use std::fs;
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    /// `/proc/net/arp` columns (whitespace-separated, header on line 1):
+    ///   `IP address  HW type  Flags  HW address         Mask  Device`
+    /// Flags `0x0` means "incomplete" — drop those.
+    pub(super) fn list() -> Vec<ArpEntry> {
+        let raw = match fs::read_to_string("/proc/net/arp") {
+            Ok(s) => s,
+            Err(e) => {
+                log::debug!("arp: /proc/net/arp not readable: {}", e);
+                return Vec::new();
+            }
+        };
+        parse(&raw)
+    }
+
+    fn parse(raw: &str) -> Vec<ArpEntry> {
+        let mut out = Vec::new();
+        for line in raw.lines().skip(1) {
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            if cols.len() < 6 {
+                continue;
+            }
+            let (ip_s, flags, mac_s, ifname) = (cols[0], cols[2], cols[3], cols[5]);
+            if flags == "0x0" {
+                continue;
+            }
+            let Ok(ip) = Ipv4Addr::from_str(ip_s) else {
+                continue;
+            };
+            let Some(mac) = normalize_mac(mac_s) else {
+                continue;
+            };
+            out.push(ArpEntry {
+                ip,
+                mac,
+                ifname: Some(ifname.to_string()),
+            });
+        }
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parses_a_typical_proc_arp() {
+            let sample = "IP address       HW type     Flags       HW address            Mask     Device\n\
+                          192.168.1.1      0x1         0x2         a4:2b:b0:11:22:33     *        eth0\n\
+                          192.168.1.50     0x1         0x0         00:00:00:00:00:00     *        eth0\n\
+                          192.168.1.99     0x1         0x2         aa-bb-cc-dd-ee-ff     *        eth0\n";
+            let entries = parse(sample);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].ip, Ipv4Addr::new(192, 168, 1, 1));
+            assert_eq!(entries[0].mac, "a4:2b:b0:11:22:33");
+            assert_eq!(entries[0].ifname.as_deref(), Some("eth0"));
+            // The 0x0-flag entry must be skipped (incomplete).
+            assert_eq!(entries[1].ip, Ipv4Addr::new(192, 168, 1, 99));
+            // Dashes are normalized to colons.
+            assert_eq!(entries[1].mac, "aa:bb:cc:dd:ee:ff");
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod unix_arp {
+    use super::{ArpEntry, normalize_mac};
+    use std::net::Ipv4Addr;
+    use std::process::Command;
+    use std::str::FromStr;
+
+    pub(super) fn list() -> Vec<ArpEntry> {
+        // -a: all, -n: numeric (no DNS lookup, much faster on a marine LAN
+        // with no DNS server reachable). Bail quietly if arp(8) is missing
+        // or refuses to run — the diagnostics are best-effort.
+        let output = match Command::new("/usr/sbin/arp").args(["-an"]).output() {
+            Ok(o) if o.status.success() => o,
+            Ok(o) => {
+                log::debug!(
+                    "arp: arp -an exited with {}: {}",
+                    o.status,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                );
+                return Vec::new();
+            }
+            Err(e) => {
+                log::debug!("arp: cannot spawn /usr/sbin/arp: {}", e);
+                return Vec::new();
+            }
+        };
+        parse(&String::from_utf8_lossy(&output.stdout))
+    }
+
+    /// macOS `arp -an` lines look like:
+    ///   ? (10.0.0.1) at a4:2b:b0:11:22:33 on en0 ifscope [ethernet]
+    ///   ? (10.0.0.50) at (incomplete) on en0 ifscope [ethernet]
+    fn parse(raw: &str) -> Vec<ArpEntry> {
+        let mut out = Vec::new();
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            let Some(open) = trimmed.find('(') else {
+                continue;
+            };
+            let Some(close_rel) = trimmed[open + 1..].find(')') else {
+                continue;
+            };
+            let ip_s = &trimmed[open + 1..open + 1 + close_rel];
+            let Ok(ip) = Ipv4Addr::from_str(ip_s) else {
+                continue;
+            };
+            let rest = &trimmed[open + close_rel + 2..];
+            let Some(at_idx) = rest.find(" at ") else {
+                continue;
+            };
+            let after_at = &rest[at_idx + 4..];
+            // After " at ", the next whitespace-delimited token is either
+            // a MAC or the literal "(incomplete)".
+            let Some(mac_tok) = after_at.split_whitespace().next() else {
+                continue;
+            };
+            if mac_tok.starts_with('(') {
+                continue;
+            }
+            let Some(mac) = normalize_mac(mac_tok) else {
+                continue;
+            };
+            let ifname = after_at
+                .split_whitespace()
+                .skip_while(|t| *t != "on")
+                .nth(1)
+                .map(|s| s.to_string());
+            out.push(ArpEntry { ip, mac, ifname });
+        }
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parses_typical_macos_arp() {
+            let sample = "\
+? (10.0.0.1) at a4:2b:b0:11:22:33 on en0 ifscope [ethernet]
+? (10.0.0.50) at (incomplete) on en0 ifscope [ethernet]
+halo.local (192.168.1.50) at aa-bb-cc-dd-ee-ff on en1 ifscope permanent [ethernet]
+";
+            let entries = parse(sample);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].ip, Ipv4Addr::new(10, 0, 0, 1));
+            assert_eq!(entries[0].mac, "a4:2b:b0:11:22:33");
+            assert_eq!(entries[0].ifname.as_deref(), Some("en0"));
+            assert_eq!(entries[1].ip, Ipv4Addr::new(192, 168, 1, 50));
+            assert_eq!(entries[1].mac, "aa:bb:cc:dd:ee:ff");
+            assert_eq!(entries[1].ifname.as_deref(), Some("en1"));
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_arp {
+    use super::{ArpEntry, normalize_mac};
+    use std::net::Ipv4Addr;
+    use std::process::Command;
+    use std::str::FromStr;
+
+    pub(super) fn list() -> Vec<ArpEntry> {
+        let output = match Command::new("arp").args(["-a"]).output() {
+            Ok(o) if o.status.success() => o,
+            Ok(o) => {
+                log::debug!(
+                    "arp: arp -a exited with {}: {}",
+                    o.status,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                );
+                return Vec::new();
+            }
+            Err(e) => {
+                log::debug!("arp: cannot spawn arp.exe: {}", e);
+                return Vec::new();
+            }
+        };
+        parse(&String::from_utf8_lossy(&output.stdout))
+    }
+
+    /// Windows `arp -a` is grouped by NIC. Each interface section starts
+    /// with a header like:
+    ///   `Interface: 192.168.1.5 --- 0xa`
+    /// followed by a column header line and one row per neighbour:
+    ///   `  192.168.1.1           aa-bb-cc-dd-ee-ff     dynamic`
+    /// We track the current section's NIC IP (used as ifname fallback —
+    /// Windows interface name lookup is its own rabbit hole) and emit
+    /// dynamic entries with a resolved MAC.
+    fn parse(raw: &str) -> Vec<ArpEntry> {
+        let mut out = Vec::new();
+        let mut current_nic: Option<String> = None;
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("Interface:") {
+                current_nic = rest
+                    .split_whitespace()
+                    .next()
+                    .map(|s| s.to_string());
+                continue;
+            }
+            let cols: Vec<&str> = trimmed.split_whitespace().collect();
+            if cols.len() < 3 {
+                continue;
+            }
+            let Ok(ip) = Ipv4Addr::from_str(cols[0]) else {
+                continue;
+            };
+            let Some(mac) = normalize_mac(cols[1]) else {
+                continue;
+            };
+            // Skip multicast/broadcast static rows. "dynamic" entries are
+            // the kernel's resolved neighbours.
+            if !cols[2].eq_ignore_ascii_case("dynamic") {
+                continue;
+            }
+            out.push(ArpEntry {
+                ip,
+                mac,
+                ifname: current_nic.clone(),
+            });
+        }
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parses_typical_windows_arp() {
+            let sample = "\
+Interface: 192.168.1.5 --- 0xa
+  Internet Address      Physical Address      Type
+  192.168.1.1           aa-bb-cc-dd-ee-ff     dynamic
+  192.168.1.255         ff-ff-ff-ff-ff-ff     static
+  224.0.0.22            01-00-5e-00-00-16     static
+
+Interface: 10.0.0.7 --- 0xb
+  Internet Address      Physical Address      Type
+  10.0.0.1              11-22-33-44-55-66     dynamic
+";
+            let entries = parse(sample);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].ip, Ipv4Addr::new(192, 168, 1, 1));
+            assert_eq!(entries[0].mac, "aa:bb:cc:dd:ee:ff");
+            assert_eq!(entries[0].ifname.as_deref(), Some("192.168.1.5"));
+            assert_eq!(entries[1].ip, Ipv4Addr::new(10, 0, 0, 1));
+            assert_eq!(entries[1].ifname.as_deref(), Some("10.0.0.7"));
+        }
+    }
+}
+
+/// Accept MACs in either `aa:bb:cc:dd:ee:ff` or `aa-bb-cc-dd-ee-ff` form
+/// (both common across the platforms we read from). Output is always
+/// lowercase colon-separated.
+fn normalize_mac(raw: &str) -> Option<String> {
+    let s: String = raw
+        .chars()
+        .map(|c| if c == '-' { ':' } else { c.to_ascii_lowercase() })
+        .collect();
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 6 || parts.iter().any(|p| p.len() != 2) {
+        return None;
+    }
+    if !parts.iter().all(|p| p.chars().all(|c| c.is_ascii_hexdigit())) {
+        return None;
+    }
+    if parts.iter().all(|p| *p == "00") {
+        // Suppress all-zero MAC entries — Linux uses this for incomplete
+        // entries we already filter on `Flags`, but some macOS rows can
+        // be a placeholder too.
+        return None;
+    }
+    if parts.iter().all(|p| *p == "ff") {
+        // ff:ff:ff:ff:ff:ff is the static ARP entry every OS keeps for
+        // the IPv4 broadcast address — not a real device.
+        return None;
+    }
+    Some(s)
+}

--- a/src/lib/network/devices.rs
+++ b/src/lib/network/devices.rs
@@ -1,0 +1,193 @@
+//! Per-interface device discovery used by the network-diagnostics export.
+//!
+//! Combines three best-effort sources (ARP cache, scoped mDNS browse,
+//! passive multicast snooping) into one `Vec<Device>` per host NIC where
+//! mayara currently has at least one radar locator actively listening.
+//! Designed to give a maintainer enough context to answer "is this subnet
+//! even populated?" from a downloaded diagnostic file.
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::InterfaceApi;
+use crate::network::{arp, match_ipv4, mdns_browse, passive_capture};
+
+/// How long the mDNS browse runs. mDNS responders typically reply within
+/// 1 s on a quiet LAN; 3 s gives slow MFDs a margin.
+const MDNS_DURATION: Duration = Duration::from_secs(3);
+
+/// How long passive multicast capture runs. The shared deadline bounds
+/// the whole endpoint's latency; the user clicked a button, so this is
+/// also the perceived UI delay.
+const CAPTURE_DURATION: Duration = Duration::from_secs(5);
+
+/// A device observed on one host NIC's L2 segment, possibly via multiple
+/// evidence sources merged together.
+#[derive(Debug, Clone, Serialize)]
+pub struct Device {
+    #[serde(serialize_with = "serialize_ip")]
+    pub ip: Ipv4Addr,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac: Option<String>,
+    pub hostnames: Vec<String>,
+    /// Sources we learned about this device from, e.g.
+    /// `"arp"`, `"mdns:_workstation._tcp.local."`, `"passive:ssdp"`.
+    pub sources: Vec<String>,
+}
+
+/// Run ARP + mDNS + passive capture in parallel and group the merged
+/// results by qualifying NIC IPv4 address. NICs that have no active
+/// listener (or aren't `Ok`) are skipped — qualification matches the
+/// existing diagnostics scope.
+///
+/// Returns an empty map if no NIC qualifies. In that case the function
+/// also skips the network I/O entirely, so the endpoint stays fast on
+/// degraded setups (laptop with only Wi-Fi, `--allow-wifi` off, etc.).
+pub async fn collect_per_interface(
+    iface_api: &InterfaceApi,
+) -> HashMap<Ipv4Addr, Vec<Device>> {
+    let qualifying = collect_qualifying_nics(iface_api);
+    if qualifying.is_empty() {
+        return HashMap::new();
+    }
+
+    let nic_addrs: Vec<Ipv4Addr> = qualifying.iter().map(|q| q.ip).collect();
+    let if_names: Vec<String> = {
+        let mut names: Vec<String> = qualifying.iter().map(|q| q.name.clone()).collect();
+        names.sort();
+        names.dedup();
+        names
+    };
+
+    // ARP is a synchronous one-shot file/process read. Wrap it in
+    // spawn_blocking so a slow `arp(8)` on macOS doesn't block the
+    // reactor while mDNS + passive capture are running.
+    let arp_fut = tokio::task::spawn_blocking(arp::list);
+    let mdns_fut = mdns_browse::browse_one_shot(&if_names, MDNS_DURATION);
+    let capture_fut = passive_capture::capture_one_shot(&nic_addrs, CAPTURE_DURATION);
+
+    let (arp_res, mdns_hits, passive_hits) = tokio::join!(arp_fut, mdns_fut, capture_fut);
+    let arp_entries = arp_res.unwrap_or_else(|e| {
+        log::debug!("devices: arp::list join error: {}", e);
+        Vec::new()
+    });
+
+    let mut per_nic: HashMap<Ipv4Addr, HashMap<Ipv4Addr, Device>> = HashMap::new();
+    for q in &qualifying {
+        per_nic.insert(q.ip, HashMap::new());
+    }
+
+    // 1. ARP: filter to entries that fall in some qualifying NIC's subnet.
+    for entry in arp_entries {
+        for q in &qualifying {
+            if entry.ip != q.ip && match_ipv4(&entry.ip, &q.ip, &q.netmask) {
+                let dev = per_nic
+                    .get_mut(&q.ip)
+                    .expect("seeded above")
+                    .entry(entry.ip)
+                    .or_insert_with(|| empty_device(entry.ip));
+                if dev.mac.is_none() {
+                    dev.mac = Some(entry.mac.clone());
+                }
+                push_unique(&mut dev.sources, "arp".to_string());
+                // ARP cache holds each IP once; no need to keep checking.
+                break;
+            }
+        }
+    }
+
+    // 2. mDNS: same subnet filter; attach hostname.
+    for hit in mdns_hits {
+        for q in &qualifying {
+            if hit.ip != q.ip && match_ipv4(&hit.ip, &q.ip, &q.netmask) {
+                let dev = per_nic
+                    .get_mut(&q.ip)
+                    .expect("seeded above")
+                    .entry(hit.ip)
+                    .or_insert_with(|| empty_device(hit.ip));
+                push_unique(&mut dev.hostnames, hit.hostname.clone());
+                push_unique(&mut dev.sources, format!("mdns:{}", hit.service));
+                break;
+            }
+        }
+    }
+
+    // 3. Passive capture: NIC binding is already explicit — no need to
+    //    subnet-match; the hit carries the NIC it came in on.
+    for hit in passive_hits {
+        if let Some(bucket) = per_nic.get_mut(&hit.nic) {
+            let dev = bucket
+                .entry(hit.ip)
+                .or_insert_with(|| empty_device(hit.ip));
+            push_unique(&mut dev.sources, format!("passive:{}", hit.protocol));
+        }
+    }
+
+    per_nic
+        .into_iter()
+        .map(|(nic, devs)| {
+            let mut list: Vec<Device> = devs.into_values().collect();
+            list.sort_by_key(|d| u32::from(d.ip));
+            for d in &mut list {
+                d.sources.sort();
+                d.hostnames.sort();
+            }
+            (nic, list)
+        })
+        .collect()
+}
+
+struct QualifyingNic {
+    name: String,
+    ip: Ipv4Addr,
+    netmask: Ipv4Addr,
+}
+
+fn collect_qualifying_nics(iface_api: &InterfaceApi) -> Vec<QualifyingNic> {
+    let mut out = Vec::new();
+    for (id, iface) in &iface_api.interfaces {
+        let (Some(ip), Some(netmask)) = (iface.ip, iface.netmask) else {
+            continue;
+        };
+        if !matches!(iface.status, crate::InterfaceStatus::Ok) {
+            continue;
+        }
+        let Some(listeners) = iface.listeners.as_ref() else {
+            continue;
+        };
+        let has_active = listeners
+            .values()
+            .any(|status| status == "Listening" || status == "Active");
+        if !has_active {
+            continue;
+        }
+        out.push(QualifyingNic {
+            name: id.name.clone(),
+            ip,
+            netmask,
+        });
+    }
+    out
+}
+
+fn empty_device(ip: Ipv4Addr) -> Device {
+    Device {
+        ip,
+        mac: None,
+        hostnames: Vec::new(),
+        sources: Vec::new(),
+    }
+}
+
+fn push_unique(v: &mut Vec<String>, item: String) {
+    if !v.iter().any(|existing| existing == &item) {
+        v.push(item);
+    }
+}
+
+fn serialize_ip<S: serde::Serializer>(ip: &Ipv4Addr, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&ip.to_string())
+}

--- a/src/lib/network/mdns_browse.rs
+++ b/src/lib/network/mdns_browse.rs
@@ -1,0 +1,134 @@
+//! One-shot mDNS browse for the diagnostics endpoint.
+//!
+//! Spins up a fresh [`ServiceDaemon`], issues `browse()` for a handful of
+//! common service types, collects [`ServiceEvent::ServiceResolved`] events
+//! for a short window, then shuts the daemon down. Used by
+//! [`super::devices::collect_per_interface`] to attach hostnames to the
+//! per-interface device list.
+//!
+//! The daemon is scoped to a caller-supplied set of interface names so the
+//! browse does not leak across the host's other LANs (e.g. probing the
+//! house Wi-Fi from a marine engine-room install).
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use mdns_sd::{IfKind, ServiceDaemon, ServiceEvent};
+use tokio::task::JoinSet;
+use tokio::time::{Instant, sleep_until};
+
+#[derive(Debug, Clone)]
+pub struct MdnsHit {
+    pub ip: Ipv4Addr,
+    /// e.g. `halo-bridge.local.`
+    pub hostname: String,
+    /// The service type we caught it on, e.g. `_workstation._tcp.local.`
+    pub service: &'static str,
+}
+
+/// Service types worth browsing for "what's on this LAN" diagnostics.
+/// Each one catches a different population of devices:
+///
+/// - `_workstation._tcp` — Avahi/Bonjour-published generic hosts (Linux/macOS)
+/// - `_http._tcp` / `_https._tcp` — webservers, very common on MFDs/plotters
+/// - `_signalk-tcp._tcp` / `_signalk-http._tcp` / `_signalk-https._tcp` —
+///   Signal K servers, an obvious sibling on a radar net
+/// - `_googlecast._tcp` — Chromecasts; useful "is the AV LAN even alive?"
+/// - `_printer._tcp` / `_ipp._tcp` — printers / Bonjour print
+/// - `_services._dns-sd._udp` — meta service enumerating advertised types
+const SERVICE_TYPES: &[&str] = &[
+    "_workstation._tcp.local.",
+    "_http._tcp.local.",
+    "_https._tcp.local.",
+    "_signalk-tcp._tcp.local.",
+    "_signalk-http._tcp.local.",
+    "_signalk-https._tcp.local.",
+    "_googlecast._tcp.local.",
+    "_printer._tcp.local.",
+    "_ipp._tcp.local.",
+    "_services._dns-sd._udp.local.",
+];
+
+/// Browse mDNS for up to `duration` and return the resolved IPv4 hits.
+///
+/// `enabled_ifnames` are the NIC names (as `network-interface` reports
+/// them) that the daemon should listen on; if empty, the daemon's
+/// default behaviour is left alone (all interfaces). Any I/O error is
+/// soft-failed — the diagnostics are best-effort.
+pub async fn browse_one_shot(enabled_ifnames: &[String], duration: Duration) -> Vec<MdnsHit> {
+    let mdns = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            log::debug!("mdns_browse: ServiceDaemon::new failed: {}", e);
+            return Vec::new();
+        }
+    };
+
+    if !enabled_ifnames.is_empty() {
+        // Default is to listen on everything — narrow first, then opt in
+        // explicitly, so adjacent LANs the host happens to be on don't
+        // appear in this diagnostic.
+        let _ = mdns.disable_interface(IfKind::All);
+        for name in enabled_ifnames {
+            let _ = mdns.enable_interface(IfKind::Name(name.clone()));
+        }
+    }
+
+    let deadline = Instant::now() + duration;
+    let mut set: JoinSet<Vec<MdnsHit>> = JoinSet::new();
+
+    for st in SERVICE_TYPES {
+        let st: &'static str = st;
+        let rx = match mdns.browse(st) {
+            Ok(rx) => rx,
+            Err(e) => {
+                log::debug!("mdns_browse: browse({}) failed: {}", st, e);
+                continue;
+            }
+        };
+        set.spawn(async move {
+            let mut hits = Vec::new();
+            loop {
+                tokio::select! {
+                    _ = sleep_until(deadline) => return hits,
+                    event = rx.recv_async() => {
+                        match event {
+                            Ok(ServiceEvent::ServiceResolved(info)) => {
+                                let hostname = info.get_hostname().to_string();
+                                for addr in info.get_addresses_v4() {
+                                    hits.push(MdnsHit {
+                                        ip: addr,
+                                        hostname: hostname.clone(),
+                                        service: st,
+                                    });
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(_) => return hits,
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    let mut all = Vec::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok(hits) = res {
+            all.extend(hits);
+        }
+    }
+
+    if let Ok(stop) = mdns.shutdown() {
+        // Drain so the daemon thread exits cleanly. Bounded with a short
+        // timeout so a wedged daemon never holds the endpoint past its
+        // budget.
+        let _ = tokio::time::timeout(
+            Duration::from_millis(500),
+            tokio::task::spawn_blocking(move || stop.recv()),
+        )
+        .await;
+    }
+
+    all
+}

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -17,6 +17,11 @@ pub(crate) mod macos;
 #[cfg(target_os = "windows")]
 pub(crate) mod windows;
 
+pub mod arp;
+pub mod devices;
+pub mod mdns_browse;
+pub mod passive_capture;
+
 static G_REPLAY: AtomicBool = AtomicBool::new(false);
 
 pub fn set_replay(replay: bool) {

--- a/src/lib/network/passive_capture.rs
+++ b/src/lib/network/passive_capture.rs
@@ -1,0 +1,105 @@
+//! Passively snoop the well-known noisy IPv4 multicast groups on each
+//! caller-supplied NIC and report any source IPs we hear during a short
+//! window. Used by [`super::devices::collect_per_interface`] to surface
+//! devices that are currently chatting but haven't shown up in the host's
+//! ARP cache yet.
+//!
+//! All listen targets are high-port multicast (5353 mDNS, 1900 SSDP,
+//! 5355 LLMNR), so no root / `CAP_NET_RAW` is required.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+use tokio::time::{Instant, sleep_until};
+
+use crate::network::{SocketType, create_udp_listen};
+
+#[derive(Debug, Clone)]
+pub struct PassiveHit {
+    /// Source address of the packet we heard.
+    pub ip: Ipv4Addr,
+    /// The NIC the packet arrived on (matches one of `nic_addrs`).
+    pub nic: Ipv4Addr,
+    /// The well-known protocol/group we caught it on.
+    pub protocol: &'static str,
+}
+
+/// (Label, group address, port) for each multicast group we passively
+/// listen on. Receiving on these groups joins the group on the NIC, which
+/// is sufficient to harvest the source IP of every packet sent into the
+/// group by any device on the same L2 segment.
+const NOISY_GROUPS: &[(&str, Ipv4Addr, u16)] = &[
+    ("mdns", Ipv4Addr::new(224, 0, 0, 251), 5353),
+    ("ssdp", Ipv4Addr::new(239, 255, 255, 250), 1900),
+    ("llmnr", Ipv4Addr::new(224, 0, 0, 252), 5355),
+];
+
+/// Listen for up to `duration` on each (NIC × multicast group) pair and
+/// return every (source IP, NIC, protocol) triple we hear. Per-(NIC ×
+/// group) socket failures (e.g. IGMP join refused on a virtual NIC) are
+/// soft-failed at `debug` level so a single broken pair doesn't kill the
+/// rest.
+pub async fn capture_one_shot(nic_addrs: &[Ipv4Addr], duration: Duration) -> Vec<PassiveHit> {
+    if nic_addrs.is_empty() {
+        return Vec::new();
+    }
+
+    let deadline = Instant::now() + duration;
+    let mut set: JoinSet<Vec<PassiveHit>> = JoinSet::new();
+
+    for &nic_addr in nic_addrs {
+        for (protocol, group_ip, port) in NOISY_GROUPS {
+            let group = SocketAddrV4::new(*group_ip, *port);
+            let socket = match create_udp_listen(&group, &nic_addr, SocketType::Multicast) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::debug!(
+                        "passive_capture: skip {} on {}: {}",
+                        group, nic_addr, e
+                    );
+                    continue;
+                }
+            };
+            let protocol: &'static str = protocol;
+            set.spawn(async move {
+                let mut socket = socket;
+                let mut hits = Vec::new();
+                let mut buf: Vec<u8> = Vec::with_capacity(64);
+                loop {
+                    buf.clear();
+                    tokio::select! {
+                        _ = sleep_until(deadline) => return hits,
+                        res = socket.recv_buf_from(&mut buf) => {
+                            match res {
+                                Ok((_, SocketAddr::V4(src))) => {
+                                    let src_ip = *src.ip();
+                                    // Filter loopback and self — we're
+                                    // looking for *other* devices on the
+                                    // segment, not our own packets.
+                                    if src_ip != nic_addr && !src_ip.is_loopback() {
+                                        hits.push(PassiveHit {
+                                            ip: src_ip,
+                                            nic: nic_addr,
+                                            protocol,
+                                        });
+                                    }
+                                }
+                                Ok((_, SocketAddr::V6(_))) => {}
+                                Err(_) => return hits,
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    let mut all = Vec::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok(hits) = res {
+            all.extend(hits);
+        }
+    }
+    all
+}

--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -9,6 +9,8 @@
 const SIGNALK_RADARS_API = "/signalk/v2/api/vessels/self/radars";
 const STANDALONE_INTERFACES_API =
   "/signalk/v2/api/vessels/self/radars/interfaces";
+const DIAGNOSTICS_API =
+  "/signalk/v2/api/vessels/self/radars/diagnostics";
 const ENDPOINT_API = "/signalk";
 
 // Mount prefix to prepend to every API/WS path.
@@ -98,6 +100,14 @@ export function getRadarsPath() {
  */
 export function getInterfacesUrl() {
   return apiBase(STANDALONE_INTERFACES_API);
+}
+
+/**
+ * Get the network-diagnostics download URL (gzipped JSON).
+ * @returns {string} API URL
+ */
+export function getDiagnosticsUrl() {
+  return apiBase(DIAGNOSTICS_API);
 }
 
 /**

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0" />
     <link type="text/css" rel="stylesheet" href="base.css?v=1" />
     <link type="text/css" rel="stylesheet" href="discovery.css?v=1" />
-    <script type="module" src="mayara.js?v=4"></script>
+    <script type="module" src="mayara.js?v=5"></script>
 </head>
 <body>
     <div class="myr_discovery_container">

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0" />
     <link type="text/css" rel="stylesheet" href="base.css?v=1" />
     <link type="text/css" rel="stylesheet" href="discovery.css?v=1" />
-    <script type="module" src="mayara.js?v=3"></script>
+    <script type="module" src="mayara.js?v=4"></script>
 </head>
 <body>
     <div class="myr_discovery_container">

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -2,6 +2,7 @@ import van from "./vendor/van-1.5.2.debug.js";
 import {
   fetchRadars,
   fetchInterfaces,
+  getDiagnosticsUrl,
   isStandaloneMode,
   detectMode,
 } from "./api.js";
@@ -759,19 +760,15 @@ function hideInterfacesPopup() {
 }
 
 function showActionButtons() {
-  if (!isStandaloneMode()) {
-    return;
-  }
-
   const container = document.getElementById("action_buttons");
   if (!container) {
     return;
   }
 
-  van.add(
-    container,
-    div(
-      { class: "myr_action_buttons" },
+  const buttons = [];
+
+  if (isStandaloneMode()) {
+    buttons.push(
       button(
         {
           class: "myr_radar_link myr_radar_link_secondary",
@@ -786,8 +783,28 @@ function showActionButtons() {
         },
         "Recordings"
       )
+    );
+  }
+
+  buttons.push(
+    a(
+      {
+        href: getDiagnosticsUrl(),
+        class: "myr_radar_link myr_radar_link_secondary",
+        // The server sets Content-Disposition: attachment with a timestamped
+        // filename, so the empty `download` attribute just nudges browsers
+        // that ignore it in cross-origin / proxied setups to still treat
+        // the response as a download instead of navigating to it.
+        download: "",
+        title:
+          "Download a gzipped JSON report of the network state. " +
+          "Attach this to a GitHub issue when reporting that a radar is not detected.",
+      },
+      "Network Diagnostics"
     )
   );
+
+  van.add(container, div({ class: "myr_action_buttons" }, ...buttons));
 }
 
 async function loadRadars() {

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -759,6 +759,68 @@ function hideInterfacesPopup() {
   }
 }
 
+// Fetch the diagnostics blob via JS so we can show a busy state on the
+// button instead of giving the user no feedback while the ~5 s endpoint
+// runs. Mutates the button DOM directly — Van.js reactive state would
+// be overkill for a single transient interaction.
+async function downloadDiagnostics(btn) {
+  if (btn.disabled) return;
+  const restoreLabel = btn.textContent;
+  btn.disabled = true;
+  btn.replaceChildren(
+    span({
+      class: "myr_pulse",
+      style:
+        "display: inline-block; vertical-align: middle; margin-right: 10px;",
+    }),
+    document.createTextNode("Generating diagnostics…")
+  );
+  try {
+    const resp = await fetch(getDiagnosticsUrl());
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+    }
+    const blob = await resp.blob();
+    const filename =
+      parseAttachmentFilename(resp.headers.get("Content-Disposition")) ||
+      fallbackDiagnosticsFilename();
+    triggerBlobDownload(blob, filename);
+  } catch (err) {
+    console.error("Failed to download diagnostics:", err);
+    alert("Failed to generate diagnostics: " + err.message);
+  } finally {
+    btn.disabled = false;
+    btn.replaceChildren(document.createTextNode(restoreLabel));
+  }
+}
+
+// Parse the filename out of `attachment; filename="…"`. Only the quoted
+// form is recognised — that's what mayara always emits.
+function parseAttachmentFilename(headerValue) {
+  if (!headerValue) return null;
+  const m = headerValue.match(/filename="([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+function fallbackDiagnosticsFilename() {
+  const ts = new Date()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d+Z$/, "Z");
+  return `mayara-network-diagnostics-${ts}.json.gz`;
+}
+
+function triggerBlobDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
 function showActionButtons() {
   const container = document.getElementById("action_buttons");
   if (!container) {
@@ -786,19 +848,21 @@ function showActionButtons() {
     );
   }
 
+  // Generating the diagnostics is a ~5 s blocking operation server-side
+  // (ARP read + 3 s mDNS browse + 5 s passive multicast snoop, run in
+  // parallel and capped by the longest leg). Without an explicit busy
+  // state the button would just look broken for that whole interval, so
+  // intercept the click, fetch via JS, and swap the label for a pulsing
+  // "Generating diagnostics…" indicator while the request is in flight.
   buttons.push(
-    a(
+    button(
       {
-        href: getDiagnosticsUrl(),
         class: "myr_radar_link myr_radar_link_secondary",
-        // The server sets Content-Disposition: attachment with a timestamped
-        // filename, so the empty `download` attribute just nudges browsers
-        // that ignore it in cross-origin / proxied setups to still treat
-        // the response as a download instead of navigating to it.
-        download: "",
         title:
-          "Download a gzipped JSON report of the network state. " +
-          "Attach this to a GitHub issue when reporting that a radar is not detected.",
+          "Download a gzipped JSON report of the network state " +
+          "(takes ~5 seconds). Attach this to a GitHub issue when " +
+          "reporting that a radar is not detected.",
+        onclick: (e) => downloadDiagnostics(e.currentTarget),
       },
       "Network Diagnostics"
     )


### PR DESCRIPTION
## Summary

Add a Network Diagnostics button on the main radar overview page that
downloads a gzipped JSON snapshot of how mayara sees the network. Users
can attach the file to a GitHub issue when reporting that a radar is not
being detected, giving maintainers enough information to reproduce the
network configuration.

The snapshot includes:
- Server info (version, compiled features, OS / arch)
- Sanitized CLI config (Signal K bearer token is intentionally excluded)
- Host network interfaces (name, index, MAC, all IPv4/IPv6 addresses, netmask, broadcast)
- Per-interface per-brand locator/listener status, including the reason any interface was skipped (`WirelessIgnored`, `NoIPv4Address`, or `No match for <multicast>`)
- Detected radars with their IP/multicast addresses

A new endpoint `GET /signalk/v2/api/vessels/self/radars/diagnostics`
returns the snapshot as `application/gzip` with a `Content-Disposition:
attachment` filename like `mayara-network-diagnostics-<timestamp>.json.gz`.

`flate2` is promoted from an optional dep to a regular one (it was
already pulled in by the `pcap-replay` feature).

## Test plan

- [x] `cargo build --bin mayara-server`
- [x] `cargo build --features pcap-replay --bin mayara-server`
- [x] `cargo test --no-fail-fast` (282 lib + 15 integration tests pass)
- [x] Manual smoke test with `--emulator`: endpoint returns gzip, headers correct, radar shows up in `radars[]`
- [x] Manual smoke test without `--emulator`: locator section populated with all 5 brands and 26 interfaces, including `WirelessIgnored` / `NoIPv4Address` reasons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Network Diagnostics Feature

Adds a Network Diagnostics download button to the main radar overview page. When clicked, the button downloads a gzipped JSON snapshot containing diagnostic information about network configuration and radar detection.

## Backend Implementation

Introduces a new REST endpoint `GET /signalk/v2/api/vessels/self/radars/diagnostics` that returns a gzipped JSON snapshot with:
- Server metadata (version, compiled features, OS/architecture)
- Sanitized CLI configuration (Signal K bearer token excluded)
- Host network interfaces with names, indices, MAC addresses, IPv4/IPv6 addresses, netmasks, and broadcast addresses
- Per-interface and per-brand locator/listener status and skip reasons (e.g., `WirelessIgnored`, `NoIPv4Address`)
- Detected radars with IP and multicast addresses

The endpoint returns responses with `Content-Type: application/gzip`, appropriate `Content-Disposition` attachment headers, and a timestamp-based filename (`mayara-network-diagnostics-<timestamp>.json.gz`). The implementation uses internal `mpsc` channel communication to request current interface API state.

## Frontend Implementation

Adds a "Network Diagnostics" button to the radar overview page action buttons. The button is always visible (unlike standalone-mode-only links) and triggers a download of the diagnostic snapshot.

## Dependency Changes

Promotes `flate2` from an optional dependency gated by the `pcap-replay` feature to a standard dependency. The `pcap-replay` feature flag is now empty; the `generate-fixtures` example still requires this feature for its own purposes.

## Testing

Verified with:
- Successful builds with and without the `pcap-replay` feature
- All 282 library tests and 15 integration tests passing
- Manual smoke tests confirming gzip format and correct response headers
- Manual verification that the diagnostics endpoint populates correctly with all 5 brands and 26 interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->