### PR TITLE
chore(issue-template): ask for a network diagnostics file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,6 +36,26 @@ body:
       description: Drag and drop a PCAP capture file here (optional but very helpful for bugs related to issues with interpreting the radar picture and controls that do not work or have an incorrect value.)
 
   - type: textarea
+    id: network_diagnostics
+    attributes:
+      label: Network diagnostics
+      description: |
+        Drag and drop a network diagnostics file here. Strongly recommended if
+        your radar is not being detected, or for any other network / discovery
+        bug.
+
+        To generate the file: open the Mayara web GUI (the page where detected
+        radars are listed) and click the **Network Diagnostics** button. Your
+        browser will download a `mayara-network-diagnostics-…json.gz` file —
+        attach it here.
+
+        The file contains a snapshot of how Mayara sees the network: host
+        interfaces, per-interface locator status (including any skip reasons),
+        detected radars, and a per-subnet list of other devices observed via
+        ARP, mDNS and a passive multicast snoop. It does **not** contain any
+        radar data, control values, or credentials.
+
+  - type: textarea
     id: media
     attributes:
       label: Screenshot or video


### PR DESCRIPTION
## Summary

Add a drag-and-drop field to the bug report issue template for the
`mayara-network-diagnostics-*.json.gz` snapshot that the GUI's
**Network Diagnostics** button (added in #352) produces. Strongly
recommended for "radar not detected" reports, where the file gives
maintainers a full picture of the user's network setup without
needing remote access.

The field description explains how to generate the file and what it
does (and does not) contain, so users can make an informed decision
before attaching it.

## Test plan

- [x] YAML parses cleanly; field order is version → brand → model → pcap → **network_diagnostics** → media → description