### PR TITLE
refactor: drop magic numbers when sending Power control values

### DIFF
--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -131,33 +131,27 @@ impl EmulatorReportReceiver {
 
         match cv.id {
             ControlId::Power => {
-                if let Some(ref value) = cv.value
-                    && let Some(power_val) = value.as_f64()
-                {
-                    let power = power_val as i32;
-                    match power {
-                        2 => {
-                            // Transmit
+                if let Some(ref value) = cv.value {
+                    match Power::from_value(value) {
+                        Ok(Power::Transmit) => {
                             log::info!("{}: Starting transmission", self.common.key);
                             self.transmitting = true;
                             self.common
                                 .set_value(&ControlId::Power, Power::Transmit as i32 as f64);
                         }
-                        1 => {
-                            // Standby
+                        Ok(Power::Standby) => {
                             log::info!("{}: Stopping transmission (standby)", self.common.key);
                             self.transmitting = false;
                             self.common
                                 .set_value(&ControlId::Power, Power::Standby as i32 as f64);
                         }
-                        0 => {
-                            // Off
+                        Ok(Power::Off) => {
                             log::info!("{}: Power off", self.common.key);
                             self.transmitting = false;
                             self.common
                                 .set_value(&ControlId::Power, Power::Off as i32 as f64);
                         }
-                        _ => {}
+                        Ok(Power::Preparing) | Err(_) => {}
                     }
                 }
             }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -892,7 +892,7 @@ impl SharedRadars {
                 log::info!("Requesting transmit mode for radar '{}'", key);
                 let control_value = ControlValue::new(
                     ControlId::Power,
-                    serde_json::Value::Number(serde_json::Number::from(2)), // 2 = Transmit
+                    serde_json::Value::Number(serde_json::Number::from(Power::Transmit as i32)),
                 );
                 // Create a dummy reply channel - we don't need the response
                 let (reply_tx, _reply_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
## What changes

Two leftover sites in mayara wrote raw \`0\` / \`1\` / \`2\` for the internal
Power control scale. Both now go through the existing \`Power\` enum
(\`Power::Transmit as i32\`, \`Power::from_value\`), so what the code says
matches what it means. Same pattern is already used in
\`koden::{report,command}\`, \`furuno::report\` and \`recording::player\`.

No user-visible change — purely cosmetic. The brand-specific *wire
bytes* (e.g. furuno=2 / navico=1 for Transmit) stay in each brand's
\`match Power::X => N\` arms; they're paired with that brand's report
parser and out of scope here.

Closes #364

## Test plan

- [x] \`cargo test\`, \`cargo fmt --check\`, \`cargo clippy --no-deps --all-targets -- -D warnings\` (default + \`pcap-replay\`). All green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Magic number elimination for Power control values

Refactors two locations to use the existing `Power` enum instead of raw numeric literals when handling Power control values, improving code clarity and maintainability.

### `src/lib/brand/emulator/report.rs`

The `EmulatorReportReceiver::handle_control_update` method now decodes incoming `ControlValue` for `ControlId::Power` using `Power::from_value()` and matches on the resulting enum variant. Instead of manually interpreting numeric values (2/1/0), the code explicitly handles `Power::Transmit`, `Power::Standby`, and `Power::Off` by logging, toggling `self.transmitting`, and writing the corresponding numeric discriminant. `Power::Preparing` and parse errors are treated as no-ops.

### `src/lib/radar/mod.rs`

The `SharedRadars::request_transmit_all` method derives the transmitted value from `Power::Transmit as i32` instead of using the hard-coded literal `2`.

### Scope

This refactoring is purely internal with no user-visible behavior changes. Brand-specific wire bytes remain in each brand's report parser match arms, as they are intentionally paired with that parser's logic and constitute a separate cleanup effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->