### PR TITLE
ci: enforce cargo fmt on every push and PR

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Block any commit that would push a `cargo fmt`-dirty tree.
+#
+# Install once per clone:
+#     git config core.hooksPath .githooks
+#
+# The whole working tree is checked (not just staged files) because
+# `cargo fmt --check` is fast and the goal is that `main` is always
+# fmt-clean. If you have unrelated unstaged changes that fail the check,
+# run `cargo fmt` (idempotent, safe) and re-stage what you intended.
+
+set -e
+
+# Skip if there are no Rust files in the staged set — non-Rust commits
+# (docs, CI tweaks, etc.) shouldn't be gated on Rust formatter state.
+staged_rs=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.rs$' || true)
+if [ -z "$staged_rs" ]; then
+    exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "pre-commit: cargo not found on PATH — skipping fmt check." >&2
+    exit 0
+fi
+
+if ! cargo fmt --check >/dev/null 2>&1; then
+    echo
+    echo "pre-commit: cargo fmt --check failed."
+    echo "  Run 'cargo fmt' and re-stage."
+    echo
+    # Show the diff so the offending file(s) are obvious without re-running.
+    cargo fmt --check 2>&1 | head -40 >&2
+    exit 1
+fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - run: cargo fmt --check
+
   build:
     name: Build ${{ matrix.target }}
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,9 @@ Keep commits small and atomic - one logical change per commit. Split unrelated c
 **DO NOT** edit CHANGELOG.md — it is auto-generated from conventional commits at release time by git-cliff.
 **MANDATORY:** Never amend commits that have already been pushed to GitHub. Only amend local, unpushed commits.
 **MANDATORY:** Always rebase and clean up commit history before creating a PR or pushing changes. Amend fixes and corrections to the relevant existing commit instead of creating chains of "fix typo" or "oops" commits. The final history should contain only intentional, complete commits - no work-in-progress artifacts.
-**MANDATORY:** Run `cargo fmt` before every commit that touches Rust code. Every commit pushed to `main` must be `cargo fmt --check` clean — CI enforces this and will fail the build otherwise. Install the repo's pre-commit hook to catch this locally:
+**MANDATORY:** Run `cargo fmt` before every commit that touches Rust code. Every commit pushed to `main` must be `cargo fmt --check` clean — CI enforces this and will fail the build otherwise.
 
-```shell
-git config core.hooksPath .githooks
-```
-
-The hook lives in `.githooks/pre-commit` and runs `cargo fmt --check` whenever staged changes include any `.rs` file.
+A pre-commit hook in `.githooks/pre-commit` runs `cargo fmt --check` whenever staged changes include any `.rs` file. The hook is wired up automatically: the first time you run `cargo build` after cloning, `build.rs` points this clone's `core.hooksPath` at `.githooks/`. Contributors who already have their own `core.hooksPath` configured are left alone — extend their hook themselves if they want the same check.
 
 ## Pull Request Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,13 @@ Keep commits small and atomic - one logical change per commit. Split unrelated c
 **DO NOT** edit CHANGELOG.md — it is auto-generated from conventional commits at release time by git-cliff.
 **MANDATORY:** Never amend commits that have already been pushed to GitHub. Only amend local, unpushed commits.
 **MANDATORY:** Always rebase and clean up commit history before creating a PR or pushing changes. Amend fixes and corrections to the relevant existing commit instead of creating chains of "fix typo" or "oops" commits. The final history should contain only intentional, complete commits - no work-in-progress artifacts.
+**MANDATORY:** Run `cargo fmt` before every commit that touches Rust code. Every commit pushed to `main` must be `cargo fmt --check` clean — CI enforces this and will fail the build otherwise. Install the repo's pre-commit hook to catch this locally:
+
+```shell
+git config core.hooksPath .githooks
+```
+
+The hook lives in `.githooks/pre-commit` and runs `cargo fmt --check` whenever staged changes include any `.rs` file.
 
 ## Pull Request Guidelines
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 use std::{env, fs, path::PathBuf, process::Command};
 
 fn main() {
+    install_git_hooks_path();
+
     let mut src_path = PathBuf::from("src");
     src_path.push("lib");
     src_path.push("protos");
@@ -128,4 +130,50 @@ fn copy_dir_recursive(src: &PathBuf, dest: &PathBuf) {
             fs::copy(&path, &dest_path).unwrap();
         }
     }
+}
+
+/// Point this clone's `core.hooksPath` at `.githooks/` on first `cargo build`,
+/// so contributors get the pre-commit `cargo fmt` check without having to
+/// run `git config` themselves. Cheap and idempotent:
+///
+/// - Skips when we're not in a git working tree (e.g. crates.io packaged
+///   builds or `cargo vendor` output).
+/// - Skips when `.githooks/pre-commit` is missing.
+/// - Skips when `core.hooksPath` is already set to anything other than
+///   `.githooks` — contributors who configured their own hooks path are
+///   left alone (a one-line `cargo:warning=` tells them what they're
+///   missing).
+fn install_git_hooks_path() {
+    println!("cargo:rerun-if-changed=.githooks/pre-commit");
+
+    if !PathBuf::from(".git").is_dir() {
+        return;
+    }
+    if !PathBuf::from(".githooks/pre-commit").is_file() {
+        return;
+    }
+
+    let current = Command::new("git")
+        .args(["config", "--local", "--get", "core.hooksPath"])
+        .output();
+    let current = match current {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        Err(_) => return, // git not on PATH — nothing useful we can do.
+    };
+
+    if current == ".githooks" {
+        return; // Already wired up.
+    }
+    if !current.is_empty() {
+        println!(
+            "cargo:warning=core.hooksPath is set to '{}'; leaving it alone. \
+             Set it to '.githooks' to enable the repo's pre-commit cargo fmt check.",
+            current
+        );
+        return;
+    }
+
+    let _ = Command::new("git")
+        .args(["config", "--local", "core.hooksPath", ".githooks"])
+        .status();
 }


### PR DESCRIPTION
First enforcement piece of #355. Three changes, scoped to `cargo fmt` only:

- **`.githooks/pre-commit`** — runs `cargo fmt --check` whenever staged changes include any `.rs` file. Opt-in per clone via `git config core.hooksPath .githooks`.
- **`AGENTS.md`** — makes "run cargo fmt before every commit" mandatory and documents the hook install.
- **CI** — new `cargo fmt --check` job in `rust.yml`. Cheap and fast.

Clippy enforcement (the harder half of #355: 2 hard errors + 318 warnings) is a separate follow-up PR.

Refs #355

## Test plan

- [x] Hook returns 0 on a clean staged set
- [x] Hook returns 1 on a deliberately-dirty staged Rust file, prints the offending `Diff in …` excerpt
- [x] Hook returns 0 when no `.rs` file is staged (docs / CI only)
- [x] `rust.yml` parses