### PR TITLE
fix(raymarine): do not draw targets in doppler color when doppler is off

### DIFF
--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -131,33 +131,27 @@ impl EmulatorReportReceiver {
 
         match cv.id {
             ControlId::Power => {
-                if let Some(ref value) = cv.value
-                    && let Some(power_val) = value.as_f64()
-                {
-                    let power = power_val as i32;
-                    match power {
-                        2 => {
-                            // Transmit
+                if let Some(ref value) = cv.value {
+                    match Power::from_value(value) {
+                        Ok(Power::Transmit) => {
                             log::info!("{}: Starting transmission", self.common.key);
                             self.transmitting = true;
                             self.common
                                 .set_value(&ControlId::Power, Power::Transmit as i32 as f64);
                         }
-                        1 => {
-                            // Standby
+                        Ok(Power::Standby) => {
                             log::info!("{}: Stopping transmission (standby)", self.common.key);
                             self.transmitting = false;
                             self.common
                                 .set_value(&ControlId::Power, Power::Standby as i32 as f64);
                         }
-                        0 => {
-                            // Off
+                        Ok(Power::Off) => {
                             log::info!("{}: Power off", self.common.key);
                             self.transmitting = false;
                             self.common
                                 .set_value(&ControlId::Power, Power::Off as i32 as f64);
                         }
-                        _ => {}
+                        Ok(Power::Preparing) | Err(_) => {}
                     }
                 }
             }

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -40,12 +40,10 @@ const WAKE_INTERVAL: Duration = Duration::from_secs(3);
 const OBSERVATION_WINDOW: Duration = Duration::from_secs(5);
 const EXTERNAL_QUIET_WINDOW: Duration = Duration::from_secs(60);
 
-// The LookupSpokeEnum is an index into an array, really.
-// `Normal` is unused at the moment — the runtime always picks the
-// Doppler row (see quantum::process_frame); the variant is kept so
-// the enum continues to document the table's layout.
-#[allow(dead_code)]
-enum LookupDoppler {
+// The LookupSpokeEnum is an index into an array, really. `process_frame`
+// picks the row based on whether the radar currently reports Doppler on
+// (see `process_doppler_report`).
+pub(super) enum LookupDoppler {
     Normal = 0,
     Doppler = 1,
 }
@@ -160,6 +158,10 @@ pub(crate) struct RaymarineReportReceiver {
     // For data (spokes)
     range_meters: u32,
     wire_to_legend: WireToLegendTable,
+    // Tracks the radar's current Doppler state, fed by `process_doppler_report`.
+    // Selects the row in `wire_to_legend`: when off, byte 0xFE/0xFF stay raw;
+    // when on, they are remapped to the doppler-receding / -approaching markers.
+    doppler: bool,
 }
 
 impl RaymarineReportReceiver {
@@ -215,6 +217,7 @@ impl RaymarineReportReceiver {
             features_seen: false,
             range_meters: 0,
             wire_to_legend,
+            doppler: false,
         }
     }
 

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -95,6 +95,12 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
     }
     let spoke = &data[next_offset..next_offset + data_len];
 
+    let doppler_row = if receiver.doppler {
+        LookupDoppler::Doppler
+    } else {
+        LookupDoppler::Normal
+    } as usize;
+
     receiver.common.add_spoke(
         receiver.range_meters * returns_per_line / returns_per_range,
         azimuth,
@@ -102,7 +108,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
         process_spoke(
             returns_per_line as usize,
             spoke,
-            LookupDoppler::Doppler as usize,
+            doppler_row,
             &receiver.wire_to_legend,
         ),
     );
@@ -439,6 +445,7 @@ pub(super) fn process_doppler_report(receiver: &mut RaymarineReportReceiver, dat
     };
 
     log::trace!("{}: Doppler {} -> {doppler}", receiver.common.key, data[4]);
+    receiver.doppler = doppler != 0;
     receiver
         .common
         .set_value(&ControlId::Doppler, doppler as f64);
@@ -520,5 +527,34 @@ mod tests {
             /*returns_per_line=*/ 32, &spoke, /*doppler=*/ 1, &lookup,
         );
         assert_eq!(out, vec![0x12, 0x34]);
+    }
+
+    #[test]
+    fn process_spoke_normal_row_skips_doppler_substitution() {
+        // Build a table where Normal is identity but Doppler remaps
+        // 0xFE/0xFF to sentinel marker values. With the Normal row
+        // selected, 0xFE/0xFF must come out unchanged — exercising the
+        // row-selection branch that was previously hard-coded to
+        // Doppler regardless of the radar's actual mode.
+        let mut lookup: WireToLegendTable = [[0u8; BYTE_LOOKUP_LENGTH]; LOOKUP_DOPPLER_LENGTH];
+        for row in lookup.iter_mut() {
+            for (j, slot) in row.iter_mut().enumerate() {
+                *slot = j as u8;
+            }
+        }
+        lookup[1][0xFE] = 0xAA;
+        lookup[1][0xFF] = 0xBB;
+
+        let spoke = [0xFEu8, 0xFF, 0x42];
+
+        let normal = process_spoke(
+            /*returns_per_line=*/ 32, &spoke, /*doppler=*/ 0, &lookup,
+        );
+        assert_eq!(normal, vec![0xFE, 0xFF, 0x42]);
+
+        let doppler = process_spoke(
+            /*returns_per_line=*/ 32, &spoke, /*doppler=*/ 1, &lookup,
+        );
+        assert_eq!(doppler, vec![0xAA, 0xBB, 0x42]);
     }
 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -892,7 +892,7 @@ impl SharedRadars {
                 log::info!("Requesting transmit mode for radar '{}'", key);
                 let control_value = ControlValue::new(
                     ControlId::Power,
-                    serde_json::Value::Number(serde_json::Number::from(2)), // 2 = Transmit
+                    serde_json::Value::Number(serde_json::Number::from(Power::Transmit as i32)),
                 );
                 // Create a dummy reply channel - we don't need the response
                 let (reply_tx, _reply_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
## Symptom

On a Raymarine Quantum with Doppler **off**, occasional wire bytes of
0xFE / 0xFF in the spoke stream were being painted as
doppler-receding / -approaching pixels rather than as their plain
intensity values. In practice that meant the radar image could show
"ghost doppler" colouring on a radar that wasn't even in Doppler mode.

Doppler-capable Quantum hardware in Doppler mode is unaffected — that
path was already correct.

## Cause

\`process_frame\` indexed the \`wire_to_legend\` lookup table at
\`LookupDoppler::Doppler\` unconditionally, instead of choosing
\`Normal\` vs \`Doppler\` from the radar's current Doppler control.

## Fix

Track the radar's current Doppler state on \`RaymarineReportReceiver\`
(set from \`process_doppler_report\`, which already updates the
\`ControlId::Doppler\` control), and pick the row at frame time. Same
shape as the existing Navico path that picks one of six
\`LookupDoppler\` variants from \`DopplerMode\`.

Removed the \`#[allow(dead_code)]\` on \`LookupDoppler::Normal\` that
PR #358 had to add to keep clippy happy — both variants are now
reachable.

Closes #365

## Test plan

- [x] New unit test: build a table where Normal is identity and Doppler remaps 0xFE/0xFF; verify the row index drives the output.
- [x] Existing Quantum tests still pass.
- [x] \`cargo test\`, \`cargo fmt --check\`, \`cargo clippy --no-deps --all-targets -- -D warnings\` (default + \`pcap-replay\`).