### PR TITLE
fix(raymarine): surface discovered radars so an asleep Quantum is visible

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -225,7 +225,7 @@ async fn get_radars(State(state): State<Web>, headers: hyper::header::HeaderMap)
 
     log::debug!("Radar state request, target host = '{}'", host);
     let mut api: HashMap<String, RadarApiV3> = HashMap::new();
-    for info in state.radars.get_active() {
+    for info in state.radars.get_discovered() {
         let spoke_data_uri = SPOKES_URI.replace("{id}", &info.key());
         let v = RadarApiV3 {
             name: info.controls.user_name(),

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -1067,6 +1067,66 @@ mod tests {
     }
 
     #[test]
+    fn discovered_quantum_without_ranges_is_visible_but_not_active() {
+        // A Quantum that has been located via beacon but is still asleep has
+        // no ranges yet. It must still surface from get_discovered()/
+        // have_discovered() (so the /radars listing shows it and the locator
+        // stops hunting), while get_active()/have_active() stay empty until a
+        // status report fills the ranges. The locator relying on
+        // have_discovered() is what lets the external-controller witness fall
+        // quiet so the WiFi wake nudge can eventually fire — see report.rs.
+        let args = Cli::parse_from(["mayara-server"]);
+        let mut locator = RaymarineLocator::new(args);
+        let radars = &SharedRadars::new();
+        const SRC: Ipv4Addr = Ipv4Addr::new(198, 18, 0, 31);
+
+        // 56-byte identity beacon: subtype 0x66, model "QuantumRadar".
+        const BEACON_56: [u8; 56] = [
+            0x01, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x48, 0x81, 0x81, 0xD6, 0x03, 0x01,
+            0x00, 0x00, 0x13, 0x2B, 0xA8, 0xC0, 0x51, 0x75, 0x61, 0x6E, 0x74, 0x75, 0x6D, 0x52,
+            0x61, 0x64, 0x61, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        ];
+        // 36-byte address beacon with a real MULTICAST report group
+        // (report=232.1.19.1:2574, command=198.18.2.59:2575) — the topology
+        // from the field capture, distinct from the MFD-as-AP unicast case.
+        const BEACON_36: [u8; 36] = [
+            0x00, 0x00, 0x00, 0x00, 0x48, 0x81, 0x81, 0xD6, 0x28, 0x00, 0x00, 0x00, 0x03, 0x00,
+            0x64, 0x00, 0x06, 0x08, 0x10, 0x00, 0x01, 0x13, 0x01, 0xE8, 0x0E, 0x0A, 0x00, 0x20,
+            0x3B, 0x02, 0x12, 0xC6, 0x0F, 0x0A, 0x00, 0x00,
+        ];
+
+        locator.process_beacon_56_report(&BEACON_56, &SRC).unwrap();
+        let (info, model) = locator
+            .process_beacon_36_report(&BEACON_36, &SRC, radars)
+            .unwrap()
+            .expect("radar should be created");
+        assert_eq!(model, BaseModel::Quantum);
+        assert!(
+            info.ranges.is_empty(),
+            "a freshly located radar has no ranges yet"
+        );
+
+        // Register it the way the locator's found() does.
+        radars.add(info);
+
+        assert!(
+            radars.have_discovered(),
+            "a located radar must count as discovered even without ranges"
+        );
+        assert_eq!(
+            radars.get_discovered().len(),
+            1,
+            "the rangeless radar must surface from get_discovered()"
+        );
+        assert!(!radars.have_active(), "a rangeless radar is not yet active");
+        assert!(
+            radars.get_active().is_empty(),
+            "get_active() stays empty until ranges arrive"
+        );
+    }
+
+    #[test]
     fn features_flags_parsed() {
         let packets = parse_fixture(PELAGIA_FIXTURE);
         let features_pkt = packets

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -137,7 +137,7 @@ impl Locator {
             let mut set = JoinSet::new();
             let cancellation_token = cancellation_token.clone();
 
-            if self.args.multiple_radar || !radars.have_active() {
+            if self.args.multiple_radar || !radars.have_discovered() {
                 // actively listening for new radars
                 // create a list of sockets for all listen addresses
                 for socket in
@@ -200,7 +200,7 @@ impl Locator {
                                     radars,
                                     subsys,
                                 );
-                                if self.args.multiple_radar || !radars.have_active() {
+                                if self.args.multiple_radar || !radars.have_discovered() {
                                     // Respawn this task
                                     spawn_receive(&mut set, locator_socket);
                                 } else {

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -793,6 +793,29 @@ impl SharedRadars {
             > 0
     }
 
+    ///
+    /// Return every radar that has been discovered, including those that have
+    /// not yet reported their ranges. Use this where a radar should surface as
+    /// soon as it is found (e.g. the `/radars` listing) rather than only once
+    /// it is fully usable — see [`get_active`](Self::get_active) for the
+    /// range-filtered set used by the spoke/data paths.
+    ///
+    pub fn get_discovered(&self) -> Vec<RadarInfo> {
+        let radars = self.radars.read().unwrap();
+        radars.info.values().cloned().collect()
+    }
+
+    /// True once any radar has been discovered, regardless of whether its
+    /// ranges have arrived. The locator uses this (not `have_active`) to decide
+    /// when to stop hunting for beacons: a Quantum that is discovered but still
+    /// asleep keeps `have_active` false forever, which would otherwise keep the
+    /// locator marking the external-controller witness and starve the wake
+    /// nudge that is meant to wake it.
+    pub fn have_discovered(&self) -> bool {
+        let radars = self.radars.read().unwrap();
+        !radars.info.is_empty()
+    }
+
     #[allow(dead_code)]
     pub fn get_by_key(&self, key: &str) -> Option<RadarInfo> {
         let radars = self.radars.read().unwrap();


### PR DESCRIPTION
## What a user sees

A Raymarine Quantum that is asleep (power-off/standby) never appears in the radar web page — it sits on "Searching for Radars…" indefinitely, even though `/radars/<key>/capabilities` answers fine. On a boat with a live Axiom MFD on the LAN it may eventually un-stick on its own once something puts the radar into transmit, which is the tell-tale of a wake/timing problem rather than a discovery failure. This happens whether the Quantum is wired or behind an Axiom acting as its WiFi access point — mayara discovers the radar (directly or via the Axiom's RayNet-side traffic) but can't surface it until ranges arrive.

## Root cause

A discovered-but-asleep Quantum reports no ranges yet, and two range-based filters combine into a deadlock:

1. `/radars` lists only `get_active()`, which filters on non-empty ranges, so the asleep radar is hidden.
2. The locator keeps hunting for beacons while `!have_active()`, and `have_active()` is **also** range-filtered. With 0 ranges it stays false forever, so the locator never stops — and it keeps marking the `ExternalControllerWitness` on every MFD beacon.
3. `maybe_send_wake_nudge()` is gated on the witness being quiet for 60s. With a live Axiom beaconing several times a second, that window never lapses, so the WiFi wake nudge that would wake the radar is permanently suppressed.

So the radar stays invisible and the wake nudge is starved.

## Fix

Decouple "discovered" from "has ranges": add `get_discovered()` / `have_discovered()` (no range filter) and use them for the `/radars` listing and the locator's stop-hunting decision. `get_active()` stays range-filtered for the spoke/data paths that genuinely need ranges. The radar now surfaces in `/radars` as soon as it is located, and once the locator stops re-marking the witness the 60s quiet window can lapse so the existing wake nudge is no longer starved — with no change to the nudge logic, so a radar an MFD is actively transmitting is never nudged toward standby.

The per-radar report receiver runs in its own subsystem with its own socket, so the locator stopping does not stop reports arriving.

This reliably fixes **visibility** (the radar appears instead of "Searching" forever) and removes the starvation. Whether the un-starved nudge then actually **wakes** a given radar is a separate question that depends on routing and the power-off wake sequence: `WAKE_WIFI` was reverse-engineered for sleep→standby and has not been validated against full power-off, and on a topology where mayara sits behind the Axiom the nudge may not reach the radar at all. Confirming/extending the wake itself is follow-up work pending the Axiom↔Quantum capture being gathered on #160, and is intentionally out of scope here.

## Scope

This addresses the visibility + wake-starvation half only. It is orthogonal to the `command_sender` priming chicken-and-egg and the `Unknown model serial` tag parsing discussed on #160; those belong in their own PRs. The richer `Initializing`/`ModelDetecting` radar-status model is also left for a separate change.

Relates to #160.

## Tested

- `cargo fmt --check`, `cargo clippy --no-deps --all-targets -- -D warnings` clean.
- `cargo test` — 314 lib tests + 15 websocket integration tests pass.
- New unit test `discovered_quantum_without_ranges_is_visible_but_not_active`, built from a real multicast Quantum beacon, asserts a rangeless located radar surfaces from `get_discovered()`/`have_discovered()` while `get_active()`/`have_active()` stay empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Separates radar discovery from range availability so a Quantum radar discovered on WiFi but still asleep can appear in `/radars` before it reports ranges.

- `SharedRadars` adds `get_discovered()` and `have_discovered()` to report radars present in the shared registry regardless of range data.
- `/radars` now lists discovered radars instead of only active ones.
- `Locator::run` stops hunting once discovery is reached, rather than waiting for active/range data.
- Adds a test covering a discovered Quantum that is visible but not active until reports populate ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
