### PR TITLE
fix(navdata): keep own ship out of the AIS overlay

### DIFF
--- a/src/lib/ais.rs
+++ b/src/lib/ais.rs
@@ -240,6 +240,24 @@ impl AisVesselStore {
         })
     }
 
+    /// Remove a vessel from the store. Used when the own-ship context is
+    /// established after the REST seed has already loaded the operator's
+    /// own boat as if it were an AIS target — otherwise the PPI overlay
+    /// would render own-ship on top of itself.
+    pub fn evict(&self, context: &str) -> bool {
+        let Some(mmsi) = Self::extract_mmsi(context) else {
+            return false;
+        };
+        let Ok(mut vessels) = self.vessels.write() else {
+            return false;
+        };
+        let removed = vessels.remove(&mmsi).is_some();
+        if removed {
+            log::info!("Evicted MMSI {} from AIS store (own ship)", mmsi);
+        }
+        removed
+    }
+
     /// Extract MMSI from context like "vessels.urn:mrn:imo:mmsi:227334400"
     fn extract_mmsi(context: &str) -> Option<String> {
         // Look for pattern "mmsi:" followed by digits

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -561,18 +561,32 @@ pub async fn start_session(
     // soon as discovery resolves an HTTP URL. Polls until either shutdown
     // or discovery resolves; the WS task and discovery race startup and
     // discovery may take arbitrarily long on a quiet network.
+    //
+    // Once the HTTP base is known, wait a bounded extra window for the WS
+    // task to latch `OWN_SHIP_CONTEXT` from the `vessels.self` subscription
+    // before seeding. The REST tree contains the operator's own ship under
+    // its MMSI URN just like any other vessel, and the seed function uses
+    // the latched context to skip it. If the operator runs without an
+    // upstream Signal K (no own-ship will ever latch), the timeout still
+    // lets the seed proceed so an offline GUI overlay isn't blocked.
     let accept_invalid_certs = args.accept_invalid_certs;
     subsystem.start(SubsystemBuilder::new(
         "AIS Seed",
         async move |subsys: &mut SubsystemHandle| {
+            let own_ship_wait_deadline =
+                tokio::time::Instant::now() + std::time::Duration::from_secs(30);
             loop {
                 tokio::select! { biased;
                     _ = subsys.on_shutdown_requested() => break,
                     _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {},
                 }
                 if crate::signalk::get_upstream_http_base().is_some() {
-                    navdata::seed_ais_from_upstream(accept_invalid_certs).await;
-                    break;
+                    let own_ship_latched = navdata::get_own_ship_context().is_some();
+                    let deadline_passed = tokio::time::Instant::now() >= own_ship_wait_deadline;
+                    if own_ship_latched || deadline_passed {
+                        navdata::seed_ais_from_upstream(accept_invalid_certs).await;
+                        break;
+                    }
                 }
             }
             Ok::<(), miette::Report>(())

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -99,7 +99,7 @@ static OWN_SHIP_CONTEXT: OnceLock<RwLock<Option<String>>> = OnceLock::new();
 static AIS_STORE: OnceLock<std::sync::Arc<AisVesselStore>> = OnceLock::new();
 
 /// Get the own-ship context if detected
-fn get_own_ship_context() -> Option<String> {
+pub(crate) fn get_own_ship_context() -> Option<String> {
     OWN_SHIP_CONTEXT
         .get()
         .and_then(|lock| lock.read().ok())
@@ -123,6 +123,16 @@ fn set_own_ship_context(context: &str) {
         if should_set {
             log::info!("Own-ship context set to: {}", context);
             *guard = Some(context.to_string());
+            // Drop the write guard before calling into AIS_STORE so the
+            // store's own locks can be taken without holding ours.
+            drop(guard);
+            // If the REST seed already loaded our own ship as an AIS
+            // target (the seed runs in parallel with this latch — see the
+            // AIS Seed subsystem in lib/mod.rs), remove it now so the GUI
+            // overlay doesn't render the operator's own boat as a target.
+            if let Some(store) = AIS_STORE.get() {
+                store.evict(context);
+            }
         }
     }
 }
@@ -282,7 +292,12 @@ pub(crate) async fn seed_ais_from_upstream(accept_invalid_certs: bool) {
     let Some(tree_obj) = tree.as_object() else {
         return;
     };
+    // Skip own-ship's MMSI context — it shows up in the REST tree just like
+    // any other vessel, and without this guard the GUI would render the
+    // operator's own boat as a moving AIS target on the PPI.
+    let own_ship = get_own_ship_context();
     let mut seeded = 0;
+    let mut skipped_own_ship = false;
     for (ctx_key, vessel) in tree_obj {
         // Skip `urn:mrn:signalk:uuid:*` entries — those are own-ship or
         // local-without-MMSI vessels; the GUI filters them too.
@@ -290,6 +305,10 @@ pub(crate) async fn seed_ais_from_upstream(accept_invalid_certs: bool) {
             continue;
         }
         let context = format!("vessels.{}", ctx_key);
+        if own_ship.as_deref() == Some(context.as_str()) {
+            skipped_own_ship = true;
+            continue;
+        }
         let Some(updates) = build_seed_updates(vessel) else {
             continue;
         };
@@ -297,7 +316,15 @@ pub(crate) async fn seed_ais_from_upstream(accept_invalid_certs: bool) {
             seeded += 1;
         }
     }
-    log::info!("Seeded {} AIS vessels from upstream snapshot", seeded);
+    log::info!(
+        "Seeded {} AIS vessels from upstream snapshot{}",
+        seeded,
+        if skipped_own_ship {
+            " (own ship skipped)"
+        } else {
+            ""
+        }
+    );
 }
 
 /// Flatten a Signal K vessel REST node `{ navigation: { position: {value: ...},


### PR DESCRIPTION
## Summary

The GUI's PPI was rendering the operator's own boat as a moving AIS target on the radar overlay. The bug was in the **REST seed** path — the upstream Signal K server's `/vessels/` tree contains the own ship under its own MMSI URN (e.g. `vessels.urn:mrn:imo:mmsi:244060807`) exactly like any other vessel, and the AIS-seed task happily loaded it into the AIS store. Live deltas were already correctly filtered, so this only affected the snapshot loaded at startup — but that snapshot is what populates the GUI overlay the moment it opens.

Reproduction was timing-dependent: the seed kicks off as soon as the upstream HTTP base is set during discovery, which happens **before** the WS task can subscribe to `vessels.self` and latch `OWN_SHIP_CONTEXT`. So the seed had no own-ship context to compare against and could not filter the own boat out.

## Fix

Three coordinated changes on the seed path:

1. **`seed_ais_from_upstream`** reads `get_own_ship_context()` up front and skips the matching MMSI URN as it walks the REST tree. Logs `(own ship skipped)` when it fires for diagnostics.
2. **AIS Seed subsystem** in [src/lib/mod.rs](src/lib/mod.rs#L565) now waits for the own-ship context to be latched before triggering the seed (with a 30 s timeout so a no-upstream-Signal-K setup still drains the loop and doesn't permanently block the GUI overlay).
3. **`set_own_ship_context`** calls a new `AisVesselStore::evict(context)` after latching — covers the timeout case and any future race where the seed beats the latch despite the wait.

Live-delta path (`parse_signalk`) was already correct; no changes there.

## Test plan
- [x] `cargo build --features pcap-replay` clean
- [x] `cargo clippy --no-deps --all-targets --features pcap-replay -- -D warnings` clean
- [x] All 322 lib tests + 9 brand replay tests pass
- [x] Live test on Pi against an actual Signal K server: own ship no longer appears on the PPI overlay
- [x] `Seeded N AIS vessels from upstream snapshot (own ship skipped)` log line confirms the filter fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)