### PR TITLE
chore(docker): add profile-gated mayara service for real-radar deploys

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,32 @@ services:
       - ALL
     restart: unless-stopped
 
+  # Real-radar deployment. Gated by the `radar` profile so a bare
+  # `docker compose up` (no args / no profile) does not start it — keep
+  # the emulator service as the default zero-config experience and have
+  # operators opt into the radar service explicitly:
+  #
+  #     docker compose --profile radar pull mayara
+  #     docker compose --profile radar up -d mayara
+  #
+  # No `restart` policy: the operator manages lifecycle. Override the
+  # image with `MAYARA_IMAGE=<tag>` when running a locally built image
+  # (e.g. for dev iteration).
+  mayara:
+    profiles: ["radar"]
+    image: ${MAYARA_IMAGE:-ghcr.io/marineyachtradar/mayara-server:latest}
+    network_mode: host
+    command: ["mayara-server", "-v", "--transmit"]
+    tmpfs:
+      - /home/mayara/.config/mayara
+      - /home/mayara/.local/share/mayara
+      - /tmp
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
   # Example: real radar with persistent config and recordings
   # mayara-radar:
   #   image: ghcr.io/marineyachtradar/mayara-server:latest


### PR DESCRIPTION
## What changes for you

If you run mayara via Docker Compose against a real radar (not the emulator), there's now a ready-made `mayara` service in `docker/docker-compose.yml` you can opt into:

```sh
docker compose --profile radar pull mayara
docker compose --profile radar up -d mayara
```

The existing `mayara-server` emulator service is untouched — a bare `docker compose up` still brings the emulator up exactly as before. The new service only materialises when the `radar` profile is named explicitly, and it has no `restart` policy, so it stays down after a stop, reboot, or crash until you start it again. You manage the lifecycle.

If you're not using Docker Compose for mayara, nothing changes.

## Technical detail

- New `mayara` service in [docker/docker-compose.yml](docker/docker-compose.yml) — `profiles: ["radar"]` so it never starts under bare `docker compose up`, and no `restart` policy so it never auto-restarts. Both behaviours are deliberate: real-radar deploys want explicit operator control.
- Image is `${MAYARA_IMAGE:-ghcr.io/marineyachtradar/mayara-server:latest}`. The default pulls GHCR latest; setting `MAYARA_IMAGE=mayara-server:dev` (or any other tag) drives the same compose definition with a locally built image — useful for dev iteration without editing the file.
- `network_mode: host` (required for radar multicast discovery), and the same hardening as the emulator service: `read_only`, `no-new-privileges`, all caps dropped.
- Avoids a port-6502 collision with the emulator service: profile-gating ensures only one of the two is up at a time.

Verified locally: `docker compose config --services` lists only `mayara-server`; `docker compose --profile radar config --services` lists both.