### PR TITLE
feat(web): add --no-websocket-compression flag

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -580,8 +580,12 @@ async fn spokes_handler(
             radar.wake_up();
             // finalize the upgrade process by returning upgrade callback.
             // we can customize the callback by sending additional info such as address.
-            ws.permessage_deflate()
-                .on_upgrade(move |socket| spokes_stream(socket, radar_message_rx, shutdown_rx))
+            let ws = if state.args.no_websocket_compression {
+                ws
+            } else {
+                ws.permessage_deflate()
+            };
+            ws.on_upgrade(move |socket| spokes_stream(socket, radar_message_rx, shutdown_rx))
         }
         None => RadarError::NoSuchRadar(params.id).into_response(),
     }

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1132,7 +1132,12 @@ async fn control_stream_handler(
 
     // finalize the upgrade process by returning upgrade callback.
     // we can customize the callback by sending additional info such as address.
-    ws.permessage_deflate().on_upgrade(move |socket| {
+    let ws = if state.args.no_websocket_compression {
+        ws
+    } else {
+        ws.permessage_deflate()
+    };
+    ws.on_upgrade(move |socket| {
         ws_signalk_delta_shim(socket, subscribe, send_cached_values, radars, shutdown_tx)
     })
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -170,6 +170,12 @@ pub struct Cli {
     /// Merge targets from multiple radars into a single shared target list
     #[arg(long, default_value_t = false)]
     pub merge_targets: bool,
+
+    /// Disable permessage-deflate compression on outbound WebSocket streams
+    /// (spoke and Signal K delta). Trades bandwidth for CPU — useful on LAN
+    /// deployments where compression cost exceeds the bandwidth benefit.
+    #[arg(long, default_value_t = false)]
+    pub no_websocket_compression: bool,
 }
 
 /// Static position data (latitude, longitude, heading)

--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -37,6 +37,7 @@ fn test_args() -> Cli {
         signalk_token_file: None,
         emulator: false,
         merge_targets: false,
+        no_websocket_compression: false,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a CLI flag `--no-websocket-compression` that disables permessage-deflate on the outbound WebSocket streams (spoke data and Signal K delta). Useful for LAN deployments where compression's CPU cost outweighs the bandwidth saving — on a Raspberry Pi running a live HALO radar, deflate alone was costing ~33 % of tokio-worker CPU before this flag.

The default behaviour is unchanged: clients that offer permessage-deflate during the WebSocket handshake still get it. Operators who want CPU instead of bandwidth now have a one-line toggle.

## Changes

- New `Cli` flag `no_websocket_compression: bool` (default `false`)
- `spokes_handler` ([web/mod.rs:583](src/bin/mayara-server/web/mod.rs#L583)) skips `ws.permessage_deflate()` when the flag is set
- `control_stream_handler` ([web/signalk/v2.rs:1135](src/bin/mayara-server/web/signalk/v2.rs#L1135)) does the same for the Signal K delta stream

The flag is read from `State<Web>` which already carries the parsed `Cli`, so no plumbing changes were needed.

## Test plan
- [x] `cargo build --features pcap-replay` clean
- [x] `cargo clippy --no-deps --all-targets --features pcap-replay -- -D warnings` clean
- [x] All 322 lib tests pass; all brand replay integration tests pass
- [x] `mayara-server --help` shows the new flag
- [x] Without the flag: client `Sec-WebSocket-Extensions: permessage-deflate` offer is accepted (default behaviour preserved)
- [x] With the flag: handshake response omits `Sec-WebSocket-Extensions`, frames go uncompressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Adds a CLI flag `--no-websocket-compression` to disable permessage-deflate compression on WebSocket streams, addressing CPU overhead issues on resource-constrained deployments like Raspberry Pi.

## Changes

**New CLI Flag** (`src/lib/mod.rs`):
- Adds `--no-websocket-compression` boolean flag (defaults to `false`)
- Disables permessage-deflate compression on outbound WebSocket streams for both spoke data and Signal K delta streams

**WebSocket Handlers** (`src/bin/mayara-server/web/mod.rs` and `src/bin/mayara-server/web/signalk/v2.rs`):
- Modified `spokes_handler` in `web/mod.rs` to conditionally apply `ws.permessage_deflate()` based on the flag
- Modified `control_stream_handler` in `web/signalk/v2.rs` to conditionally enable `permessage_deflate` for Signal K delta streams
- Flag is accessed via `State<Web>`, which already carries the parsed CLI configuration

## Context

WebSocket compression (permessage-deflate) consumes significant CPU on resource-constrained systems (~33-34% of tokio-worker CPU when streaming radar spokes), often outweighing bandwidth savings on local area network deployments.

## Backward Compatibility

Default behavior remains unchanged. Clients offering permessage-deflate during the WebSocket handshake still receive compression unless the flag is explicitly enabled.

## Testing

- Clean builds pass
- Clippy checks pass
- 322 lib tests passing
- All replay integration tests passing
- Manual verification confirms help text displays the new flag and handshake behavior is correct in both enabled and disabled modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->