### PR TITLE
refactor: consolidate NM and knot conversion constants

### DIFF
--- a/src/lib/brand/emulator/mod.rs
+++ b/src/lib/brand/emulator/mod.rs
@@ -6,7 +6,10 @@ use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
 use crate::config::GuardZone;
 use crate::locator::LocatorAddress;
 use crate::radar::settings::ControlId;
-use crate::radar::{GeoPosition, RadarInfo, SharedRadars};
+use crate::radar::{
+    FRAC_NM_2, FRAC_NM_4, FRAC_NM_8, FRAC_NM_16, FRAC_NM_32, GeoPosition, NM, RadarInfo,
+    SharedRadars,
+};
 use crate::{Brand, Cli};
 
 mod command;
@@ -26,11 +29,50 @@ const EMULATOR_HEADING: f64 = 270.0; // West
 // Speed in knots (nautical miles per hour)
 const EMULATOR_SPEED_KNOTS: f64 = 2.0;
 
-// Supported ranges in meters
+// Supported ranges in meters. The list interleaves metric (50, 75, 100, …)
+// and NM-derived (FRAC_NM_8, FRAC_NM_4, …) values so the emulator covers
+// both range modes.
 pub(crate) const EMULATOR_RANGES: &[i32] = &[
-    50, 57, 75, 100, 115, 231, 250, 463, 500, 750, 926, 1000, 1389, 1500, 1852, 2000, 2778, 3000,
-    3704, 4000, 5556, 6000, 7408, 8000, 11112, 12000, 14816, 16000, 22224, 24000, 29632, 36000,
-    44448, 48000, 59264, 64000, 66672, 72000, 74080, 88896,
+    50,
+    FRAC_NM_32,
+    75,
+    100,
+    FRAC_NM_16,
+    FRAC_NM_8,
+    250,
+    FRAC_NM_4,
+    500,
+    750,
+    FRAC_NM_2,
+    1000,
+    NM * 3 / 4,
+    1500,
+    NM,
+    2000,
+    NM * 3 / 2,
+    3000,
+    NM * 2,
+    4000,
+    NM * 3,
+    6000,
+    NM * 4,
+    8000,
+    NM * 6,
+    12000,
+    NM * 8,
+    16000,
+    NM * 12,
+    24000,
+    NM * 16,
+    36000,
+    NM * 24,
+    48000,
+    NM * 32,
+    64000,
+    NM * 36,
+    72000,
+    NM * 40,
+    NM * 48,
 ];
 
 /// Get the initial position for the emulator, considering static-position/stationary override

--- a/src/lib/brand/emulator/report.rs
+++ b/src/lib/brand/emulator/report.rs
@@ -11,7 +11,7 @@ use crate::Cli;
 use crate::radar::settings::{ControlId, ControlUpdate};
 use crate::radar::spoke::GenericSpoke;
 use crate::radar::{
-    CommonRadar, GeoPosition, NAUTICAL_MILE, Power, RadarError, RadarInfo, SharedRadars,
+    CommonRadar, FRAC_NM_2, GeoPosition, KN_TO_MS, Power, RadarError, RadarInfo, SharedRadars,
 };
 
 // Rotation speed: ~24 RPM = 2.5 seconds per rotation
@@ -19,7 +19,6 @@ const ROTATION_TIME_MS: u64 = 2500;
 const SPOKES_PER_BATCH: usize = 32; // Like Navico
 
 // Conversion constants
-const KNOTS_TO_MS: f64 = 1852.0 / 3600.0;
 const DEG_TO_RAD: f64 = PI / 180.0;
 
 pub(crate) struct EmulatorReportReceiver {
@@ -72,7 +71,7 @@ impl EmulatorReportReceiver {
             boat_position: initial_pos,
             boat_heading: heading,
             boat_speed: speed,
-            current_range: (NAUTICAL_MILE / 2) as u32, // Default 1/2 nm
+            current_range: FRAC_NM_2 as u32, // Default 1/2 nm
             transmitting: false,
             boat_turn: None,
             initial_lon: initial_pos.lon(),
@@ -182,7 +181,7 @@ impl EmulatorReportReceiver {
         let elapsed_secs = elapsed.as_secs_f64();
 
         if let Some(mut turn) = self.boat_turn.take() {
-            let speed_ms = self.boat_speed * KNOTS_TO_MS;
+            let speed_ms = self.boat_speed * KN_TO_MS;
             let angular_velocity = speed_ms / turn.radius;
             turn.turned += angular_velocity * elapsed_secs;
 
@@ -220,7 +219,7 @@ impl EmulatorReportReceiver {
             }
         } else if self.boat_speed != 0.0 {
             // Straight-line movement
-            let distance = self.boat_speed * KNOTS_TO_MS * elapsed_secs;
+            let distance = self.boat_speed * KN_TO_MS * elapsed_secs;
             let heading_rad = self.boat_heading * DEG_TO_RAD;
             self.boat_position = self
                 .boat_position
@@ -297,7 +296,7 @@ impl EmulatorReportReceiver {
             "emulator",
         );
         crate::navdata::set_heading_true(Some(self.boat_heading * DEG_TO_RAD), "emulator");
-        crate::navdata::set_sog(Some(self.boat_speed * KNOTS_TO_MS));
+        crate::navdata::set_sog(Some(self.boat_speed * KN_TO_MS));
         crate::navdata::set_cog(Some(self.boat_heading * DEG_TO_RAD));
     }
 

--- a/src/lib/brand/emulator/world.rs
+++ b/src/lib/brand/emulator/world.rs
@@ -1,6 +1,6 @@
 use std::f64::consts::{PI, TAU};
 
-use crate::radar::GeoPosition;
+use crate::radar::{GeoPosition, KN_TO_MS};
 
 // Constants for east-moving targets simulation
 const TARGET_SPEED_KNOTS: f64 = 5.0;
@@ -32,7 +32,6 @@ const FAST_TARGET_SPACING: f64 = 400.0; // meters between targets
 const NUM_FAST_TARGETS: usize = 10;
 
 // Conversion constants
-const KNOTS_TO_MS: f64 = 1852.0 / 3600.0; // 1 knot = 1852m/h = 0.5144 m/s
 const DEG_TO_RAD: f64 = PI / 180.0;
 
 /// Radius of the half-circle turn when reversing course (meters)
@@ -73,7 +72,7 @@ impl Target {
         Target {
             position,
             heading,
-            speed: speed_knots * KNOTS_TO_MS,
+            speed: speed_knots * KN_TO_MS,
             turn: None,
         }
     }
@@ -172,7 +171,7 @@ pub(crate) struct CirclingTarget {
 
 impl CirclingTarget {
     fn new(center: GeoPosition, radius: f64, speed_knots: f64) -> Self {
-        let speed_ms = speed_knots * KNOTS_TO_MS;
+        let speed_ms = speed_knots * KN_TO_MS;
         // Angular velocity = v / r (radians per second)
         let angular_velocity = speed_ms / radius;
 

--- a/src/lib/brand/furuno/protocol.rs
+++ b/src/lib/brand/furuno/protocol.rs
@@ -29,6 +29,8 @@ use std::fmt::{self, Display};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::time::Duration;
 
+use crate::radar::{FRAC_NM_2, FRAC_NM_4, FRAC_NM_8, FRAC_NM_16, NM};
+
 // =============================================================================
 // Spoke geometry
 // =============================================================================
@@ -489,28 +491,28 @@ pub(crate) const WIRE_UNIT_KM: i32 = 1;
 /// that do not correspond to a sorted range order. Verified via Wireshark
 /// captures from TimeZero ↔ DRS4D-NXT.
 pub(crate) const WIRE_INDEX_TABLE: [(i32, i32); 22] = [
-    (21, 116),    // 1/16 nm = 116m - wire index 21!
-    (0, 231),     // 1/8 nm = 231m
-    (1, 463),     // 1/4 nm = 463m
-    (2, 926),     // 1/2 nm = 926m
-    (3, 1389),    // 3/4 nm = 1389m
-    (4, 1852),    // 1 nm = 1852m
-    (5, 2778),    // 1.5 nm = 2778m
-    (6, 3704),    // 2 nm = 3704m
-    (7, 5556),    // 3 nm = 5556m
-    (8, 7408),    // 4 nm = 7408m
-    (9, 11112),   // 6 nm = 11112m
-    (10, 14816),  // 8 nm = 14816m
-    (11, 22224),  // 12 nm = 22224m
-    (12, 29632),  // 16 nm = 29632m
-    (13, 44448),  // 24 nm = 44448m
-    (14, 59264),  // 32 nm = 59264m
-    (19, 66672),  // 36 nm = 66672m (OUT OF SEQUENCE!)
-    (15, 88896),  // 48 nm = 88896m
-    (20, 118528), // 64 nm = 118528m (OUT OF SEQUENCE!)
-    (16, 133344), // 72 nm = 133344m
-    (17, 177792), // 96 nm = 177792m
-    (18, 222240), // 120 nm = 222240m
+    (21, FRAC_NM_16), // 1/16 nm — wire index 21!
+    (0, FRAC_NM_8),   // 1/8 nm
+    (1, FRAC_NM_4),   // 1/4 nm
+    (2, FRAC_NM_2),   // 1/2 nm
+    (3, NM * 3 / 4),  // 3/4 nm
+    (4, NM),          // 1 nm
+    (5, NM * 3 / 2),  // 1.5 nm
+    (6, NM * 2),      // 2 nm
+    (7, NM * 3),      // 3 nm
+    (8, NM * 4),      // 4 nm
+    (9, NM * 6),      // 6 nm
+    (10, NM * 8),     // 8 nm
+    (11, NM * 12),    // 12 nm
+    (12, NM * 16),    // 16 nm
+    (13, NM * 24),    // 24 nm
+    (14, NM * 32),    // 32 nm
+    (19, NM * 36),    // 36 nm (OUT OF SEQUENCE!)
+    (15, NM * 48),    // 48 nm
+    (20, NM * 64),    // 64 nm (OUT OF SEQUENCE!)
+    (16, NM * 72),    // 72 nm
+    (17, NM * 96),    // 96 nm
+    (18, NM * 120),   // 120 nm
 ];
 
 /// Wire index → meters mapping (km mode, wire unit 1).

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -6,7 +6,9 @@ use crate::{
         ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
         new_sector, new_string,
     },
-    radar::{RadarInfo, range::Ranges, units::Units},
+    radar::{
+        FRAC_NM_2, FRAC_NM_4, FRAC_NM_8, FRAC_NM_16, NM, RadarInfo, range::Ranges, units::Units,
+    },
     stream::SignalKDelta,
 };
 
@@ -406,49 +408,49 @@ pub(crate) fn update_when_model_known(info: &mut RadarInfo, model: RadarModel, v
 /// Range table for DRS-NXT series (in meters)
 /// Ranges: 1/16, 1/8, 1/4, 1/2, 3/4, 1, 1.5, 2, 3, 4, 6, 8, 12, 16, 24, 32, 36, 48 NM
 static RANGE_TABLE_DRS_NXT: &[i32] = &[
-    116,   // 1/16 NM
-    231,   // 1/8 NM
-    463,   // 1/4 NM
-    926,   // 1/2 NM
-    1389,  // 3/4 NM
-    1852,  // 1 NM
-    2778,  // 1.5 NM
-    3704,  // 2 NM
-    5556,  // 3 NM
-    7408,  // 4 NM
-    11112, // 6 NM
-    14816, // 8 NM
-    22224, // 12 NM
-    29632, // 16 NM
-    44448, // 24 NM
-    59264, // 32 NM
-    66672, // 36 NM
-    88896, // 48 NM
+    FRAC_NM_16, // 1/16 NM
+    FRAC_NM_8,  // 1/8 NM
+    FRAC_NM_4,  // 1/4 NM
+    FRAC_NM_2,  // 1/2 NM
+    NM * 3 / 4, // 3/4 NM
+    NM,         // 1 NM
+    NM * 3 / 2, // 1.5 NM
+    NM * 2,     // 2 NM
+    NM * 3,     // 3 NM
+    NM * 4,     // 4 NM
+    NM * 6,     // 6 NM
+    NM * 8,     // 8 NM
+    NM * 12,    // 12 NM
+    NM * 16,    // 16 NM
+    NM * 24,    // 24 NM
+    NM * 32,    // 32 NM
+    NM * 36,    // 36 NM
+    NM * 48,    // 48 NM
 ];
 
 /// Extended range table for DRS12A/DRS25A-NXT (adds 64, 72, 96 NM)
 static RANGE_TABLE_DRS_NXT_EXTENDED: &[i32] = &[
-    116,    // 1/16 NM
-    231,    // 1/8 NM
-    463,    // 1/4 NM
-    926,    // 1/2 NM
-    1389,   // 3/4 NM
-    1852,   // 1 NM
-    2778,   // 1.5 NM
-    3704,   // 2 NM
-    5556,   // 3 NM
-    7408,   // 4 NM
-    11112,  // 6 NM
-    14816,  // 8 NM
-    22224,  // 12 NM
-    29632,  // 16 NM
-    44448,  // 24 NM
-    59264,  // 32 NM
-    66672,  // 36 NM
-    88896,  // 48 NM
-    118528, // 64 NM
-    133344, // 72 NM
-    177792, // 96 NM
+    FRAC_NM_16, // 1/16 NM
+    FRAC_NM_8,  // 1/8 NM
+    FRAC_NM_4,  // 1/4 NM
+    FRAC_NM_2,  // 1/2 NM
+    NM * 3 / 4, // 3/4 NM
+    NM,         // 1 NM
+    NM * 3 / 2, // 1.5 NM
+    NM * 2,     // 2 NM
+    NM * 3,     // 3 NM
+    NM * 4,     // 4 NM
+    NM * 6,     // 6 NM
+    NM * 8,     // 8 NM
+    NM * 12,    // 12 NM
+    NM * 16,    // 16 NM
+    NM * 24,    // 24 NM
+    NM * 32,    // 32 NM
+    NM * 36,    // 36 NM
+    NM * 48,    // 48 NM
+    NM * 64,    // 64 NM
+    NM * 72,    // 72 NM
+    NM * 96,    // 96 NM
 ];
 
 /// Range table for DRS-NXT series in km mode (in meters)
@@ -550,20 +552,20 @@ static RANGE_TABLE_FAR_KM: &[i32] = &[
 /// Wire index 21 (1/16 NM) is not supported on DRS4W; 32/36 NM are
 /// out of reach for this 4 kW WiFi radar.
 static RANGE_TABLE_DRS4W: &[i32] = &[
-    231,   // 1/8 NM
-    463,   // 1/4 NM
-    926,   // 1/2 NM
-    1389,  // 3/4 NM
-    1852,  // 1 NM
-    2778,  // 1.5 NM
-    3704,  // 2 NM
-    5556,  // 3 NM
-    7408,  // 4 NM
-    11112, // 6 NM
-    14816, // 8 NM
-    22224, // 12 NM
-    29632, // 16 NM
-    44448, // 24 NM
+    FRAC_NM_8,  // 1/8 NM
+    FRAC_NM_4,  // 1/4 NM
+    FRAC_NM_2,  // 1/2 NM
+    NM * 3 / 4, // 3/4 NM
+    NM,         // 1 NM
+    NM * 3 / 2, // 1.5 NM
+    NM * 2,     // 2 NM
+    NM * 3,     // 3 NM
+    NM * 4,     // 4 NM
+    NM * 6,     // 6 NM
+    NM * 8,     // 8 NM
+    NM * 12,    // 12 NM
+    NM * 16,    // 16 NM
+    NM * 24,    // 24 NM
 ];
 
 /// Range table for DRS4W WiFi radar in km mode (0.125–24 km).
@@ -586,44 +588,44 @@ static RANGE_TABLE_DRS4W_KM: &[i32] = &[
 
 /// Range table for standard DRS series (non-NXT, up to 36 NM)
 static RANGE_TABLE_DRS: &[i32] = &[
-    116,   // 1/16 NM
-    231,   // 1/8 NM
-    463,   // 1/4 NM
-    926,   // 1/2 NM
-    1389,  // 3/4 NM
-    1852,  // 1 NM
-    2778,  // 1.5 NM
-    3704,  // 2 NM
-    5556,  // 3 NM
-    7408,  // 4 NM
-    11112, // 6 NM
-    14816, // 8 NM
-    22224, // 12 NM
-    29632, // 16 NM
-    44448, // 24 NM
-    59264, // 32 NM
-    66672, // 36 NM
+    FRAC_NM_16, // 1/16 NM
+    FRAC_NM_8,  // 1/8 NM
+    FRAC_NM_4,  // 1/4 NM
+    FRAC_NM_2,  // 1/2 NM
+    NM * 3 / 4, // 3/4 NM
+    NM,         // 1 NM
+    NM * 3 / 2, // 1.5 NM
+    NM * 2,     // 2 NM
+    NM * 3,     // 3 NM
+    NM * 4,     // 4 NM
+    NM * 6,     // 6 NM
+    NM * 8,     // 8 NM
+    NM * 12,    // 12 NM
+    NM * 16,    // 16 NM
+    NM * 24,    // 24 NM
+    NM * 32,    // 32 NM
+    NM * 36,    // 36 NM
 ];
 
 /// Range table for FAR series commercial radars (different range increments)
 static RANGE_TABLE_FAR: &[i32] = &[
-    231,    // 1/8 NM
-    463,    // 1/4 NM
-    926,    // 1/2 NM
-    1389,   // 3/4 NM
-    1852,   // 1 NM
-    2778,   // 1.5 NM
-    3704,   // 2 NM
-    5556,   // 3 NM
-    7408,   // 4 NM
-    11112,  // 6 NM
-    14816,  // 8 NM
-    22224,  // 12 NM
-    29632,  // 16 NM
-    44448,  // 24 NM
-    59264,  // 32 NM
-    88896,  // 48 NM
-    177792, // 96 NM
+    FRAC_NM_8,  // 1/8 NM
+    FRAC_NM_4,  // 1/4 NM
+    FRAC_NM_2,  // 1/2 NM
+    NM * 3 / 4, // 3/4 NM
+    NM,         // 1 NM
+    NM * 3 / 2, // 1.5 NM
+    NM * 2,     // 2 NM
+    NM * 3,     // 3 NM
+    NM * 4,     // 4 NM
+    NM * 6,     // 6 NM
+    NM * 8,     // 8 NM
+    NM * 12,    // 12 NM
+    NM * 16,    // 16 NM
+    NM * 24,    // 24 NM
+    NM * 32,    // 32 NM
+    NM * 48,    // 48 NM
+    NM * 96,    // 96 NM
 ];
 
 /// Get the combined NM + km range table for a specific model.

--- a/src/lib/brand/garmin/mod.rs
+++ b/src/lib/brand/garmin/mod.rs
@@ -22,8 +22,7 @@ mod settings;
 use capabilities::GarminCapabilities;
 use protocol::*;
 
-// 1 nautical mile in meters
-const NM: i32 = 1852;
+use crate::radar::{FRAC_NM_2, FRAC_NM_4, NM};
 
 // Garmin HD metric ranges (meters)
 const GARMIN_HD_RANGES_METRIC: &[i32] = &[
@@ -34,8 +33,8 @@ const GARMIN_HD_RANGES_METRIC: &[i32] = &[
 // Garmin HD nautical ranges (meters, based on NM fractions)
 const GARMIN_HD_RANGES_NAUTICAL: &[i32] = &[
     232,        // ~1/8 NM
-    NM / 4,     // 463
-    NM / 2,     // 926
+    FRAC_NM_4,  // 463
+    FRAC_NM_2,  // 926
     NM * 3 / 4, // 1389
     NM,         // 1852
     NM * 3 / 2, // 2778

--- a/src/lib/brand/koden/protocol.rs
+++ b/src/lib/brand/koden/protocol.rs
@@ -22,6 +22,8 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+use crate::radar::NM_F64;
+
 // =============================================================================
 // Spoke geometry
 // =============================================================================
@@ -211,16 +213,14 @@ pub(crate) const RANGE_TABLE_NM: [f64; 20] = [
     64.0, 72.0, 96.0,
 ];
 
-const NM_TO_METERS: f64 = 1852.0;
-
 /// Convert a range index to meters.
 pub(crate) fn range_index_to_meters(index: u8) -> f64 {
     let idx = index as usize;
     if idx < RANGE_TABLE_NM.len() {
-        RANGE_TABLE_NM[idx] * NM_TO_METERS
+        RANGE_TABLE_NM[idx] * NM_F64
     } else {
         // Fallback for unknown indices
-        RANGE_TABLE_NM[RANGE_TABLE_NM.len() - 1] * NM_TO_METERS
+        RANGE_TABLE_NM[RANGE_TABLE_NM.len() - 1] * NM_F64
     }
 }
 

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -24,9 +24,9 @@ use crate::Cli;
 use crate::brand::navico::info::{HaloHeadingPacket, HaloNavigationPacket, Information};
 use crate::brand::navico::{HALO_HEADING_INFO_ADDRESS, HaloMode};
 use crate::network;
+use crate::radar::MS_TO_KN;
 use crate::radar::settings::ControlId;
 use crate::radar::spoke::GenericSpoke;
-use crate::radar::target::MS_TO_KN;
 use crate::radar::{
     BYTE_LOOKUP_LENGTH, CommonRadar, DopplerMode, Legend, Power, RadarError, RadarInfo,
     SharedRadars, SpokeBearing,

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -43,8 +43,25 @@ use crate::stream::SignalKDelta;
 use crate::{Brand, Cli, TargetMode};
 use range::Ranges;
 
-pub const NAUTICAL_MILE: i32 = 1852; // 1 nautical mile in meters
-pub const NAUTICAL_MILE_F64: f64 = 1852.; // 1 nautical mile in meters
+/// 1 nautical mile in metres, integer.
+pub const NM: i32 = 1852;
+/// 1 nautical mile in metres, floating point.
+pub const NM_F64: f64 = 1852.;
+
+/// `FRAC_NM_n` = 1 nm / n in metres, mirroring `std::f64::consts::FRAC_PI_n`.
+/// Defined for the powers-of-two denominators that show up in radar range
+/// tables; awkward fractions (3/4 nm, 1.5 nm, …) are written inline as
+/// `NM * 3 / 4` / `NM * 3 / 2`.
+pub const FRAC_NM_2: i32 = NM / 2;
+pub const FRAC_NM_4: i32 = NM / 4;
+pub const FRAC_NM_8: i32 = NM / 8;
+pub const FRAC_NM_16: i32 = NM / 16;
+pub const FRAC_NM_32: i32 = NM / 32;
+
+/// Knots ↔ m/s, derived from `NM_F64`. Placed here (alongside the NM
+/// constants) rather than scattered as `1852.0 / 3600.0` literals.
+pub const KN_TO_MS: f64 = NM_F64 / 3600.;
+pub const MS_TO_KN: f64 = 3600. / NM_F64;
 
 // A "native to radar" bearing, usually [0..2048] or [0..4096] or [0..8192]
 pub type SpokeBearing = u16;

--- a/src/lib/radar/range.rs
+++ b/src/lib/radar/range.rs
@@ -10,9 +10,9 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::sync::LazyLock;
 
-use crate::radar::NAUTICAL_MILE_F64;
+use crate::radar::NM_F64;
 
-use super::NAUTICAL_MILE;
+use super::{FRAC_NM_2, FRAC_NM_4, FRAC_NM_8, FRAC_NM_16, FRAC_NM_32, NM};
 
 // What follows are ranges that we try when range detection is attempted
 // where the code will send all those ranges to the radar to see if it
@@ -21,30 +21,30 @@ use super::NAUTICAL_MILE;
 // All ranges seen on all radars
 static ALL_POSSIBLE_NAUTICAL_RANGES: LazyLock<Ranges> = LazyLock::new(|| {
     Ranges::new(vec![
-        Range::initial(57),                  // 1/32 nm
-        Range::initial(115),                 // 1/16 nm
-        Range::initial(231),                 // 1/8 nm
-        Range::initial(463),                 // 1/4 nm
-        Range::initial(926),                 // 1/2 nm
-        Range::initial(1389),                // 3/4 nm
-        Range::initial(NAUTICAL_MILE),       // 1 nm
-        Range::initial(NAUTICAL_MILE + 926), // 1.5 nm
-        Range::initial(NAUTICAL_MILE * 2),   // 2 nm
-        Range::initial(NAUTICAL_MILE * 3),   // 3 nm
-        Range::initial(NAUTICAL_MILE * 4),   // 4 nm
-        Range::initial(NAUTICAL_MILE * 6),   // 6 nm
-        Range::initial(NAUTICAL_MILE * 8),   // 8 nm
-        Range::initial(NAUTICAL_MILE * 12),  // 12 nm
-        Range::initial(NAUTICAL_MILE * 16),  // 16 nm
-        Range::initial(NAUTICAL_MILE * 24),  // 24 nm
-        Range::initial(NAUTICAL_MILE * 32),  // 32 nm
-        Range::initial(NAUTICAL_MILE * 36),  // 36 nm
-        Range::initial(NAUTICAL_MILE * 40),  // 40 nm
-        Range::initial(NAUTICAL_MILE * 48),  // 48 nm
-        Range::initial(NAUTICAL_MILE * 64),  // 64 nm
-        Range::initial(NAUTICAL_MILE * 72),  // 72 nm
-        Range::initial(NAUTICAL_MILE * 96),  // 96 nm
-        Range::initial(NAUTICAL_MILE * 120), // 120 nm
+        Range::initial(FRAC_NM_32), // 1/32 nm
+        Range::initial(FRAC_NM_16), // 1/16 nm
+        Range::initial(FRAC_NM_8),  // 1/8 nm
+        Range::initial(FRAC_NM_4),  // 1/4 nm
+        Range::initial(FRAC_NM_2),  // 1/2 nm
+        Range::initial(NM * 3 / 4), // 3/4 nm
+        Range::initial(NM),         // 1 nm
+        Range::initial(NM * 3 / 2), // 1.5 nm
+        Range::initial(NM * 2),     // 2 nm
+        Range::initial(NM * 3),     // 3 nm
+        Range::initial(NM * 4),     // 4 nm
+        Range::initial(NM * 6),     // 6 nm
+        Range::initial(NM * 8),     // 8 nm
+        Range::initial(NM * 12),    // 12 nm
+        Range::initial(NM * 16),    // 16 nm
+        Range::initial(NM * 24),    // 24 nm
+        Range::initial(NM * 32),    // 32 nm
+        Range::initial(NM * 36),    // 36 nm
+        Range::initial(NM * 40),    // 40 nm
+        Range::initial(NM * 48),    // 48 nm
+        Range::initial(NM * 64),    // 64 nm
+        Range::initial(NM * 72),    // 72 nm
+        Range::initial(NM * 96),    // 96 nm
+        Range::initial(NM * 120),   // 120 nm
     ])
 });
 
@@ -179,24 +179,24 @@ impl Display for Range {
                 } else {
                     write!(f, "{} m", v)
                 }
-            } else if v >= NAUTICAL_MILE - 1 {
-                if Self::near(v, NAUTICAL_MILE) {
-                    write!(f, "{} nm", (v + 1) / NAUTICAL_MILE)
+            } else if v >= NM - 1 {
+                if Self::near(v, NM) {
+                    write!(f, "{} nm", (v + 1) / NM)
                 } else {
-                    write!(f, "{} nm", v as f64 / NAUTICAL_MILE_F64)
+                    write!(f, "{} nm", v as f64 / NM_F64)
                 }
-            } else if Self::near(v, NAUTICAL_MILE / 2) {
-                write!(f, "{}/2 nm", (v + 1) / (NAUTICAL_MILE / 2))
-            } else if Self::near(v, NAUTICAL_MILE / 4) {
-                write!(f, "{}/4 nm", (v + 1) / (NAUTICAL_MILE / 4))
-            } else if Self::near(v, NAUTICAL_MILE / 8) {
-                write!(f, "{}/8 nm", (v + 1) / (NAUTICAL_MILE / 8))
-            } else if Self::near(v, NAUTICAL_MILE / 16) {
-                write!(f, "{}/16 nm", (v + 1) / (NAUTICAL_MILE / 16))
-            } else if Self::near(v, NAUTICAL_MILE / 32) {
-                write!(f, "{}/32 nm", (v + 1) / (NAUTICAL_MILE / 32))
+            } else if Self::near(v, FRAC_NM_2) {
+                write!(f, "{}/2 nm", (v + 1) / FRAC_NM_2)
+            } else if Self::near(v, FRAC_NM_4) {
+                write!(f, "{}/4 nm", (v + 1) / FRAC_NM_4)
+            } else if Self::near(v, FRAC_NM_8) {
+                write!(f, "{}/8 nm", (v + 1) / FRAC_NM_8)
+            } else if Self::near(v, FRAC_NM_16) {
+                write!(f, "{}/16 nm", (v + 1) / FRAC_NM_16)
+            } else if Self::near(v, FRAC_NM_32) {
+                write!(f, "{}/32 nm", (v + 1) / FRAC_NM_32)
             } else {
-                write!(f, "{} nm", v as f64 / NAUTICAL_MILE_F64)
+                write!(f, "{} nm", v as f64 / NM_F64)
             }
         }
     }

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -16,7 +16,7 @@ use strum::{EnumCount, EnumIter, EnumString, IntoStaticStr};
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use super::NAUTICAL_MILE;
+use super::NM;
 use super::range::Range;
 use super::units::Units;
 use crate::Cli;
@@ -636,7 +636,7 @@ impl Controls {
         }
 
         // Note: valid range values are set per-model in update_when_model_known()
-        let max_value = 120. * NAUTICAL_MILE as f64;
+        let max_value = 120. * NM as f64;
         new_numeric(ControlId::Range, 0., max_value)
             .wire_units(Units::Meters)
             .build(&mut controls);

--- a/src/lib/radar/target/manager.rs
+++ b/src/lib/radar/target/manager.rs
@@ -12,11 +12,8 @@ use tokio::sync::{broadcast, mpsc};
 use super::blob::CompletedBlob;
 use super::tracker::{CandidateSource, ProcessResult, TargetCandidate, TargetTracker};
 use super::{ArpaTargetApi, TargetDangerApi, TargetMotionApi, TargetPositionApi};
-use crate::radar::GeoPosition;
+use crate::radar::{GeoPosition, KN_TO_MS};
 use crate::stream::SignalKDelta;
-
-/// Knots to m/s conversion
-const KN_TO_MS: f64 = 1852.0 / 3600.0;
 
 /// Context from the spoke that produced a blob
 #[derive(Clone, Debug)]

--- a/src/lib/radar/target/mod.rs
+++ b/src/lib/radar/target/mod.rs
@@ -20,15 +20,13 @@ pub use tracker::{
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use super::NAUTICAL_MILE_F64;
+use super::NM_F64;
 
 // ============================================================================
 // Geographic constants and utilities
 // ============================================================================
 
-pub const METERS_PER_DEGREE_LATITUDE: f64 = 60. * NAUTICAL_MILE_F64;
-pub const KN_TO_MS: f64 = NAUTICAL_MILE_F64 / 3600.;
-pub const MS_TO_KN: f64 = 3600. / NAUTICAL_MILE_F64;
+pub const METERS_PER_DEGREE_LATITUDE: f64 = 60. * NM_F64;
 
 /// The length of a degree longitude varies by the latitude,
 /// the more north or south you get the shorter it becomes.
@@ -122,7 +120,7 @@ pub struct TargetDangerApi {
 
 impl TargetDangerApi {
     /// CPA threshold for the danger flag (0.5 nautical miles in metres).
-    pub const DANGER_CPA_M: f64 = 0.5 * super::NAUTICAL_MILE_F64;
+    pub const DANGER_CPA_M: f64 = 0.5 * super::NM_F64;
     /// TCPA threshold for the danger flag (6 minutes in seconds).
     pub const DANGER_TCPA_S: f64 = 6.0 * 60.0;
 

--- a/src/lib/radar/target/motion.rs
+++ b/src/lib/radar/target/motion.rs
@@ -427,6 +427,7 @@ mod tests {
     use std::f64::consts::PI;
 
     use super::*;
+    use crate::radar::KN_TO_MS;
 
     #[test]
     fn test_imm_model_straight_line() {
@@ -495,7 +496,7 @@ mod tests {
         // Circle parameters (matching emulator world.rs)
         let radius_m = 250.0;
         let speed_knots = 15.0;
-        let speed_ms = speed_knots * 1852.0 / 3600.0; // ~7.72 m/s
+        let speed_ms = speed_knots * KN_TO_MS; // ~7.72 m/s
         let angular_velocity = speed_ms / radius_m; // ~0.031 rad/s
 
         // Time for one full circle = 2π / angular_velocity ≈ 203 seconds

--- a/src/lib/radar/target/tracker.rs
+++ b/src/lib/radar/target/tracker.rs
@@ -834,9 +834,10 @@ mod tests {
     use std::f64::consts::PI;
 
     use super::*;
+    use crate::radar::KN_TO_MS;
 
     /// Default max speed for tests (50 knots)
-    const TEST_MAX_SPEED_MS: f64 = 50.0 * 0.5144;
+    const TEST_MAX_SPEED_MS: f64 = 50.0 * KN_TO_MS;
 
     fn make_candidate(lat: f64, lon: f64, time: u64) -> TargetCandidate {
         make_candidate_with_source(lat, lon, time, CandidateSource::GuardZone(1))
@@ -1232,7 +1233,7 @@ mod tests {
         // Circle parameters (matching emulator world.rs)
         let radius_m = 250.0;
         let speed_knots = 15.0;
-        let speed_ms = speed_knots * 1852.0 / 3600.0; // ~7.72 m/s
+        let speed_ms = speed_knots * KN_TO_MS; // ~7.72 m/s
         let angular_velocity = speed_ms / radius_m; // ~0.031 rad/s
 
         // Time for one full circle = 2π / angular_velocity ≈ 203 seconds
@@ -1351,7 +1352,7 @@ mod tests {
         // Circle parameters (matching emulator world.rs)
         let radius_m = 250.0;
         let speed_knots = 15.0;
-        let speed_ms = speed_knots * 1852.0 / 3600.0; // ~7.72 m/s
+        let speed_ms = speed_knots * KN_TO_MS; // ~7.72 m/s
         let angular_velocity = speed_ms / radius_m; // ~0.031 rad/s
 
         // Time for one full circle = 2π / angular_velocity ≈ 203 seconds
@@ -1465,7 +1466,7 @@ mod tests {
         // Circle parameters (matching emulator world.rs)
         let radius_m = 250.0;
         let speed_knots = 15.0;
-        let speed_ms = speed_knots * 1852.0 / 3600.0; // ~7.72 m/s
+        let speed_ms = speed_knots * KN_TO_MS; // ~7.72 m/s
         let angular_velocity = speed_ms / radius_m; // ~0.031 rad/s
 
         let circle_time_s = TAU / angular_velocity;
@@ -1579,7 +1580,7 @@ mod tests {
         // Circle parameters (matching emulator world.rs)
         let radius_m = 250.0;
         let speed_knots = 15.0;
-        let speed_ms = speed_knots * 1852.0 / 3600.0; // ~7.72 m/s
+        let speed_ms = speed_knots * KN_TO_MS; // ~7.72 m/s
         let angular_velocity = speed_ms / radius_m; // ~0.031 rad/s
 
         let circle_time_s = TAU / angular_velocity;
@@ -1722,7 +1723,6 @@ mod tests {
         // reaches established tracking (update_count > 2), the normal speed max_dist becomes
         // limiting and the target is lost.
 
-        const KN_TO_MS: f64 = 0.5144;
         const NORMAL_SPEED_MS: f64 = 25.0 * KN_TO_MS; // ~12.9 m/s
         const MEDIUM_SPEED_MS: f64 = 40.0 * KN_TO_MS; // ~20.6 m/s
         const FAST_SPEED_MS: f64 = 50.0 * KN_TO_MS; // ~25.7 m/s

--- a/src/lib/radar/units.rs
+++ b/src/lib/radar/units.rs
@@ -2,6 +2,8 @@ use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum
 use std::f64::consts::{PI, TAU};
 use utoipa::ToSchema;
 
+use crate::radar::{KN_TO_MS, MS_TO_KN, NM_F64};
+
 #[derive(
     Copy,
     PartialEq,
@@ -62,10 +64,10 @@ impl Units {
             Units::Kelvin => (Units::Kelvin, 1.),
             Units::Minutes => (Units::Seconds, 60.),
             Units::KiloMeters => (Units::Meters, 1000.),
-            Units::Knots => (Units::MetersPerSecond, 1852. / 3600.),
+            Units::Knots => (Units::MetersPerSecond, KN_TO_MS),
             Units::Meters => (Units::Meters, 1.),
             Units::MetersPerSecond => (Units::MetersPerSecond, 1.),
-            Units::NauticalMiles => (Units::Meters, 1852.),
+            Units::NauticalMiles => (Units::Meters, NM_F64),
             Units::None => unreachable!("Units::None"),
             Units::Radians => (Units::Radians, 1.),
             Units::RadiansPerSecond => (Units::RadiansPerSecond, 1.),
@@ -94,10 +96,10 @@ impl Units {
             Units::Kelvin => 1.,
             Units::Minutes => 1. / 60.,
             Units::KiloMeters => 0.001,
-            Units::Knots => 3600. / 1852.,
+            Units::Knots => MS_TO_KN,
             Units::Meters => 1.,
             Units::MetersPerSecond => 1.,
-            Units::NauticalMiles => 1. / 1852.,
+            Units::NauticalMiles => 1. / NM_F64,
             Units::None => unreachable!("Units::None"),
             Units::Radians => 1.,
             Units::RadiansPerSecond => 1.,


### PR DESCRIPTION
## What changes

Nothing user-visible. Code hygiene only.

Mayara had three near-duplicate definitions of 1 nautical mile in
metres (\`NAUTICAL_MILE\` plus \`NM\` in garmin and \`NM_TO_METERS\` in
koden), five duplicates of the knots-to-m/s factor scattered across
\`emulator\` and \`target\`, plus ~50 bare \`1852\` / \`926\` / \`463\` / …
literals in conversion arithmetic across brand modules and range
tables.

Consolidated everything in [\`src/lib/radar/mod.rs\`](src/lib/radar/mod.rs):

- \`NM\` / \`NM_F64\` (renamed from \`NAUTICAL_MILE\` / \`NAUTICAL_MILE_F64\`)
- \`FRAC_NM_2\` / \`FRAC_NM_4\` / \`FRAC_NM_8\` / \`FRAC_NM_16\` / \`FRAC_NM_32\`, mirroring \`std::f64::consts::FRAC_PI_n\`
- \`KN_TO_MS\` / \`MS_TO_KN\`, moved up from \`radar/target/mod.rs\`

Awkward fractions (3/4 nm, 1.5 nm) are written inline as \`NM * 3 / 4\`
and \`NM * 3 / 2\` rather than getting their own constants — mirroring
how std only names power-of-2-denominator PI fractions.

## Behaviour change to note

One site changes numerically: a local \`const KN_TO_MS: f64 = 0.5144\`
(rounded) in \`tracker.rs\` is replaced with the shared \`NM_F64 / 3600.\`
(≈ 0.51444…). This shifts ARPA target-speed bucket boundaries by
~0.005% — sub-mm/s at 25 kn, well below any radar's measurement
precision.

## Left alone (per the issue)

- Wire-format LE byte sequences in \`garmin/range_table.rs\` and the
  test fixture in \`garmin/command.rs\`.
- Test-fixture range tables in \`radar/range.rs::tests\` documenting
  specific Furuno models' expected meters values.
- Multicast IP octets (\`224.29.69.231\`, …).
- OpenAPI \`#[schema(example = 1852.0)]\` annotations.

Closes #366

## Test plan

- [x] \`cargo test\`, \`cargo fmt --check\`, \`cargo clippy --no-deps --all-targets -- -D warnings\` (default + \`pcap-replay\`) — all green.
- [x] Spot-check grep for remaining \`1852\` / \`926\` / \`463\` / … literals — only the documented exemptions left.