### PR TITLE
feat(raymarine): surface Quantum self-test faults and decode per-item results

### DIFF
--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -154,6 +154,10 @@ pub(crate) struct RaymarineReportReceiver {
     reported_unknown: HashMap<u32, bool>,
     features: FeatureFlags,
     features_seen: bool,
+    /// True while the radar's last status report indicated a self-test fault
+    /// (Quantum status byte 0x0A). Used to edge-trigger the Signal K alarm
+    /// so it raises once on entry and clears once on exit.
+    pub(super) self_test_fault: bool,
 
     // For data (spokes)
     range_meters: u32,
@@ -215,6 +219,7 @@ impl RaymarineReportReceiver {
             reported_unknown: HashMap::new(),
             features: FeatureFlags::default(),
             features_seen: false,
+            self_test_fault: false,
             range_meters: 0,
             wire_to_legend,
             doppler: false,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -158,6 +158,11 @@ pub(crate) struct RaymarineReportReceiver {
     /// (Quantum status byte 0x0A). Used to edge-trigger the Signal K alarm
     /// so it raises once on entry and clears once on exit.
     pub(super) self_test_fault: bool,
+    /// Most recent per-item Quantum self-test results (24 items, wire
+    /// id `0x28080a`). `None` until the first packet arrives — captured
+    /// so transitions can be edge-logged instead of spamming once per
+    /// broadcast.
+    pub(super) self_test_results: Option<[u8; quantum::SELF_TEST_ITEM_COUNT]>,
 
     // For data (spokes)
     range_meters: u32,
@@ -220,6 +225,7 @@ impl RaymarineReportReceiver {
             features: FeatureFlags::default(),
             features_seen: false,
             self_test_fault: false,
+            self_test_results: None,
             range_meters: 0,
             wire_to_legend,
             doppler: false,
@@ -427,7 +433,12 @@ impl RaymarineReportReceiver {
             0x280030 => {
                 quantum::process_doppler_report(self, data);
             }
-            // Guard zone, alarm, MARPA, self-test, etc. — logged but not acted on
+            // SelfTestResults — radar pushes 24 per-item results unsolicited;
+            // see research/raymarine/radar-error-reporting.md.
+            quantum::SELF_TEST_RESULTS_ID => {
+                quantum::process_self_test_results(self, data);
+            }
+            // Guard zone, alarm, MARPA, etc. — logged but not acted on
             id if (id & 0xFFFF0000 == 0x28000000 || id & 0xFFFF0000 == 0x01000000) => {
                 if !self.reported_unknown.contains_key(&id) {
                     log::debug!(

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -470,10 +470,218 @@ pub(super) fn process_doppler_report(receiver: &mut RaymarineReportReceiver, dat
         .set_value(&ControlId::Doppler, doppler as f64);
 }
 
+// ---------------------------------------------------------------------------
+// SelfTestResults — wire id `0a 08 28 00` (LE u32 `0x0028080a`).
+//
+// The radar pushes this unsolicited on the report multicast channel; no
+// request is needed. Payload is `SELF_TEST_ITEM_COUNT` bytes after the
+// 4-byte id. Item layout was confirmed by cross-referencing the Pelagia
+// Quantum 2 capture against the Axiom MFD's Radar diagnostics → Self-test
+// results screen (recording IMG_1045.MOV):
+//
+// * Bytes  0..12 — 13 enum items shown by the MFD (Pass / Fail / Not Tested
+//   / Did not run). Wire encoding: `0x01` = Pass; `0xff` = Did not run (or
+//   still pending — flips to `0x01` as warm-up completes); any other value
+//   is treated conservatively as a failure (the exact Fail wire byte is
+//   unconfirmed without a faulting-unit capture).
+// * Bytes 13..15 — 3 internal items the Axiom MFD does not display. Byte 13
+//   was observed transitioning `0xff`→`0x01` during warm-up on the healthy
+//   Pelagia unit, so these are enum-style results, just hidden from the
+//   user. Logged but never alarmed.
+// * Bytes 16..23 — 8 boolean items shown by the MFD. Wire encoding: `0x00`
+//   = False; non-zero = True. Item index 22 ("Main enable initial state")
+//   is steady False on the healthy Pelagia unit, so it's treated as
+//   informational (no alarm) — the other 7 should be True and raise an
+//   alarm if False.
+//
+// See research/raymarine/radar-error-reporting.md for the full table.
+// ---------------------------------------------------------------------------
+
+pub(crate) const SELF_TEST_RESULTS_ID: u32 = 0x0028080a;
+pub(crate) const SELF_TEST_ITEM_COUNT: usize = 24;
+
+const SELF_TEST_PASS: u8 = 0x01;
+const SELF_TEST_PENDING: u8 = 0xff;
+
+/// High-byte tag for per-item self-test SK notifications. The full code is
+/// `SELF_TEST_ERROR_CODE_BASE | item_index`, which yields a distinct path
+/// per item (`notifications.radar.<id>.error.0xa00`..`0xa17`) and stays
+/// out of the way of the Layer-1 self-test fault code (`0x0a`) raised from
+/// the status byte.
+const SELF_TEST_ERROR_CODE_BASE: u32 = 0x0a00;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SelfTestKind {
+    /// Pass / Fail / Did not run enum. Alarm if value is not Pass or
+    /// Did-not-run/Pending.
+    Enum,
+    /// Boolean (True/False) that should be True on a healthy radar; alarm
+    /// if False.
+    Bool,
+    /// Boolean that is expected to vary even on a healthy radar
+    /// (informational, never alarmed).
+    BoolInfo,
+    /// Wire byte present in the message but not surfaced by the Axiom MFD.
+    /// Logged on change but never alarmed.
+    Reserved,
+}
+
+const SELF_TEST_LAYOUT: [(SelfTestKind, &str); SELF_TEST_ITEM_COUNT] = [
+    // Bytes 0..12 — 13 enum items shown by the Axiom MFD, in display order.
+    (SelfTestKind::Enum, "Power-up self Test Gpio"),
+    (SelfTestKind::Enum, "Power-up self Test AD9963"),
+    (SelfTestKind::Enum, "Power-up self Test ADF4159"),
+    (SelfTestKind::Enum, "Power-up self Test DspBlock"),
+    (SelfTestKind::Enum, "Power-up self Test Fpga"),
+    (SelfTestKind::Enum, "Power-up self Test I2C"),
+    (SelfTestKind::Enum, "Power-up self Test Uart"),
+    (SelfTestKind::Enum, "Power-up self Test WiFi"),
+    (SelfTestKind::Enum, "Runtime self Test WiFi Spi"),
+    (SelfTestKind::Enum, "Runtime self Test AD9963 Data Lines"),
+    (SelfTestKind::Enum, "Runtime self Test Psu Comms"),
+    (SelfTestKind::Enum, "Runtime self Test Limiter Detect"),
+    (SelfTestKind::Enum, "Runtime self Test Power Detect"),
+    // Bytes 13..15 — internal results not shown by the MFD.
+    (SelfTestKind::Reserved, "(internal self-test 13)"),
+    (SelfTestKind::Reserved, "(internal self-test 14)"),
+    (SelfTestKind::Reserved, "(internal self-test 15)"),
+    // Bytes 16..23 — 8 boolean items shown by the Axiom MFD, in display order.
+    (SelfTestKind::Bool, "Power in good"),
+    (SelfTestKind::Bool, "Standby current good"),
+    (SelfTestKind::Bool, "Main board connected"),
+    (SelfTestKind::Bool, "Main EEPROM connection good"),
+    (SelfTestKind::Bool, "Main supply on voltages good"),
+    (SelfTestKind::Bool, "Main supply on current good"),
+    // Steady False on the healthy Pelagia unit — treat as informational.
+    (SelfTestKind::BoolInfo, "Main enable initial state"),
+    (SelfTestKind::Bool, "POST run"),
+];
+
+fn item_is_failing(kind: SelfTestKind, value: u8) -> bool {
+    match kind {
+        SelfTestKind::Enum => !matches!(value, SELF_TEST_PASS | SELF_TEST_PENDING),
+        SelfTestKind::Bool => value == 0,
+        SelfTestKind::BoolInfo | SelfTestKind::Reserved => false,
+    }
+}
+
+fn format_value(kind: SelfTestKind, value: u8) -> String {
+    match (kind, value) {
+        (SelfTestKind::Enum, SELF_TEST_PASS) => "Pass".to_string(),
+        (SelfTestKind::Enum, SELF_TEST_PENDING) => "Did not run".to_string(),
+        (SelfTestKind::Enum, v) => format!("Fail(0x{v:02x})"),
+        (SelfTestKind::Bool | SelfTestKind::BoolInfo, 0) => "False".to_string(),
+        (SelfTestKind::Bool | SelfTestKind::BoolInfo, _) => "True".to_string(),
+        (SelfTestKind::Reserved, v) => format!("0x{v:02x}"),
+    }
+}
+
+pub(super) fn process_self_test_results(receiver: &mut RaymarineReportReceiver, data: &[u8]) {
+    let body = match data.get(4..4 + SELF_TEST_ITEM_COUNT) {
+        Some(b) => b,
+        None => {
+            log::warn!(
+                "{}: SelfTestResults too short: len={}",
+                receiver.common.key,
+                data.len()
+            );
+            return;
+        }
+    };
+    let mut items = [0u8; SELF_TEST_ITEM_COUNT];
+    items.copy_from_slice(body);
+
+    let prev = receiver.self_test_results;
+    let key = receiver.common.key.clone();
+    for (i, &(kind, label)) in SELF_TEST_LAYOUT.iter().enumerate() {
+        let curr = items[i];
+        let prev_val = prev.map(|p| p[i]);
+
+        if prev_val != Some(curr) {
+            match prev_val {
+                Some(p) => log::info!(
+                    "{}: SelfTest [{}] {}: {} (was {})",
+                    key,
+                    i,
+                    label,
+                    format_value(kind, curr),
+                    format_value(kind, p)
+                ),
+                None => log::info!(
+                    "{}: SelfTest [{}] {}: {}",
+                    key,
+                    i,
+                    label,
+                    format_value(kind, curr)
+                ),
+            }
+        }
+
+        let was_failing = prev_val.is_some_and(|v| item_is_failing(kind, v));
+        let now_failing = item_is_failing(kind, curr);
+        if was_failing != now_failing {
+            receiver.common.info.controls.send_radar_error_notification(
+                SELF_TEST_ERROR_CODE_BASE | (i as u32),
+                Some(label),
+                now_failing,
+            );
+        }
+    }
+
+    receiver.self_test_results = Some(items);
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{process_spoke, status_to_power};
+    use super::{
+        SELF_TEST_ITEM_COUNT, SELF_TEST_LAYOUT, SelfTestKind, item_is_failing, process_spoke,
+        status_to_power,
+    };
     use crate::radar::{BYTE_LOOKUP_LENGTH, Power};
+
+    #[test]
+    fn self_test_layout_has_one_label_per_wire_byte() {
+        assert_eq!(SELF_TEST_LAYOUT.len(), SELF_TEST_ITEM_COUNT);
+    }
+
+    #[test]
+    fn self_test_failure_classifier_silent_on_pelagia_capture() {
+        // Pelagia Quantum 2, "running" snapshot, 24 wire bytes:
+        //   01 01 01 01 01 01 01 01 01 ff 01 ff ff 01 01 ff 01 01 01 01 01 01 00 01
+        // None of the items should fire an alarm on this healthy radar.
+        let pelagia_running: [u8; SELF_TEST_ITEM_COUNT] = [
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0xff, 0x01, 0xff, 0xff, 0x01,
+            0x01, 0xff, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x01,
+        ];
+        for (i, &(kind, _)) in SELF_TEST_LAYOUT.iter().enumerate() {
+            assert!(
+                !item_is_failing(kind, pelagia_running[i]),
+                "item {} ({:?} = 0x{:02x}) should not flag as failing on a healthy radar",
+                i,
+                kind,
+                pelagia_running[i]
+            );
+        }
+    }
+
+    #[test]
+    fn self_test_failure_classifier_flags_fail_and_false_states() {
+        // Enum: any byte outside {Pass=0x01, Pending=0xff} is conservatively
+        // treated as a failure (the exact wire byte for Fail is unconfirmed).
+        assert!(!item_is_failing(SelfTestKind::Enum, 0x01));
+        assert!(!item_is_failing(SelfTestKind::Enum, 0xff));
+        assert!(item_is_failing(SelfTestKind::Enum, 0x00));
+        assert!(item_is_failing(SelfTestKind::Enum, 0x02));
+
+        // Bool: 0 = False = alarm; any non-zero = True = silent.
+        assert!(item_is_failing(SelfTestKind::Bool, 0x00));
+        assert!(!item_is_failing(SelfTestKind::Bool, 0x01));
+        assert!(!item_is_failing(SelfTestKind::Bool, 0xff));
+
+        // BoolInfo and Reserved never alarm.
+        assert!(!item_is_failing(SelfTestKind::BoolInfo, 0x00));
+        assert!(!item_is_failing(SelfTestKind::Reserved, 0x00));
+    }
 
     use crate::brand::raymarine::report::{LOOKUP_DOPPLER_LENGTH, WireToLegendTable};
 

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -231,23 +231,18 @@ const STATUS_PREPARING: u8 = 0x02;
 const STATUS_OFF: u8 = 0x03;
 const STATUS_FAULT_SELF_TEST: u8 = 0x0a;
 
-/// Map a Quantum status-report byte to a `Power` state, logging anything
-/// outside the normal set. The self-test fault is surfaced distinctly rather
-/// than masked as "unknown" (observed on a faulty unit asked to transmit),
-/// though it still maps to Standby since the Power control has no fault state.
-/// `key` is only used for the log line.
+/// Map a Quantum status-report byte to a `Power` state. The self-test fault
+/// (observed on a faulty unit asked to transmit) maps to `Power::Fault` so
+/// the GUI and Signal K consumers can distinguish it from a routine standby;
+/// other out-of-range values fall back to Standby with a warning.
+/// `key` is only used for the log line on unknown values.
 fn status_to_power(status: u8, key: &str) -> Power {
     match status {
         STATUS_STANDBY => Power::Standby,
         STATUS_TRANSMIT => Power::Transmit,
         STATUS_PREPARING => Power::Preparing,
         STATUS_OFF => Power::Off,
-        STATUS_FAULT_SELF_TEST => {
-            log::warn!(
-                "{key}: radar reported FAULT status {STATUS_FAULT_SELF_TEST:#x} (self-test failure); no image will appear until it clears"
-            );
-            Power::Standby
-        }
+        STATUS_FAULT_SELF_TEST => Power::Fault,
         other => {
             log::warn!("{key}: unknown status 0x{other:02x}");
             Power::Standby
@@ -268,6 +263,24 @@ pub(super) fn process_status_report(receiver: &mut RaymarineReportReceiver, data
 
     // Update controls based on the report
     let status = status_to_power(report.status, &receiver.common.key);
+    let in_fault = status == Power::Fault;
+    if in_fault != receiver.self_test_fault {
+        if in_fault {
+            log::warn!(
+                "{}: radar reported FAULT status {:#x} (self-test failure); no image will appear until it clears",
+                receiver.common.key,
+                STATUS_FAULT_SELF_TEST
+            );
+        } else {
+            log::info!("{}: self-test fault cleared", receiver.common.key);
+        }
+        receiver.common.info.controls.send_radar_error_notification(
+            STATUS_FAULT_SELF_TEST as u32,
+            Some("Self-test failure"),
+            in_fault,
+        );
+        receiver.self_test_fault = in_fault;
+    }
     receiver
         .common
         .set_value(&ControlId::Power, status as i32 as f64);
@@ -467,11 +480,16 @@ mod tests {
     }
 
     #[test]
-    fn fault_and_unknown_fall_back_to_standby() {
-        // 0x0a is the self-test fault; other out-of-range values are unknown.
-        // Both map to Standby (the Power control has no fault state) but are
-        // logged distinctly.
-        assert_eq!(status_to_power(0x0a, "k"), Power::Standby);
+    fn self_test_fault_maps_to_fault_state() {
+        // 0x0a is the documented self-test fault; surface it on the Power
+        // control so consumers can distinguish it from a routine standby.
+        assert_eq!(status_to_power(0x0a, "k"), Power::Fault);
+    }
+
+    #[test]
+    fn unknown_status_falls_back_to_standby() {
+        // Anything outside the documented set is treated as standby (with a
+        // warning) rather than mis-claimed as a fault.
         assert_eq!(status_to_power(0xff, "k"), Power::Standby);
     }
 

--- a/src/lib/brand/raymarine/report/quantum.rs
+++ b/src/lib/brand/raymarine/report/quantum.rs
@@ -229,6 +229,12 @@ const STATUS_STANDBY: u8 = 0x00;
 const STATUS_TRANSMIT: u8 = 0x01;
 const STATUS_PREPARING: u8 = 0x02;
 const STATUS_OFF: u8 = 0x03;
+// 0x04 = "transmitting but no display consuming the image" — observed on
+// healthy Quantum 2 captures when the operator is on a non-radar MFD page.
+// The antenna parks itself after a ~30 s grace, but mayara has no display
+// concept, so we treat it as a normal Transmit state.
+// See research/raymarine/radar-error-reporting.md (Pelagia capture analysis).
+const STATUS_TRANSMIT_DISPLAY_INACTIVE: u8 = 0x04;
 const STATUS_FAULT_SELF_TEST: u8 = 0x0a;
 
 /// Map a Quantum status-report byte to a `Power` state. The self-test fault
@@ -239,7 +245,7 @@ const STATUS_FAULT_SELF_TEST: u8 = 0x0a;
 fn status_to_power(status: u8, key: &str) -> Power {
     match status {
         STATUS_STANDBY => Power::Standby,
-        STATUS_TRANSMIT => Power::Transmit,
+        STATUS_TRANSMIT | STATUS_TRANSMIT_DISPLAY_INACTIVE => Power::Transmit,
         STATUS_PREPARING => Power::Preparing,
         STATUS_OFF => Power::Off,
         STATUS_FAULT_SELF_TEST => Power::Fault,
@@ -477,6 +483,14 @@ mod tests {
         assert_eq!(status_to_power(0x01, "k"), Power::Transmit);
         assert_eq!(status_to_power(0x02, "k"), Power::Preparing);
         assert_eq!(status_to_power(0x03, "k"), Power::Off);
+    }
+
+    #[test]
+    fn transmit_display_inactive_maps_to_transmit() {
+        // 0x04 is a wire-confirmed "transmit-but-no-display-consuming" state
+        // (Pelagia Q2 healthy capture, 361 occurrences). Mayara has no display
+        // concept, so it folds onto the normal Transmit state.
+        assert_eq!(status_to_power(0x04, "k"), Power::Transmit);
     }
 
     #[test]


### PR DESCRIPTION
## What changes for you

If you run a Raymarine Quantum or Quantum 2 radar with mayara, this PR adds three improvements to how the GUI and Signal K reflect what the radar is actually doing:

* **The radar's "scanner failed self-test" state is now visible.** Previously, if your radar reported a self-test failure (the same state where the Axiom MFD shows "Not available. Scanner failed self-test."), mayara just showed it as **Standby** — exactly like a healthy idle radar. The GUI now shows **Fault**, and Signal K consumers receive an alarm at `notifications.radar.<id>.error.0xa` that raises when the fault appears and clears when it resolves.
* **You can now see which subsystem failed.** The radar's detailed self-test results — the 21 items the Axiom MFD shows under Radar diagnostics → Self-test results (Power-up self Test Fpga, WiFi, Power in good, Main board connected, etc.) — were previously dropped silently. Mayara now decodes them, logs every change with human-readable names, and raises a per-item Signal K alarm when an item fails (path `notifications.radar.<id>.error.0xa00`..`0xa17`).
* **"Transmitting in the background" no longer reads as Standby.** When you're using the Axiom on a non-radar page and the Quantum stops painting but stays TX-ready (a normal power-saving state), the GUI used to say Standby. It now correctly says Transmit.

You don't need to change any configuration for these to take effect. The improvements are passive: mayara starts using new fields from packets the radar already broadcasts.

## Technical detail

Three commits, all on the Quantum status / diagnostics report path:

1. **`2d80246` — Status byte `0x0a` → `Power::Fault` with edge-triggered Signal K alarm.** `status_to_power` now returns `Power::Fault` for `STATUS_FAULT_SELF_TEST` instead of folding to Standby. The per-status-report warn-log is replaced with edge-only logs to avoid spam while the fault persists.
2. **`e12ff19` — Status byte `0x04` → `Power::Transmit`.** Wire-confirmed "transmit-but-no-display-consuming" state observed 361× on a healthy Pelagia Quantum 2 capture; previously fell through to Standby.
3. **`4e2321f` — Decode the `0x28080a` SelfTestResults report.** 24-byte payload, of which 21 bytes map to MFD items: 13 enum (`Pass` / `Fail` / `Did not run`), 3 internal-only, 8 boolean. Layout confirmed by cross-referencing the Pelagia capture against an IMG_1045.MOV recording of the Axiom self-test screen.

The Power-state Fault override stays driven by the Layer-1 status byte only; per-item failures fire notifications but don't override the reported Power state. The exact wire byte for `Fail` on enum items is unconfirmed (Pelagia is a healthy radar; observed values are only `0x01` Pass and `0xff` Did not run / pending), so the classifier conservatively treats any byte outside that set as a failure.

## Test plan

- [x] `cargo test --lib` (309 tests pass; new tests cover the `0x04` mapping, the fault → `Power::Fault` mapping, the layout sanity, and the classifier against the Pelagia healthy snapshot)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --no-deps --all-targets -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Raymarine Quantum Radar Self-Test Diagnostics Enhancement

Enhances how Raymarine Quantum radars surface self-test fault information and per-item diagnostic results by mapping additional status bytes and decoding a previously unhandled self-test results report.

### Status Byte Mappings

- **Status byte `0x0a` (self-test fault)** now maps to `Power::Fault` instead of Standby, enabling the GUI and Signal K consumers to distinguish faulty radars from idle units. Edge-triggered alarm added at `notifications.radar.<id>.error.0xa`.

- **Status byte `0x04` (transmit-ready without display consumption)** now maps to `Power::Transmit` instead of Standby. This byte represents TX-active state with the antenna parked during display inactivity.

### Self-Test Results Decoding

Adds decoding for the `0x28080a` SelfTestResults unsolicited report, which was previously treated as an unhandled message. The report contains 24 bytes covering 21 items visible in the Axiom MFD (13 enum items and 8 boolean items). The decoder:

- Logs per-item value transitions with human labels
- Edge-triggers Signal K alarms at `notifications.radar.<id>.error.0xa00..0xa17` when items fail
- Conservatively treats enum bytes outside `{Pass=0x01, Pending=0xff}` as failures

### Implementation Details

**`src/lib/brand/raymarine/report.rs`:**
- Added `self_test_fault: bool` field to track self-test state for edge-triggering
- Added `self_test_results: Option<[u8; SELF_TEST_ITEM_COUNT]>` field for per-item diagnostic tracking
- Routed `0x28080a` packets to `quantum::process_self_test_results`

**`src/lib/brand/raymarine/report/quantum.rs`:**
- Introduced `SelfTestKind` enum to classify byte interpretation (Enum, Bool, BoolInfo, Reserved)
- Added `SELF_TEST_RESULTS_ID` and `SELF_TEST_ITEM_COUNT` constants
- Implemented `process_self_test_results` function that validates payload length, tracks previous values, logs transitions, and manages state-change notifications
- Updated status handling to detect and log fault transitions ("fault reported" / "fault cleared")
- Extended unit tests to verify new status mappings and self-test classification behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->