### PR TITLE
fix(settings): changing controls via web socket did not work

### DIFF
--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -2043,17 +2043,27 @@ impl RadarControlValue {
         }
     }
 
+    /// Decode `path` into `radar_id` and `control_id`.
+    ///
+    /// The path is built by [`Self::new`] as `radars.<radar>.controls.<control>`.
+    /// On success the matching fields on `self` are populated and the borrowed
+    /// `radar_id` slice is returned so the caller can immediately look the
+    /// radar up.
     pub fn parse_path(&mut self) -> Option<&str> {
         let mut path = self.path.as_str();
-        if path.starts_with("radars.") {
-            path = &path["radars.".len()..];
+        if let Some(rest) = path.strip_prefix("radars.") {
+            path = rest;
         }
-        if let Some(r) = path.split('.').next_back() {
-            self.control_id = ControlId::try_from(r).ok();
-            if self.control_id.is_some() {
-                self.radar_id = Some(r.to_string());
-                return Some(r);
-            }
+        // Split on the canonical `.controls.` separator. Using `split('.')`
+        // and taking the last segment as the radar id was wrong: it stored
+        // the *control* name in `radar_id`, which broke multi-radar routing
+        // because the caller in the Signal K stream handler then looked the
+        // radar up by the control name and silently dropped the request.
+        let (radar_id, control_name) = path.rsplit_once(".controls.")?;
+        self.control_id = ControlId::try_from(control_name).ok();
+        if self.control_id.is_some() {
+            self.radar_id = Some(radar_id.to_string());
+            return Some(radar_id);
         }
 
         None
@@ -3450,6 +3460,84 @@ mod test {
     use clap::Parser;
 
     use super::*;
+
+    /// Build a `RadarControlValue` with `path` set and every other field
+    /// at its default — `parse_path` only touches `path` / `radar_id` /
+    /// `control_id`, so the rest is irrelevant for these tests.
+    fn rcv_with_path(path: &str) -> RadarControlValue {
+        RadarControlValue {
+            radar_id: None,
+            control_id: None,
+            path: path.to_string(),
+            value: None,
+            units: None,
+            auto: None,
+            auto_value: None,
+            end_value: None,
+            start_distance: None,
+            end_distance: None,
+            enabled: None,
+            allowed: None,
+            error: None,
+            x1: None,
+            y1: None,
+            x2: None,
+            y2: None,
+            width: None,
+            timestamp: None,
+        }
+    }
+
+    #[test]
+    fn parse_path_canonical_form() {
+        let mut rcv = rcv_with_path("radars.nav1034A.controls.gain");
+        let radar_id = rcv.parse_path().unwrap().to_string();
+
+        assert_eq!(radar_id, "nav1034A");
+        assert_eq!(rcv.radar_id.as_deref(), Some("nav1034A"));
+        assert_eq!(rcv.control_id, Some(ControlId::Gain));
+    }
+
+    #[test]
+    fn parse_path_without_radars_prefix() {
+        // Some clients omit the leading `radars.` segment.
+        let mut rcv = rcv_with_path("nav1034A.controls.gain");
+        let radar_id = rcv.parse_path().unwrap().to_string();
+
+        assert_eq!(radar_id, "nav1034A");
+        assert_eq!(rcv.radar_id.as_deref(), Some("nav1034A"));
+        assert_eq!(rcv.control_id, Some(ControlId::Gain));
+    }
+
+    #[test]
+    fn parse_path_unknown_control_returns_none() {
+        let mut rcv = rcv_with_path("radars.nav1034A.controls.notARealControl");
+        assert!(rcv.parse_path().is_none());
+        assert!(rcv.control_id.is_none());
+        // radar_id must NOT be populated on failure — the caller relies on the
+        // return value, but defending the field too keeps callers honest.
+        assert!(rcv.radar_id.is_none());
+    }
+
+    #[test]
+    fn parse_path_missing_controls_separator_returns_none() {
+        let mut rcv = rcv_with_path("radars.nav1034A.gain");
+        assert!(rcv.parse_path().is_none());
+        assert!(rcv.control_id.is_none());
+        assert!(rcv.radar_id.is_none());
+    }
+
+    #[test]
+    fn parse_path_radar_id_with_dots() {
+        // Hypothetical multi-segment radar id — `rsplit_once` must split
+        // on the right-most `.controls.` so the whole prefix is the radar.
+        let mut rcv = rcv_with_path("radars.foo.bar.controls.gain");
+        let radar_id = rcv.parse_path().unwrap().to_string();
+
+        assert_eq!(radar_id, "foo.bar");
+        assert_eq!(rcv.radar_id.as_deref(), Some("foo.bar"));
+        assert_eq!(rcv.control_id, Some(ControlId::Gain));
+    }
 
     #[test]
     fn serialize_control_value() {

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -2060,7 +2060,7 @@ impl RadarControlValue {
         // because the caller in the Signal K stream handler then looked the
         // radar up by the control name and silently dropped the request.
         let (radar_id, control_name) = path.rsplit_once(".controls.")?;
-        self.control_id = ControlId::try_from(control_name).ok();
+        self.control_id = ControlId::from_str(control_name).ok();
         if self.control_id.is_some() {
             self.radar_id = Some(radar_id.to_string());
             return Some(radar_id);


### PR DESCRIPTION
## Summary

`RadarControlValue::parse_path` was decoding the WS control path `radars.<radar>.controls.<control>` by taking the **last** dot-separated segment as the radar id. The last segment is the **control** name, so:

- `self.radar_id` was filled with the control name (\"gain\"), and
- the function returned the control name to the caller.

The WS stream handler then called `radars.get_by_key("gain")`, found nothing, and silently dropped the request. Every WebSocket control PUT was a no-op in multi-radar (and single-radar) setups. REST PUT was unaffected — it has its own routing.

The fix splits the path with `rsplit_once(".controls.")` so the radar id is the prefix and the control name is the suffix.

## End-to-end verification

Smoke-tested against a live mayara on a Pi with two Navico HALO24 heads (nav1034A + nav1034B):

| | OLD binary | NEW binary |
|---|---|---|
| WS `{path: radars.nav1034A.controls.gain, value: 77, auto: false}` | gain stayed at the previous REST-set value, same timestamp — silent drop | gain → **77 manual** immediately |
| nav1034B (untouched) | n/a | unchanged, auto — multi-radar isolation works |
| REST PUT (positive control) | works | works |

## Tests

Adds five unit tests for `parse_path`:

- canonical form `radars.<radar>.controls.<control>`
- some clients send the path without the leading `radars.` segment
- unknown control name → returns `None`, leaves fields unset
- missing `.controls.` separator → returns `None`
- hypothetical multi-segment radar id (e.g. `foo.bar`) — `rsplit_once` must pick the right-most separator

## Test plan

- [x] `cargo build` + `cargo build --features pcap-replay` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --no-deps --all-targets -- -D warnings` and the `--features pcap-replay` variant clean
- [x] `cargo test` — 288 lib tests pass (was 283; +5 new)
- [x] Live WS smoke-test against the patched binary — old behaviour reproduced, new behaviour confirmed

Closes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug Fix: WebSocket Radar Control Path Parsing

Fixes `RadarControlValue::parse_path` to correctly extract radar identifiers from WebSocket control paths. The previous implementation used `path.split('.').next_back()` to extract the radar ID from paths like `radars.<radar>.controls.<control>`, but this actually returned the final segment (the control name) instead of the radar identifier. This caused WebSocket control PUT requests to fail silently, as handlers attempted to look up radars by control names (e.g., `radars.get_by_key("gain")`) instead of radar IDs.

The fix replaces the parsing logic with `rsplit_once(".controls.")`, which correctly decomposes the path into the radar ID prefix and control name suffix. The implementation now also tolerates paths that omit the leading `radars.` prefix and preserves multi-segment radar IDs that contain dots.

The test suite is extended with five new unit tests covering canonical paths, paths without the `radars.` prefix, unknown control names, missing `.controls.` separators, and multi-segment radar IDs. Smoke testing on a live two-radar setup confirms WebSocket control PUTs now route to the correct radar while maintaining multi-radar isolation and REST functionality.

**Changes**: +97/-9 lines in `src/lib/radar/settings.rs` (internal logic and tests only; function signature unchanged).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->