### PR TITLE
chore(vscode): give rust-analyzer its own cargo target dir

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
         "x86_64-pc-windows-gnu",
         "aarch64-apple-darwin",
         "aarch64-unknown-linux-musl"
-    ]
+    ],
+    "rust-analyzer.cargo.targetDir": true
 }


### PR DESCRIPTION
## What developers see

When working on mayara in VS Code, rust-analyzer would re-run `cargo check` almost continuously whenever the developer also ran `cargo build`, `cargo clippy`, or the pre-commit hook from a terminal. The two `cargo` invocations were fighting over the same `target/` directory and invalidating each other's incremental cache. After this change, rust-analyzer stays quiet unless a file is actually saved.

## Technical detail

Adds `"rust-analyzer.cargo.targetDir": true` to `.vscode/settings.json`. rust-analyzer then builds into `target/rust-analyzer/` instead of `target/`, eliminating the cache fight with terminal cargo. First check after the switch will be a full rebuild because the new directory is empty.