### PR TITLE
fix(docker): make docker/Dockerfile actually build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM rust:1.94-alpine AS builder
-RUN apk add --no-cache build-base perl
+# `curl` is needed at build time by utoipa-swagger-ui's build.rs to fetch
+# the Swagger UI bundle; without it the build fails with `curl command not
+# found`. `perl` is required by openssl-sys.
+RUN apk add --no-cache build-base curl perl
 
 WORKDIR /usr/src/mayara-server
 
@@ -11,6 +14,11 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs \
     && rm -rf src
 
 COPY src src/
+# Cargo parses the whole manifest (including `[[example]]` blocks) on every
+# build. The generate-fixtures example is gated by `required-features =
+# ["pcap-replay"]` and is never built here, but the manifest is invalid
+# unless its source file is present.
+COPY examples examples/
 COPY web web/
 RUN cargo build --release
 


### PR DESCRIPTION
## What changes for you

If you build the mayara Docker image from a local checkout — `make docker`, `docker buildx build -f docker/Dockerfile .`, or anything else that uses [docker/Dockerfile](docker/Dockerfile) — it now succeeds. Until this PR the build failed early with one of two cryptic errors (Cargo manifest parse failure, or `curl command not found` from a dependency's build script), depending on how far it got. The CI-published GHCR images aren't affected — CI uses a separate `docker/Dockerfile.ci` that just packages a pre-built binary — so this only hit people building locally.

No runtime change. The resulting image is the same as before once the build completes.

## Technical detail

Two unrelated rot points in the local-build Dockerfile, surfaced together because CI never exercises this path:

1. **`examples/` wasn't copied into the build context.** The Dockerfile copies only `src/` and `web/`, but [Cargo.toml](Cargo.toml) declares `[[example]] name = "generate-fixtures"`. Cargo refuses to parse the manifest if the example's source file is absent, even though `required-features = ["pcap-replay"]` means it's never actually compiled here. Result: `error: can't find generate-fixtures example at examples/generate-fixtures.rs`.
2. **`curl` was missing from the builder stage.** `utoipa-swagger-ui`'s build.rs downloads the Swagger UI bundle at build time. Its reqwest fallback path is disabled, so it shells out to system `curl` — which the Alpine builder image (`apk add build-base perl`) doesn't include. Result: `failed to download Swagger UI: Custom { kind: NotFound, error: "curl command not found" }`.

Fixed by adding `COPY examples examples/` alongside `src/`/`web/`, and `curl` to the builder's `apk add` line. Adjacent inline comments call out *why* each is needed so the next dep update that perturbs either point gives the right signal.

## Verified

`docker buildx build --platform linux/arm64 -f docker/Dockerfile -t mayara-server:dockerfile-test --load .` runs to completion (~5 min under arm64 emulation on a Mac) and produces a 56.3 MB Alpine image identical in shape to the CI-published one.