### PR TITLE
fix(raymarine): correct Quantum model names for E70210 and E70344

### DIFF
--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -61,14 +61,14 @@ impl RaymarineModel {
                 true,
                 protocol::QUANTUM_MAX_SPOKE_LEN,
                 false,
-                "Quantum Q24",
+                "Quantum Q24C",
             ),
             "E70344" => (
                 BaseModel::Quantum,
                 true,
                 protocol::QUANTUM_MAX_SPOKE_LEN,
                 false,
-                "Quantum Q24C",
+                "Quantum Q24W",
             ),
             "E70498" => (
                 BaseModel::Quantum,


### PR DESCRIPTION
## What users see

Raymarine Quantum radars showed the wrong model name in the GUI:

- E70210 (the original CHIRP Quantum) was labelled **Quantum Q24** instead of **Quantum Q24C**.
- E70344 (the Quantum with built-in W3 wireless bridge) was labelled **Quantum Q24C**, making it indistinguishable from the actual Q24C.

After this fix the displayed model name matches the unit on the boat.

## Technical detail

Two string literals in the Raymarine model lookup table corrected:

- `E70210` → `Quantum Q24C` (was `Quantum Q24`)
- `E70344` → `Quantum Q24W` (was `Quantum Q24C`)

`E70498` (`Quantum Q24D`, Doppler) is unchanged. No behavioural change beyond the display name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the Raymarine radar model lookup table in `RaymarineModel::try_into` to correct display names for two Quantum radar units. The model code `E70210` now returns `"Quantum Q24C"` instead of `"Quantum Q24"`, and `E70344` now returns `"Quantum Q24W"` instead of `"Quantum Q24C"`. The `E70498` Quantum Q24D Doppler model mapping remains unchanged. These changes fix display ambiguity where E70344 and E70210 were previously indistinguishable in the user interface by both showing the same name. No parsing logic, fields, or control flow are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->