### PR TITLE
chore(release): 3.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.5.5-dev"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.5.5-dev"
+version = "3.6.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
Release **3.6.0**. Merge this PR; the tag is then created against the merge commit.

---

# What's new in 3.6.0

This is a minor release because a small API extension has been made to allow clients to examine radar error reports (on the two brands, Raymarine and Navico, where we have enough knowledge assembled).
Another improvement  is a major CPU reduction, most visible on low CPU power servers, support for Quantum radars over WiFi and for Fantom radars without a MFD present.

## For users

- **Lower CPU when streaming spokes.** Five independent improvements to the WebSocket spoke broadcast path stack together to roughly **cut tokio-worker CPU to about a third** of the previous baseline on a live Navico HALO. Nothing on the wire changes for existing GUIs and clients — they keep working the same way, just cheaper to serve.
- **`--no-websocket-compression` CLI flag** for LAN deployments where compression's CPU cost outweighs the bandwidth saving. Off by default; existing behaviour preserved.
- **AIS overlay no longer renders your own ship.** A startup race could load the operator's own boat into the AIS store from the upstream Signal K REST snapshot, and the PPI overlay then drew it as a moving target.
- **Raymarine Quantum over WiFi.** Quantum models that announce `0.0.0.0` as their report address (the Raymarine MFD-as-Wi-Fi-AP topology) now work, using a single connected unicast socket for command and report.

## Brand support fixes

- **Raymarine Quantum self-test faults** now surface as a `Fault` power state with per-item decoding (Pass / Fail / Did-not-run). The Axiom MFD's self-test results screen, in mayara.
- **Navico hardware errors** surface as a `Fault` power state with the wire code in the notification.
- **Garmin Fantom** wakes up correctly — the CDM V2 heartbeat is now sent.
- **Raymarine xHD doppler colours** no longer leak into non-doppler renders.

## Other

- Fixed: the Docker image now actually builds.
- New `--pcap-max-time` flag for bounded pcap replay (helpful for reproducible profiling).
- New `tests/perf/` harness for sampled profiling under (workload × compression) sweeps; runs on macOS or aarch64 Linux.
- Python `spoke_viewer` example gains a `--duration` load-driver mode.
- Docs: server description corrected (Axum, not Express); new `docs/internals/radar-status.md` design note for the status-model work in flight.

