### PR TITLE
chore(build): support per-developer Makefile.local extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /web/api
 /target
 demo/work
+# Per-developer Makefile extensions; opt-in via `-include Makefile.local`
+Makefile.local

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@
 #   make test     - Build and run tests
 #   make docs     - Generate rustdoc only
 #   make run      - Build and run server
-#   make mpi      - Build for linux and deploy and run on merrimac-pi
 #   make docker   - Build the Docker image
 #   make demo     - Rebuild the docker demo image
 #   make clean    - Clean build artifacts
@@ -38,28 +37,6 @@ debug: docs
 	@echo ""
 	@echo "Build complete: target/debug/mayara-server"
 	@echo "Rustdoc available at: http://localhost:6502/rustdoc/mayara_core/"
-
-# Build release binary with docs embedded
-mpi: 
-	@echo "Building and running on merrimac-pi..."
-	cargo build --release --target aarch64-unknown-linux-musl
-	ssh merrimac-pi killall -9 mayara-server || :
-	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
-	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server
-
-mpid:
-	@echo "Building and running with debug log on merrimac-pi..."
-	cargo build --release --target aarch64-unknown-linux-musl
-	ssh merrimac-pi killall -9 mayara-server || :
-	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
-	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v --transmit
-
-mpit:
-	@echo "Building and running with trace log on merrimac-pi..."
-	cargo build --release --target aarch64-unknown-linux-musl
-	ssh merrimac-pi killall -9 mayara-server || :
-	scp target/aarch64-unknown-linux-musl/release/mayara-server merrimac-pi:
-	ssh -L 6502:localhost:6502 merrimac-pi RUST_BACKTRACE=full ./mayara-server -v -v --transmit
 
 # Build and run the server
 run: release
@@ -102,3 +79,9 @@ changelog:
 # Clean build artifacts
 clean:
 	cargo clean
+
+# Optional per-developer extensions: targets that should never be committed
+# (deploy shortcuts to your own boxes, scratch experiments, etc.). The leading
+# dash makes the include silent when the file is absent, so a fresh clone
+# behaves identically to having no file. `Makefile.local` is gitignored.
+-include Makefile.local


### PR DESCRIPTION
## What changes for you

If you're a contributor, the Makefile no longer ships hard-coded references to a specific dev's deploy box. You can put your own personal targets — SSH deploy shortcuts, scratch test runs, anything — into a gitignored `Makefile.local` in the repo root and they'll be picked up automatically. A fresh clone without that file behaves exactly as before: a plain `make` builds the release; `make mpi` (or any other personal target) returns the normal "No rule" error.

If you're running mayara as a user, nothing changes — this is build-system only.

## Technical detail

- Dropped the `mpi` / `mpid` / `mpit` targets from the tracked `Makefile`; they hard-coded `merrimac-pi` and were single-contributor scoped.
- Added `-include Makefile.local` at the bottom of the `Makefile` (leading `-` silences the include when the file is absent).
- Added `Makefile.local` to `.gitignore`.

Verified: `git status` after `Makefile.local` is created shows it as untracked-but-ignored; `make -pq` lists targets from both files in a normal clone, and only the committed targets on a clone without the local file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Build System Customization via Optional Makefile.local

Removes three personal contributor-specific make targets (`mpi`, `mpid`, `mpit`) from the tracked Makefile and establishes a per-developer customization mechanism through an optional, gitignored `Makefile.local` file.

**Changes:**

- **`.gitignore`**: Adds `Makefile.local` entry to prevent accidental commits of local build configuration.

- **`Makefile`**: Removes the `mpi`, `mpid`, and `mpit` targets (which referenced a specific contributor's deploy box `merrimac-pi`) and adds `-include Makefile.local` statement with explanatory comments at the end of the file. The leading `-` prefix suppresses errors when the file is absent.

**Behavior:**

Contributors can now create a personal `Makefile.local` in the repository root for custom targets (e.g., SSH deploy shortcuts) without version control pollution. Fresh clones without this file operate identically to before—the default `make` builds the release normally, and invoking non-existent targets returns the standard make error. The tracked build system surface is now cleaner while remaining extensible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->