### PR TITLE
docs(agents): require user-facing description first in issues and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ PR titles are used to auto-generate the changelog and release notes. They **must
 
 PR descriptions must be **succinct and straight to the point**. Explain the motivation (why) and summarize the solution approach (how), but not the mechanics (what) - the diff shows what changed. Do not pad descriptions with unnecessary detail, verbose explanations, or self-congratulatory comments. If there are breaking changes, mention them explicitly. If a PR description includes a test plan with checkboxes, **all items must be checked** before the PR is ready for review - remove or complete any unchecked items.
 
+**Lead with the user-facing description.** Issue and PR descriptions must start with what a user of mayara sees or experiences — the symptom for a bug, the new capability for a feature, the impact for a change. Use plain language a boater or installer would understand, not Rust types, function names, or file paths. Only **after** that user-facing opener may the technical details (root cause, module, internal API, implementation approach) appear, in a clearly separated section. The same applies when rewriting an existing issue or PR description: the user-facing framing comes first, the gory details follow.
+
 When referencing issues, use `closes`, `fixes`, or `resolves` followed by the issue number (e.g., "closes #18", "fixes #21 and resolves #23").
 
 **MANDATORY:** One logical change per PR. Refactoring and behavior changes belong in separate PRs. If changes would result in multiple changelog entries, they should be separate PRs. Even if you have made multiple changes together locally, split them into separate PRs.


### PR DESCRIPTION
## What changes for contributors

Anyone reporting a bug, requesting a feature, or opening a PR is now
explicitly asked to open with what a user of mayara sees — symptom for a
bug, capability for a feature — in plain language a boater or installer
would understand. The technical detail (root cause, module names, file
paths, internal API) still belongs in the description, just below the
user-facing opener in a separated section.

## Why

Issue and PR titles drive the changelog and release notes, and the
descriptions are the first thing someone hitting the same problem reads.
Leading with `HashMap iteration index` or `parse_path rsplit_once` makes
those reports unreadable to the people they're actually written for. The
team confirmed this preference while rewriting #362 / #371.

## Test plan

- [x] Renders cleanly in the GitHub preview.