### PR TITLE
feat(raymarine): wake, control and power radars behind an Axiom

### DIFF
--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -57,10 +57,10 @@ impl Command {
                 // the relay drops them (issue #160). Set both the multicast
                 // and unicast TTL since send_command_addr may be either.
                 if let Err(e) = sock.set_multicast_ttl_v4(super::RAYMARINE_RELAY_TTL) {
-                    log::debug!("{}: command socket multicast TTL: {}", self.key, e);
+                    log::warn!("{}: command socket multicast TTL: {}", self.key, e);
                 }
                 if let Err(e) = sock.set_ttl(super::RAYMARINE_RELAY_TTL) {
-                    log::debug!("{}: command socket TTL: {}", self.key, e);
+                    log::warn!("{}: command socket TTL: {}", self.key, e);
                 }
                 log::debug!(
                     "{} {} via {}: sending commands",
@@ -146,5 +146,35 @@ impl CommandSender for Command {
             BaseModel::RD => rd::set_control(self, cv, value, controls).await,
             BaseModel::Quantum => quantum::set_control(self, cv, value, controls).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use crate::network::create_multicast_send;
+
+    // The command socket (start_socket) relays through an Axiom to a WiFi
+    // radar, so it must carry TTL > 1 or the relay drops it (issue #160).
+    // start_socket needs a full RadarInfo to build, so exercise the socket
+    // configuration it performs directly: a create_multicast_send socket must
+    // accept both the multicast and unicast relay TTL and report them back.
+    #[tokio::test]
+    async fn command_socket_accepts_relay_ttl() {
+        let dst = SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 5800);
+        let sock = create_multicast_send(&dst, &Ipv4Addr::UNSPECIFIED)
+            .expect("command send socket should be creatable");
+
+        sock.set_multicast_ttl_v4(super::super::RAYMARINE_RELAY_TTL)
+            .expect("multicast TTL settable");
+        sock.set_ttl(super::super::RAYMARINE_RELAY_TTL)
+            .expect("unicast TTL settable");
+
+        assert_eq!(
+            sock.multicast_ttl_v4().unwrap(),
+            super::super::RAYMARINE_RELAY_TTL
+        );
+        assert_eq!(sock.ttl().unwrap(), super::super::RAYMARINE_RELAY_TTL);
     }
 }

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -52,6 +52,16 @@ impl Command {
         assert!(!self.unicast_mode);
         match create_multicast_send(&self.info.send_command_addr, &self.info.nic_addr) {
             Ok(sock) => {
+                // The command address is often an Axiom that relays to a WiFi
+                // radar; like the wake burst, commands must carry TTL > 1 or
+                // the relay drops them (issue #160). Set both the multicast
+                // and unicast TTL since send_command_addr may be either.
+                if let Err(e) = sock.set_multicast_ttl_v4(super::RAYMARINE_RELAY_TTL) {
+                    log::debug!("{}: command socket multicast TTL: {}", self.key, e);
+                }
+                if let Err(e) = sock.set_ttl(super::RAYMARINE_RELAY_TTL) {
+                    log::debug!("{}: command socket TTL: {}", self.key, e);
+                }
                 log::debug!(
                     "{} {} via {}: sending commands",
                     self.key,

--- a/src/lib/brand/raymarine/command/quantum.rs
+++ b/src/lib/brand/raymarine/command/quantum.rs
@@ -7,6 +7,18 @@ fn one_byte_command(cmd: &mut Vec<u8>, lead: &[u8], value: u8) {
     two_byte_command(cmd, lead, (value as u16) << 8);
 }
 
+/// Quantum `SetRadarMode` code for a power state (`10 00 28 00 <code>`),
+/// wire-confirmed from issue #160 captures: standby 0, transmit 1, off 3.
+/// Preparing/Fault are radar-reported states, not commands — treat them as
+/// standby if ever passed in.
+fn power_mode_code(power: Power) -> u8 {
+    match power {
+        Power::Transmit => 1,
+        Power::Off => 3,
+        _ => 0,
+    }
+}
+
 fn two_byte_command(cmd: &mut Vec<u8>, lead: &[u8], value: u16) {
     two_value_command(cmd, lead, value, 0);
 }
@@ -32,15 +44,16 @@ pub async fn set_control(
 
     match cv.id {
         ControlId::Power => {
-            let value = match Power::from_value(&cv.as_value()?).unwrap_or(Power::Standby) {
-                Power::Transmit => 1,
-                _ => 0,
-            };
-            // A sleeping radar ignores the mode command; an Axiom precedes
-            // its power-on with a WOL burst, so do the same. Harmless when
+            let power = Power::from_value(&cv.as_value()?).unwrap_or(Power::Standby);
+            // A sleeping radar ignores the mode command; an Axiom precedes a
+            // power-on with a WOL burst, so do the same. Only when actually
+            // waking it — never when we are putting it to sleep. Harmless when
             // the radar is already awake.
-            super::super::send_wake_burst(&command.info.nic_addr).await;
-            cmd.extend_from_slice(&[0x10, 0x00, 0x28, 0x00, value, 0x00, 0x00, 0x00]);
+            if power != Power::Off {
+                super::super::send_wake_burst(&command.info.nic_addr).await;
+            }
+            let code = power_mode_code(power);
+            cmd.extend_from_slice(&[0x10, 0x00, 0x28, 0x00, code, 0x00, 0x00, 0x00]);
         }
 
         ControlId::Range => {
@@ -184,7 +197,17 @@ async fn send_no_transmit_cmd(
 
 #[cfg(test)]
 mod tests {
-    use super::{one_byte_command, two_byte_command};
+    use super::{one_byte_command, power_mode_code, two_byte_command};
+    use crate::radar::Power;
+
+    // Wire-confirmed Quantum SetRadarMode codes (issue #160): standby 0,
+    // transmit 1, off 3. Off must not collapse into standby.
+    #[test]
+    fn power_mode_codes_match_the_wire() {
+        assert_eq!(power_mode_code(Power::Standby), 0);
+        assert_eq!(power_mode_code(Power::Transmit), 1);
+        assert_eq!(power_mode_code(Power::Off), 3);
+    }
 
     // Channel commands (gain, sea, rain, range, ...) carry channel in wire byte 4
     // and the value in byte 5. `one_byte_command` must therefore place the value

--- a/src/lib/brand/raymarine/command/quantum.rs
+++ b/src/lib/brand/raymarine/command/quantum.rs
@@ -36,6 +36,10 @@ pub async fn set_control(
                 Power::Transmit => 1,
                 _ => 0,
             };
+            // A sleeping radar ignores the mode command; an Axiom precedes
+            // its power-on with a WOL burst, so do the same. Harmless when
+            // the radar is already awake.
+            super::super::send_wake_burst(&command.info.nic_addr).await;
             cmd.extend_from_slice(&[0x10, 0x00, 0x28, 0x00, value, 0x00, 0x00, 0x00]);
         }
 

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -825,33 +825,38 @@ mod tests {
     fn wol_wake_is_sent_as_burst() {
         // An Axiom wakes a radar with a burst of WOLs, never a single one —
         // a lone multicast datagram to a dozing WiFi radar is routinely lost.
-        // Every Raymarine beacon group must get the MFD announce and wake
-        // literal once each, and the WOL magic packet repeated as a burst.
-        let args = Cli::parse_from(["mayara-server"]);
-        let mut addresses: Vec<LocatorAddress> = Vec::new();
-        super::new(&args, &mut addresses);
-        let raymarine: Vec<_> = addresses
-            .iter()
-            .filter(|a| a.id == LocatorId::Raymarine)
-            .collect();
-        assert!(!raymarine.is_empty());
-        for a in raymarine {
-            let wols = a
-                .beacon_request_packets
+        // Every Raymarine beacon group (wired, and the WiFi group added by
+        // --allow-wifi) must get the MFD announce and wake literal once each,
+        // the WOL magic packet repeated as a burst, and the relay TTL.
+        for extra_args in [&[][..], &["--allow-wifi"][..]] {
+            let args = Cli::parse_from(std::iter::once("mayara-server").chain(extra_args.to_vec()));
+            let mut addresses: Vec<LocatorAddress> = Vec::new();
+            super::new(&args, &mut addresses);
+            let raymarine: Vec<_> = addresses
                 .iter()
-                .filter(|p| **p == super::RAYMARINE_WOL_RADAR)
-                .count();
-            assert_eq!(wols, super::WOL_WAKE_BURST);
-            assert_eq!(
-                a.beacon_request_packets.len(),
-                super::WOL_WAKE_BURST + 2,
-                "expected MFD announce + wake literal + WOL burst"
-            );
-            assert_eq!(
-                a.beacon_multicast_ttl,
-                Some(super::RAYMARINE_RELAY_TTL),
-                "Raymarine beacons must carry the relay-eligible TTL"
-            );
+                .filter(|a| a.id == LocatorId::Raymarine)
+                .collect();
+            assert!(!raymarine.is_empty());
+            for a in raymarine {
+                let wols = a
+                    .beacon_request_packets
+                    .iter()
+                    .filter(|p| **p == super::RAYMARINE_WOL_RADAR)
+                    .count();
+                assert_eq!(wols, super::WOL_WAKE_BURST, "group {}", a.address);
+                assert_eq!(
+                    a.beacon_request_packets.len(),
+                    super::WOL_WAKE_BURST + 2,
+                    "group {}: expected MFD announce + wake literal + WOL burst",
+                    a.address
+                );
+                assert_eq!(
+                    a.beacon_multicast_ttl,
+                    Some(super::RAYMARINE_RELAY_TTL),
+                    "group {}: Raymarine beacons must carry the relay-eligible TTL",
+                    a.address
+                );
+            }
         }
     }
 

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -690,11 +690,21 @@ const RAYMARINE_WOL_RADAR: [u8; 102] = [
     0xc7, 0xd, 0xef, 0xa0,
 ];
 
-const BEACONS: [&[u8]; 3] = [
-    &RAYMARINE_MFD_BEACON,
-    &RAYMARINE_WAKE_RADAR,
-    &RAYMARINE_WOL_RADAR,
-];
+/// How many WOL magic packets to send per beacon cycle. An Axiom wakes a
+/// radar with a burst of 7–10 WOLs, never a single one — a lone multicast
+/// datagram to a dozing WiFi radar is routinely lost. Wire-confirmed in
+/// MarineYachtRadar/mayara-server#160.
+const WOL_WAKE_BURST: usize = 8;
+
+/// The discovery/wake packets sent to a beacon group each locator cycle:
+/// the MFD announce, the wake literal, then the WOL magic packet as a burst.
+fn beacon_request_packets() -> Vec<&'static [u8]> {
+    let mut packets: Vec<&'static [u8]> = vec![&RAYMARINE_MFD_BEACON, &RAYMARINE_WAKE_RADAR];
+    for _ in 0..WOL_WAKE_BURST {
+        packets.push(&RAYMARINE_WOL_RADAR);
+    }
+    packets
+}
 
 /// Register the Raymarine locator's beacon/wake multicast groups.
 ///
@@ -718,7 +728,7 @@ pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
                 LocatorId::Raymarine,
                 beacon_address,
                 Brand::Raymarine,
-                BEACONS.to_vec(),
+                beacon_request_packets(),
                 Box::new(RaymarineLocator::new(args.clone())),
             ));
         }
@@ -766,6 +776,35 @@ mod tests {
             vec![RAYMARINE_BEACON_ADDRESS, RAYMARINE_QUANTUM_WIFI_ADDRESS],
             "--allow-wifi must register exactly the wired group plus the WiFi group, with no duplicates or extra groups"
         );
+    }
+
+    #[test]
+    fn wol_wake_is_sent_as_burst() {
+        // An Axiom wakes a radar with a burst of WOLs, never a single one —
+        // a lone multicast datagram to a dozing WiFi radar is routinely lost.
+        // Every Raymarine beacon group must get the MFD announce and wake
+        // literal once each, and the WOL magic packet repeated as a burst.
+        let args = Cli::parse_from(["mayara-server"]);
+        let mut addresses: Vec<LocatorAddress> = Vec::new();
+        super::new(&args, &mut addresses);
+        let raymarine: Vec<_> = addresses
+            .iter()
+            .filter(|a| a.id == LocatorId::Raymarine)
+            .collect();
+        assert!(!raymarine.is_empty());
+        for a in raymarine {
+            let wols = a
+                .beacon_request_packets
+                .iter()
+                .filter(|p| **p == super::RAYMARINE_WOL_RADAR)
+                .count();
+            assert_eq!(wols, super::WOL_WAKE_BURST);
+            assert_eq!(
+                a.beacon_request_packets.len(),
+                super::WOL_WAKE_BURST + 2,
+                "expected MFD announce + wake literal + WOL burst"
+            );
+        }
     }
 
     #[test]

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -698,19 +698,25 @@ const BEACONS: [&[u8]; 3] = [
 
 pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
     if !addresses.iter().any(|i| i.id == LocatorId::Raymarine) {
-        let beacon_address = if args.allow_wifi {
-            &RAYMARINE_QUANTUM_WIFI_ADDRESS
-        } else {
-            &RAYMARINE_BEACON_ADDRESS
-        };
+        // The wired/RayNet beacon group is always needed — radomes and MFDs on
+        // RayNet announce and listen on 224.0.0.1:5800. `--allow-wifi`
+        // additionally enables the WiFi discovery group (232.1.1.1:5800); it
+        // must *add* that group, not replace the wired one, or enabling WiFi
+        // support would silently stop wired/RayNet discovery and wake.
+        let mut beacon_addresses = vec![&RAYMARINE_BEACON_ADDRESS];
+        if args.allow_wifi {
+            beacon_addresses.push(&RAYMARINE_QUANTUM_WIFI_ADDRESS);
+        }
 
-        addresses.push(LocatorAddress::new(
-            LocatorId::Raymarine,
-            beacon_address,
-            Brand::Raymarine,
-            BEACONS.to_vec(),
-            Box::new(RaymarineLocator::new(args.clone())),
-        ));
+        for beacon_address in beacon_addresses {
+            addresses.push(LocatorAddress::new(
+                LocatorId::Raymarine,
+                beacon_address,
+                Brand::Raymarine,
+                BEACONS.to_vec(),
+                Box::new(RaymarineLocator::new(args.clone())),
+            ));
+        }
     }
 }
 
@@ -720,8 +726,45 @@ mod tests {
 
     use clap::Parser;
 
-    use super::{BaseModel, protocol};
+    use super::{BaseModel, RAYMARINE_BEACON_ADDRESS, RAYMARINE_QUANTUM_WIFI_ADDRESS, protocol};
+    use crate::brand::LocatorId;
+    use crate::locator::LocatorAddress;
     use crate::{Cli, brand::raymarine::RaymarineLocator, radar::SharedRadars};
+
+    fn raymarine_beacon_groups(extra_args: &[&str]) -> Vec<std::net::SocketAddr> {
+        let mut argv = vec!["mayara-server"];
+        argv.extend_from_slice(extra_args);
+        let args = Cli::parse_from(argv);
+        let mut addresses: Vec<LocatorAddress> = Vec::new();
+        super::new(&args, &mut addresses);
+        addresses
+            .iter()
+            .filter(|a| a.id == LocatorId::Raymarine)
+            .map(|a| a.address)
+            .collect()
+    }
+
+    #[test]
+    fn default_beacons_to_wired_group_only() {
+        let groups = raymarine_beacon_groups(&[]);
+        assert_eq!(groups, vec![RAYMARINE_BEACON_ADDRESS]);
+    }
+
+    #[test]
+    fn allow_wifi_adds_wifi_group_without_dropping_wired() {
+        // --allow-wifi must *add* the WiFi discovery group, not replace the
+        // wired/RayNet one — otherwise enabling WiFi support silently stops
+        // wired discovery and wake (the radar/MFD listen on 224.0.0.1:5800).
+        let groups = raymarine_beacon_groups(&["--allow-wifi"]);
+        assert!(
+            groups.contains(&RAYMARINE_BEACON_ADDRESS),
+            "wired group 224.0.0.1:5800 must still be registered with --allow-wifi"
+        );
+        assert!(
+            groups.contains(&RAYMARINE_QUANTUM_WIFI_ADDRESS),
+            "WiFi group 232.1.1.1:5800 must be registered with --allow-wifi"
+        );
+    }
 
     #[test]
     fn decode_raymarine_locator_beacon() {

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -696,14 +696,14 @@ const RAYMARINE_WOL_RADAR: [u8; 102] = [
 /// MarineYachtRadar/mayara-server#160.
 const WOL_WAKE_BURST: usize = 8;
 
-/// Raymarine MFDs emit the radar wake/WOL with IP TTL 10, and an Axiom acting
-/// as a radar's WiFi access point only relays wake packets whose TTL is > 1
-/// (router semantics: TTL 1 means link-local only). Send our beacon requests
-/// with the same TTL so they are eligible for that relay — on the local link
-/// a larger TTL changes nothing. Wire-confirmed against a live Axiom in
-/// MarineYachtRadar/mayara-server#160. Raymarine-specific: other brands keep
-/// the OS default.
-const RAYMARINE_BEACON_TTL: u32 = 10;
+/// Raymarine MFDs emit their radar traffic with IP TTL 10, and an Axiom acting
+/// as a radar's WiFi access point only relays packets whose TTL is > 1 (router
+/// semantics: TTL 1 means link-local only). Send our wake bursts *and* our
+/// command traffic with the same TTL so they are eligible for that relay — on
+/// the local link a larger TTL changes nothing. Wire-confirmed against a live
+/// Axiom in MarineYachtRadar/mayara-server#160. Raymarine-specific: other
+/// brands keep the OS default.
+pub(super) const RAYMARINE_RELAY_TTL: u32 = 10;
 
 /// Gap between the packets of an on-demand wake burst, matching the ~20 ms
 /// spacing observed from an Axiom.
@@ -711,7 +711,7 @@ const WAKE_BURST_SPACING: Duration = Duration::from_millis(20);
 
 /// Send the WOL wake burst the way an Axiom does when the user presses "On":
 /// [`WOL_WAKE_BURST`] magic packets [`WAKE_BURST_SPACING`] apart to the wired
-/// beacon group, with [`RAYMARINE_BEACON_TTL`] so an Axiom relaying to a WiFi
+/// beacon group, with [`RAYMARINE_RELAY_TTL`] so an Axiom relaying to a WiFi
 /// radar forwards them. Failures are logged, not returned — the caller's mode
 /// command should still go out.
 async fn send_wake_burst(nic_addr: &Ipv4Addr) {
@@ -720,7 +720,7 @@ async fn send_wake_burst(nic_addr: &Ipv4Addr) {
     };
     match crate::network::create_multicast_send(&addr, nic_addr) {
         Ok(sock) => {
-            if let Err(e) = sock.set_multicast_ttl_v4(RAYMARINE_BEACON_TTL) {
+            if let Err(e) = sock.set_multicast_ttl_v4(RAYMARINE_RELAY_TTL) {
                 log::warn!("via {}: wake burst TTL: {}", nic_addr, e);
             }
             for _ in 0..WOL_WAKE_BURST {
@@ -772,7 +772,7 @@ pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
                     beacon_request_packets(),
                     Box::new(RaymarineLocator::new(args.clone())),
                 )
-                .with_beacon_multicast_ttl(RAYMARINE_BEACON_TTL),
+                .with_beacon_multicast_ttl(RAYMARINE_RELAY_TTL),
             );
         }
     }
@@ -849,7 +849,7 @@ mod tests {
             );
             assert_eq!(
                 a.beacon_multicast_ttl,
-                Some(super::RAYMARINE_BEACON_TTL),
+                Some(super::RAYMARINE_RELAY_TTL),
                 "Raymarine beacons must carry the relay-eligible TTL"
             );
         }

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -696,6 +696,11 @@ const BEACONS: [&[u8]; 3] = [
     &RAYMARINE_WOL_RADAR,
 ];
 
+/// Register the Raymarine locator's beacon/wake multicast groups.
+///
+/// The wired/RayNet group (`224.0.0.1:5800`) is always registered; the WiFi
+/// group (`232.1.1.1:5800`) is added on top when `--allow-wifi` is set. No-op
+/// if a Raymarine locator is already registered.
 pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
     if !addresses.iter().any(|i| i.id == LocatorId::Raymarine) {
         // The wired/RayNet beacon group is always needed — radomes and MFDs on
@@ -756,13 +761,10 @@ mod tests {
         // wired/RayNet one — otherwise enabling WiFi support silently stops
         // wired discovery and wake (the radar/MFD listen on 224.0.0.1:5800).
         let groups = raymarine_beacon_groups(&["--allow-wifi"]);
-        assert!(
-            groups.contains(&RAYMARINE_BEACON_ADDRESS),
-            "wired group 224.0.0.1:5800 must still be registered with --allow-wifi"
-        );
-        assert!(
-            groups.contains(&RAYMARINE_QUANTUM_WIFI_ADDRESS),
-            "WiFi group 232.1.1.1:5800 must be registered with --allow-wifi"
+        assert_eq!(
+            groups,
+            vec![RAYMARINE_BEACON_ADDRESS, RAYMARINE_QUANTUM_WIFI_ADDRESS],
+            "--allow-wifi must register exactly the wired group plus the WiFi group, with no duplicates or extra groups"
         );
     }
 

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -705,6 +705,37 @@ const WOL_WAKE_BURST: usize = 8;
 /// the OS default.
 const RAYMARINE_BEACON_TTL: u32 = 10;
 
+/// Gap between the packets of an on-demand wake burst, matching the ~20 ms
+/// spacing observed from an Axiom.
+const WAKE_BURST_SPACING: Duration = Duration::from_millis(20);
+
+/// Send the WOL wake burst the way an Axiom does when the user presses "On":
+/// [`WOL_WAKE_BURST`] magic packets [`WAKE_BURST_SPACING`] apart to the wired
+/// beacon group, with [`RAYMARINE_BEACON_TTL`] so an Axiom relaying to a WiFi
+/// radar forwards them. Failures are logged, not returned — the caller's mode
+/// command should still go out.
+async fn send_wake_burst(nic_addr: &Ipv4Addr) {
+    let SocketAddr::V4(addr) = RAYMARINE_BEACON_ADDRESS else {
+        return;
+    };
+    match crate::network::create_multicast_send(&addr, nic_addr) {
+        Ok(sock) => {
+            if let Err(e) = sock.set_multicast_ttl_v4(RAYMARINE_BEACON_TTL) {
+                log::warn!("via {}: wake burst TTL: {}", nic_addr, e);
+            }
+            for _ in 0..WOL_WAKE_BURST {
+                if let Err(e) = sock.send(&RAYMARINE_WOL_RADAR).await {
+                    log::warn!("via {}: wake burst send failed: {}", nic_addr, e);
+                    return;
+                }
+                tokio::time::sleep(WAKE_BURST_SPACING).await;
+            }
+            log::info!("via {}: sent WOL wake burst", nic_addr);
+        }
+        Err(e) => log::warn!("via {}: wake burst socket: {}", nic_addr, e),
+    }
+}
+
 /// The discovery/wake packets sent to a beacon group each locator cycle:
 /// the MFD announce, the wake literal, then the WOL magic packet as a burst.
 fn beacon_request_packets() -> Vec<&'static [u8]> {

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -696,6 +696,15 @@ const RAYMARINE_WOL_RADAR: [u8; 102] = [
 /// MarineYachtRadar/mayara-server#160.
 const WOL_WAKE_BURST: usize = 8;
 
+/// Raymarine MFDs emit the radar wake/WOL with IP TTL 10, and an Axiom acting
+/// as a radar's WiFi access point only relays wake packets whose TTL is > 1
+/// (router semantics: TTL 1 means link-local only). Send our beacon requests
+/// with the same TTL so they are eligible for that relay — on the local link
+/// a larger TTL changes nothing. Wire-confirmed against a live Axiom in
+/// MarineYachtRadar/mayara-server#160. Raymarine-specific: other brands keep
+/// the OS default.
+const RAYMARINE_BEACON_TTL: u32 = 10;
+
 /// The discovery/wake packets sent to a beacon group each locator cycle:
 /// the MFD announce, the wake literal, then the WOL magic packet as a burst.
 fn beacon_request_packets() -> Vec<&'static [u8]> {
@@ -724,13 +733,16 @@ pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
         }
 
         for beacon_address in beacon_addresses {
-            addresses.push(LocatorAddress::new(
-                LocatorId::Raymarine,
-                beacon_address,
-                Brand::Raymarine,
-                beacon_request_packets(),
-                Box::new(RaymarineLocator::new(args.clone())),
-            ));
+            addresses.push(
+                LocatorAddress::new(
+                    LocatorId::Raymarine,
+                    beacon_address,
+                    Brand::Raymarine,
+                    beacon_request_packets(),
+                    Box::new(RaymarineLocator::new(args.clone())),
+                )
+                .with_beacon_multicast_ttl(RAYMARINE_BEACON_TTL),
+            );
         }
     }
 }
@@ -803,6 +815,11 @@ mod tests {
                 a.beacon_request_packets.len(),
                 super::WOL_WAKE_BURST + 2,
                 "expected MFD announce + wake literal + WOL burst"
+            );
+            assert_eq!(
+                a.beacon_multicast_ttl,
+                Some(super::RAYMARINE_BEACON_TTL),
+                "Raymarine beacons must carry the relay-eligible TTL"
             );
         }
     }

--- a/src/lib/brand/raymarine/protocol.rs
+++ b/src/lib/brand/raymarine/protocol.rs
@@ -209,6 +209,12 @@ pub(crate) const HEARTBEAT_QUANTUM_5S: [u8; 36] = [
 /// that's already in standby. Must NOT be sent to a transmitting radar.
 pub(crate) const WAKE_WIFI: [u8; 8] = [0x10, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00];
 
+/// Quantum `SetRadarMode` → Transmit (`10 00 28 00 01 …`), mode code 1. Used to
+/// re-apply a transmit request once a cold radar has reached Standby (see
+/// `pending_transmit`), matching the byte the command path sends for
+/// `ControlId::Power` → Transmit.
+pub(crate) const SET_TRANSMIT_QUANTUM: [u8; 8] = [0x10, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00, 0x00];
+
 /// 1-second keep-alive for RD/E120 (12 bytes, contains "RADAR").
 pub(crate) const HEARTBEAT_RD_1S: [u8; 12] = [
     0x00, 0x80, 0x01, 0x00, 0x52, 0x41, 0x44, 0x41, 0x52, 0x00, 0x00, 0x00,

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -62,6 +62,13 @@ fn transmit_should_defer(requested: Power, reported: Option<Power>) -> Option<bo
     }
 }
 
+/// Whether to re-send the transmit command now: only when a transmit is
+/// pending and the radar has just reported it reached Standby (i.e. it has
+/// finished booting and will now accept the mode change).
+fn should_reapply_transmit(pending: bool, reported: Option<Power>) -> bool {
+    pending && reported == Some(Power::Standby)
+}
+
 // The LookupSpokeEnum is an index into an array, really. `process_frame`
 // picks the row based on whether the radar currently reports Doppler on
 // (see `process_doppler_report`).
@@ -462,10 +469,10 @@ impl RaymarineReportReceiver {
     /// booting). One shot: the flag is cleared whether or not this send
     /// succeeds — if it is lost too, the user can ask again.
     async fn maybe_reapply_transmit(&mut self) {
-        if !self.pending_transmit {
-            return;
-        }
-        if self.common.info.controls.get_status() != Some(Power::Standby) {
+        if !should_reapply_transmit(
+            self.pending_transmit,
+            self.common.info.controls.get_status(),
+        ) {
             return;
         }
         self.pending_transmit = false;
@@ -675,8 +682,69 @@ impl RaymarineReportReceiver {
 
 #[cfg(test)]
 mod tests {
-    use super::transmit_should_defer;
+    use super::{should_reapply_transmit, transmit_should_defer};
     use crate::radar::Power;
+
+    /// Drive a `pending_transmit` flag through the same two decisions the
+    /// receiver applies — arm on a Power request (`note_power_request`), and
+    /// re-send on a status report (`maybe_reapply_transmit`, which clears the
+    /// flag once it fires). Returns (final pending flag, number of transmit
+    /// re-sends) for a sequence of (power request, reported status) steps.
+    fn run_flow(steps: &[(Option<Power>, Option<Power>)]) -> (bool, u32) {
+        let mut pending = false;
+        let mut resends = 0;
+        for &(request, reported) in steps {
+            if let Some(req) = request
+                && let Some(p) = transmit_should_defer(req, reported)
+            {
+                pending = p;
+            }
+            if should_reapply_transmit(pending, reported) {
+                pending = false;
+                resends += 1;
+            }
+        }
+        (pending, resends)
+    }
+
+    #[test]
+    fn off_to_transmit_reapplies_once_at_standby() {
+        // Ask for transmit while off, radar stays off/preparing for a while,
+        // then reports standby -> exactly one re-send, flag cleared.
+        let (pending, resends) = run_flow(&[
+            (Some(Power::Transmit), Some(Power::Off)),
+            (None, Some(Power::Off)),
+            (None, Some(Power::Preparing)),
+            (None, Some(Power::Standby)),
+            (None, Some(Power::Standby)),
+        ]);
+        assert!(!pending);
+        assert_eq!(resends, 1);
+    }
+
+    #[test]
+    fn standby_request_cancels_pending_reapply() {
+        // Transmit-from-off arms it, but the user then asks for standby before
+        // the radar boots -> no re-send when standby finally arrives.
+        let (pending, resends) = run_flow(&[
+            (Some(Power::Transmit), Some(Power::Off)),
+            (Some(Power::Standby), Some(Power::Off)),
+            (None, Some(Power::Standby)),
+        ]);
+        assert!(!pending);
+        assert_eq!(resends, 0);
+    }
+
+    #[test]
+    fn standby_to_transmit_does_not_reapply() {
+        // Standby -> transmit is honoured immediately; nothing is deferred.
+        let (pending, resends) = run_flow(&[
+            (Some(Power::Transmit), Some(Power::Standby)),
+            (None, Some(Power::Standby)),
+        ]);
+        assert!(!pending);
+        assert_eq!(resends, 0);
+    }
 
     #[test]
     fn transmit_from_off_or_unknown_defers() {

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -280,6 +280,12 @@ impl RaymarineReportReceiver {
                     &self.common.info.send_command_addr,
                 ) {
                     Ok(sock) => {
+                        // Commands/replies on this socket may cross an Axiom
+                        // relay to a WiFi radar, which drops TTL-1 packets
+                        // (issue #160). Match the wake burst's TTL.
+                        if let Err(e) = sock.set_ttl(super::RAYMARINE_RELAY_TTL) {
+                            log::debug!("{}: unicast socket TTL: {}", self.common.key, e);
+                        }
                         let sock = Arc::new(sock);
                         if let Some(cs) = &mut self.command_sender {
                             cs.set_shared_socket(sock.clone());

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -284,7 +284,7 @@ impl RaymarineReportReceiver {
                         // relay to a WiFi radar, which drops TTL-1 packets
                         // (issue #160). Match the wake burst's TTL.
                         if let Err(e) = sock.set_ttl(super::RAYMARINE_RELAY_TTL) {
-                            log::debug!("{}: unicast socket TTL: {}", self.common.key, e);
+                            log::warn!("{}: unicast socket TTL: {}", self.common.key, e);
                         }
                         let sock = Arc::new(sock);
                         if let Some(cs) = &mut self.command_sender {

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -10,7 +10,10 @@ use crate::Cli;
 use crate::brand::raymarine::RaymarineModel;
 use crate::network;
 use crate::radar::range::Ranges;
-use crate::radar::{BYTE_LOOKUP_LENGTH, CommonRadar, Legend, RadarError, RadarInfo, SharedRadars};
+use crate::radar::settings::{ControlId, ControlValue};
+use crate::radar::{
+    BYTE_LOOKUP_LENGTH, CommonRadar, Legend, Power, RadarError, RadarInfo, SharedRadars,
+};
 use crate::replay::RadarSocket;
 
 // use super::command::Command;
@@ -39,6 +42,25 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1000);
 const WAKE_INTERVAL: Duration = Duration::from_secs(3);
 const OBSERVATION_WINDOW: Duration = Duration::from_secs(5);
 const EXTERNAL_QUIET_WINDOW: Duration = Duration::from_secs(60);
+
+/// Decide how a Power request affects the "re-apply transmit once the radar
+/// reaches standby" flag, given the radar's last reported power state.
+/// Returns `Some(new_flag)` when the request changes it, `None` to leave it.
+///
+/// A cold Quantum drops a transmit command while it boots (~25-30 s), so a
+/// transmit requested while it is off/unknown must be re-applied once it
+/// reports standby. Standby->transmit is honoured immediately (no deferral);
+/// a standby/off request cancels any pending transmit.
+fn transmit_should_defer(requested: Power, reported: Option<Power>) -> Option<bool> {
+    match requested {
+        Power::Transmit => {
+            let awake = matches!(reported, Some(Power::Standby) | Some(Power::Transmit));
+            Some(!awake)
+        }
+        Power::Standby | Power::Off => Some(false),
+        _ => None,
+    }
+}
 
 // The LookupSpokeEnum is an index into an array, really. `process_frame`
 // picks the row based on whether the radar currently reports Doppler on
@@ -170,6 +192,14 @@ pub(crate) struct RaymarineReportReceiver {
     /// broadcast.
     pub(super) self_test_results: Option<[u8; quantum::SELF_TEST_ITEM_COUNT]>,
 
+    /// True when the user asked for Transmit while the radar was not yet
+    /// awake/transmitting. A cold Quantum takes ~25-30 s to boot to Standby
+    /// before it accepts a mode change, so the transmit command sent alongside
+    /// the wake is lost. We re-send it once the radar reports Standby, then
+    /// clear this — so off->transmit is a single user action. Cleared if the
+    /// user asks for Standby/Off in the meantime.
+    pub(super) pending_transmit: bool,
+
     // For data (spokes)
     range_meters: u32,
     wire_to_legend: WireToLegendTable,
@@ -261,6 +291,7 @@ impl RaymarineReportReceiver {
             features_seen: false,
             self_test_fault: false,
             self_test_results: None,
+            pending_transmit: false,
             range_meters: 0,
             wire_to_legend,
             doppler: false,
@@ -400,10 +431,50 @@ impl RaymarineReportReceiver {
                 r = self.common.control_update_rx.recv() => {
                     match r {
                         Err(_) => {},
-                        Ok(cv) => {let _ = self.common.process_control_update(cv, &mut self.command_sender).await;},
+                        Ok(cv) => {
+                            self.note_power_request(&cv.control_value);
+                            let _ = self.common.process_control_update(cv, &mut self.command_sender).await;
+                        },
                     }
                 }
             }
+        }
+    }
+
+    /// Observe a Power control request so a Transmit asked for while the radar
+    /// is not yet transmitting can be re-applied once it reports Standby (see
+    /// `pending_transmit`). A Standby/Off request clears any pending transmit.
+    fn note_power_request(&mut self, cv: &ControlValue) {
+        if cv.id != ControlId::Power {
+            return;
+        }
+        let Some(power) = cv.value.as_ref().and_then(|v| Power::from_value(v).ok()) else {
+            return;
+        };
+        if let Some(pending) = transmit_should_defer(power, self.common.info.controls.get_status())
+        {
+            self.pending_transmit = pending;
+        }
+    }
+
+    /// If the user asked for Transmit while the radar was waking, re-send the
+    /// transmit command once it reports Standby (it ignored the first one while
+    /// booting). One shot: the flag is cleared whether or not this send
+    /// succeeds — if it is lost too, the user can ask again.
+    async fn maybe_reapply_transmit(&mut self) {
+        if !self.pending_transmit {
+            return;
+        }
+        if self.common.info.controls.get_status() != Some(Power::Standby) {
+            return;
+        }
+        self.pending_transmit = false;
+        if let Some(ref mut cs) = self.command_sender {
+            log::info!(
+                "{}: radar reached standby, re-applying transmit",
+                self.common.key
+            );
+            let _ = cs.send(&super::protocol::SET_TRANSMIT_QUANTUM).await;
         }
     }
 
@@ -501,6 +572,7 @@ impl RaymarineReportReceiver {
             }
             0x280002 => {
                 quantum::process_status_report(self, data);
+                self.maybe_reapply_transmit().await;
             }
             0x280003 => {
                 quantum::process_frame(self, data);
@@ -598,5 +670,48 @@ impl RaymarineReportReceiver {
             command_sender.set_ranges(ranges.clone());
         }
         self.common.set_ranges(ranges);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transmit_should_defer;
+    use crate::radar::Power;
+
+    #[test]
+    fn transmit_from_off_or_unknown_defers() {
+        // Off or not-yet-reported: the radar is booting, so a transmit
+        // request must be re-applied once it reaches standby.
+        assert_eq!(transmit_should_defer(Power::Transmit, None), Some(true));
+        assert_eq!(
+            transmit_should_defer(Power::Transmit, Some(Power::Off)),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn transmit_while_awake_is_not_deferred() {
+        // Standby -> transmit is honoured immediately; transmit while already
+        // transmitting is a no-op — neither should arm the pending flag.
+        assert_eq!(
+            transmit_should_defer(Power::Transmit, Some(Power::Standby)),
+            Some(false)
+        );
+        assert_eq!(
+            transmit_should_defer(Power::Transmit, Some(Power::Transmit)),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn standby_or_off_cancels_pending_transmit() {
+        assert_eq!(transmit_should_defer(Power::Standby, None), Some(false));
+        assert_eq!(transmit_should_defer(Power::Off, None), Some(false));
+    }
+
+    #[test]
+    fn other_states_leave_pending_unchanged() {
+        assert_eq!(transmit_should_defer(Power::Preparing, None), None);
+        assert_eq!(transmit_should_defer(Power::Fault, None), None);
     }
 }

--- a/src/lib/brand/raymarine/settings.rs
+++ b/src/lib/brand/raymarine/settings.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::{
     Cli,
     brand::raymarine::RaymarineModel,
+    radar::Power,
     radar::RadarInfo,
     radar::settings::{
         ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
@@ -145,4 +146,11 @@ pub(crate) fn update_when_model_known(
     );
 
     controls.add(new_list(ControlId::TargetExpansion, &["Off", "On"]));
+
+    // Quantum accepts a full power-off (mode 3, wire-confirmed in issue #160)
+    // in addition to the generic Standby/Transmit. Widen the Power control so
+    // the Radar API exposes and accepts Off for these radars.
+    if model.model == BaseModel::Quantum {
+        controls.add_valid_value(&ControlId::Power, Power::Off as i32);
+    }
 }

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -24,6 +24,19 @@ use crate::{Brand, Cli, InterfaceApi, InterfaceId, InterfaceStatus, RadarInterfa
 
 const LOCATOR_PACKET_BUFFER_LEN: usize = 300; // Long enough for any location packet
 
+// Raymarine MFDs emit the radar wake/WOL with IP TTL 10, and an Axiom acting
+// as a radar's WiFi access point only relays wake packets whose TTL is > 1
+// (router semantics: TTL 1 means link-local only). Send our beacon requests
+// with the same TTL so they are eligible for that relay — on the local link a
+// larger TTL changes nothing. Wire-confirmed against a live Axiom in
+// MarineYachtRadar/mayara-server#160.
+const BEACON_MULTICAST_TTL: u32 = 10;
+
+// An Axiom wakes a radar with a burst of WOL packets roughly 20 ms apart, not
+// a single datagram — multicast to a dozing WiFi radar is lossy, so singles
+// are routinely missed. Space consecutive beacon-request packets the same way.
+const BEACON_PACKET_SPACING: Duration = Duration::from_millis(20);
+
 pub(crate) struct LocatorAddress {
     pub id: LocatorId,
     pub address: SocketAddr,
@@ -587,6 +600,7 @@ async fn send_beacon_requests(
             if let Err(e) = send_beacon_request(interface_addresses, &x.0, beacon_request).await {
                 log::warn!("Failed to send beacon request to {}: {}", x.0, e);
             }
+            sleep(BEACON_PACKET_SPACING).await;
         }
     }
 
@@ -608,6 +622,7 @@ async fn send_beacon_request(
                 match network::create_multicast_send(addr, nic_addr) {
                     Ok(sock) => {
                         sock.set_broadcast(true)?;
+                        sock.set_multicast_ttl_v4(BEACON_MULTICAST_TTL)?;
                         match sock.send(msg).await {
                             Ok(_) => {
                                 log::debug!(

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -258,7 +258,17 @@ impl Locator {
                                         break;
                                     }
                                     RadarError::Timeout => {
-                                        if !self.args.is_replay() {
+                                        // Only ask for radars while we are still hunting for
+                                        // them. The Raymarine beacon set contains the WOL wake
+                                        // burst, and repeating that every cycle would re-wake a
+                                        // radar the user deliberately powered off from an MFD —
+                                        // an Axiom sends one burst when "On" is pressed, then
+                                        // stays silent. Waking an already-discovered radar is
+                                        // done on demand from the power command instead.
+                                        if !self.args.is_replay()
+                                            && (self.args.multiple_radar
+                                                || !radars.have_discovered())
+                                        {
                                             let _ = send_beacon_requests(
                                                 &beacon_messages,
                                                 &interface_state.active_nic_addresses,

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -24,14 +24,6 @@ use crate::{Brand, Cli, InterfaceApi, InterfaceId, InterfaceStatus, RadarInterfa
 
 const LOCATOR_PACKET_BUFFER_LEN: usize = 300; // Long enough for any location packet
 
-// Raymarine MFDs emit the radar wake/WOL with IP TTL 10, and an Axiom acting
-// as a radar's WiFi access point only relays wake packets whose TTL is > 1
-// (router semantics: TTL 1 means link-local only). Send our beacon requests
-// with the same TTL so they are eligible for that relay — on the local link a
-// larger TTL changes nothing. Wire-confirmed against a live Axiom in
-// MarineYachtRadar/mayara-server#160.
-const BEACON_MULTICAST_TTL: u32 = 10;
-
 // An Axiom wakes a radar with a burst of WOL packets roughly 20 ms apart, not
 // a single datagram — multicast to a dozing WiFi radar is lossy, so singles
 // are routinely missed. Space consecutive beacon-request packets the same way.
@@ -42,6 +34,10 @@ pub(crate) struct LocatorAddress {
     pub address: SocketAddr,
     pub brand: Brand,
     pub beacon_request_packets: Vec<&'static [u8]>, // Optional messages to send to ask radar for address
+    // Multicast TTL for the beacon requests; None keeps the OS default (1,
+    // link-local). Brands whose wake must be relayed across segments set this
+    // per locator so the workaround doesn't leak into other brands' discovery.
+    pub beacon_multicast_ttl: Option<u32>,
     pub locator: Box<dyn RadarLocator>,
 }
 
@@ -62,9 +58,24 @@ impl LocatorAddress {
             address: *address,
             brand,
             beacon_request_packets,
+            beacon_multicast_ttl: None,
             locator,
         }
     }
+
+    pub(crate) fn with_beacon_multicast_ttl(mut self, ttl: u32) -> Self {
+        self.beacon_multicast_ttl = Some(ttl);
+        self
+    }
+}
+
+/// A beacon destination plus its request packets and optional multicast TTL,
+/// extracted from [`LocatorAddress`] for the periodic send loop.
+#[derive(Debug)]
+struct BeaconRequests {
+    address: SocketAddr,
+    packets: Vec<&'static [u8]>,
+    multicast_ttl: Option<u32>,
 }
 
 struct LocatorSocket {
@@ -138,8 +149,12 @@ impl Locator {
         let beacon_messages = listen_addresses
             .iter()
             .filter(|x| !x.beacon_request_packets.is_empty())
-            .map(|x| (x.address, x.beacon_request_packets.clone()))
-            .collect::<Vec<(SocketAddr, Vec<&[u8]>)>>();
+            .map(|x| BeaconRequests {
+                address: x.address,
+                packets: x.beacon_request_packets.clone(),
+                multicast_ttl: x.beacon_multicast_ttl,
+            })
+            .collect::<Vec<BeaconRequests>>();
         log::debug!("beacon_messages = {:?}", beacon_messages);
 
         let cancellation_token = subsys.create_cancellation_token();
@@ -592,13 +607,20 @@ fn spawn_receive(set: &mut JoinSet<Result<ResultType, RadarError>>, mut socket: 
 }
 
 async fn send_beacon_requests(
-    beacon_messages: &Vec<(SocketAddr, Vec<&[u8]>)>,
+    beacon_messages: &Vec<BeaconRequests>,
     interface_addresses: &Vec<Ipv4Addr>,
 ) -> io::Result<()> {
     for x in beacon_messages {
-        for beacon_request in &x.1 {
-            if let Err(e) = send_beacon_request(interface_addresses, &x.0, beacon_request).await {
-                log::warn!("Failed to send beacon request to {}: {}", x.0, e);
+        for beacon_request in &x.packets {
+            if let Err(e) = send_beacon_request(
+                interface_addresses,
+                &x.address,
+                beacon_request,
+                x.multicast_ttl,
+            )
+            .await
+            {
+                log::warn!("Failed to send beacon request to {}: {}", x.address, e);
             }
             sleep(BEACON_PACKET_SPACING).await;
         }
@@ -611,6 +633,7 @@ async fn send_beacon_request(
     interface_addresses: &Vec<Ipv4Addr>,
     addr: &SocketAddr,
     msg: &[u8],
+    multicast_ttl: Option<u32>,
 ) -> io::Result<()> {
     if let SocketAddr::V4(addr) = addr {
         if addr.ip().is_multicast() {
@@ -622,7 +645,9 @@ async fn send_beacon_request(
                 match network::create_multicast_send(addr, nic_addr) {
                     Ok(sock) => {
                         sock.set_broadcast(true)?;
-                        sock.set_multicast_ttl_v4(BEACON_MULTICAST_TTL)?;
+                        if let Some(ttl) = multicast_ttl {
+                            sock.set_multicast_ttl_v4(ttl)?;
+                        }
                         match sock.send(msg).await {
                             Ok(_) => {
                                 log::debug!(

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -1333,9 +1333,6 @@ impl SharedControls {
         }
     }
 
-    /// Update the valid values of a list control from a bitmask.
-    /// Set bits indicate which values the radar accepts. Descriptions are
-    /// left as-is (set when the control was created).
     /// Add `value` to a control's set of valid values if it is not already
     /// present, keeping the list sorted. Used to widen a control beyond the
     /// generic default for a brand that supports the extra value — e.g. the
@@ -1352,6 +1349,9 @@ impl SharedControls {
         }
     }
 
+    /// Update the valid values of a list control from a bitmask.
+    /// Set bits indicate which values the radar accepts. Descriptions are
+    /// left as-is (set when the control was created).
     pub fn set_valid_values_bitmask(&self, control_id: &ControlId, mask: u8) {
         if mask == 0 {
             return;

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -1336,6 +1336,22 @@ impl SharedControls {
     /// Update the valid values of a list control from a bitmask.
     /// Set bits indicate which values the radar accepts. Descriptions are
     /// left as-is (set when the control was created).
+    /// Add `value` to a control's set of valid values if it is not already
+    /// present, keeping the list sorted. Used to widen a control beyond the
+    /// generic default for a brand that supports the extra value — e.g. the
+    /// Power control defaults to Standby/Transmit, and Raymarine adds Off.
+    pub(crate) fn add_valid_value(&self, control_id: &ControlId, value: i32) {
+        let mut locked = self.controls.write().unwrap();
+        if let Some(control) = locked.controls.get_mut(control_id) {
+            let mut values = control.item.valid_values.clone().unwrap_or_default();
+            if !values.contains(&value) {
+                values.push(value);
+                values.sort_unstable();
+                control.item.valid_values = Some(values);
+            }
+        }
+    }
+
     pub fn set_valid_values_bitmask(&self, control_id: &ControlId, mask: u8) {
         if mask == 0 {
             return;
@@ -3703,6 +3719,34 @@ mod test {
         assert_eq!(
             controls.get(&ControlId::TargetTrails).unwrap().value,
             Some(3.)
+        );
+    }
+
+    #[test]
+    fn add_valid_value_widens_power_and_is_idempotent() {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let controls = SharedControls::new("nav1234".to_string(), tx, &args, HashMap::new());
+
+        // Power defaults to Standby(1)/Transmit(2); process_client_request
+        // rejects anything outside valid_values, so Off(0) is not accepted.
+        assert_eq!(
+            controls.get(&ControlId::Power).unwrap().item.valid_values,
+            Some(vec![1, 2])
+        );
+
+        controls.add_valid_value(&ControlId::Power, 0);
+        assert_eq!(
+            controls.get(&ControlId::Power).unwrap().item.valid_values,
+            Some(vec![0, 1, 2]),
+            "Off must be added and the list kept sorted"
+        );
+
+        // Adding again is a no-op.
+        controls.add_valid_value(&ControlId::Power, 0);
+        assert_eq!(
+            controls.get(&ControlId::Power).unwrap().item.valid_values,
+            Some(vec![0, 1, 2])
         );
     }
 }

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1946,45 +1946,19 @@ function getUserName() {
   return myr_control_values.userName?.value || "";
 }
 
-function nextValidValue(controlId, currentValue) {
-  const control = getControl(controlId);
-  if (!control) return currentValue;
-
-  // If control has explicit validValues, cycle through those
-  if (control.validValues && control.validValues.length > 0) {
-    const validValues = control.validValues;
-
-    // Find the index of current value in validValues (handle type mismatch by comparing as numbers)
-    const currentIndex = validValues.findIndex(
-      (v) => Number(v) === Number(currentValue)
-    );
-
-    // Cycle to next value in validValues
-    // If current value is not in validValues, start at first valid value
-    const nextIndex =
-      currentIndex < 0 ? 0 : (currentIndex + 1) % validValues.length;
-
-    return validValues[nextIndex];
-  }
-
-  // Otherwise use minValue/maxValue/stepValue
-  const min = control.minValue ?? 0;
-  const max = control.maxValue ?? 1;
-  const step = control.stepValue ?? 1;
-
-  let nextValue = Number(currentValue) + step;
-  if (nextValue > max) {
-    nextValue = min;
-  }
-
-  return nextValue;
-}
+// Power states: 0 = off, 1 = standby, 2 = transmit.
+const POWER_STANDBY = 1;
+const POWER_TRANSMIT = 2;
 
 function togglePower() {
-  const currentValue = myr_control_values.power?.value ?? 0;
-  const nextValue = nextValidValue("power", currentValue);
+  // The power icon is a transmit toggle: transmit <-> standby. It must not
+  // cycle into Off even when the radar advertises Off as a valid value
+  // (Quantum does) — powering a radar down is a deliberate action done via
+  // the API, not something a single click should do by accident.
+  const currentValue = Number(myr_control_values.power?.value ?? 0);
+  const nextValue =
+    currentValue === POWER_TRANSMIT ? POWER_STANDBY : POWER_TRANSMIT;
 
-  // Send the control update
   sendControlToServer("power", { value: nextValue });
 }
 


### PR DESCRIPTION
## What a user sees

A Raymarine radar that hangs off an Axiom MFD (the Axiom acting as the radar's WiFi access point) can be powered up from any other Axiom on the boat's wired RayNet — but mayara, sitting on the same RayNet, could not wake it at all, and with `--allow-wifi` set it could not even discover it. And once awake, the Radar API only let you switch between Standby and Transmit — never fully off.

**Field-validated on the boat from #160:** with this change mayara wakes the radar through the Axiom relay exactly the way a second Axiom does; like an Axiom, it wakes the radar once when asked rather than re-waking it every 20 seconds (so a radar the user powers off from an MFD now stays off); and the API can now power the radar fully off as well as to standby/transmit.

## Root cause

Wire captures from #160 (a Quantum behind an Axiom WiFi AP, a second Axiom on RayNet, mayara on RayNet) showed the wake failing — then, once effective, misbehaving — for several reasons, and also pinned down the power-state command bytes:

1. **Wrong multicast group with `--allow-wifi`.** The flag *swapped* the Raymarine discovery/wake group from the wired `224.0.0.1:5800` to the WiFi `232.1.1.1:5800` instead of adding it, so all beacons and wake packets went to a group nothing on RayNet joins.
2. **TTL 1 makes the wake ineligible for relay.** The Axiom relays wake packets from RayNet onto the radar's WiFi segment, honouring router TTL semantics: an Axiom's wake goes out with IP TTL 10, while mayara's used the Linux default of 1 — link-local only, never relayed.
3. **A single WOL is not a wake.** An Axiom wakes a radar with a burst of 7–10 WOL magic packets ~20 ms apart; a lone multicast datagram to a dozing WiFi radar is routinely lost. mayara sent exactly one per 20 s cycle.
4. **A wake every cycle is a wake the user never asked for.** Once the burst became effective, the locator's periodic beacon cycle re-woke the radar every 20 s. An Axiom sends one burst when "On" is pressed, then stays silent.
5. **No power-off, and the wrong byte for it.** The Power control offered only Standby/Transmit, and the Quantum command path mapped every non-transmit request to standby. The captures confirm the Quantum `SetRadarMode` codes: **standby 0, transmit 1, off 3.**
6. **Commands never reached the radar.** Even once discovered and awake, the radar ignored Standby/Transmit/Off. The wake burst was fixed to carry TTL 10 so the Axiom relays it, but the *command* socket still sent with the OS default TTL of 1, so the Axiom dropped power/transmit/heartbeat frames instead of forwarding them to the radar on WiFi.

## Fix

- Register the wired beacon group unconditionally; `--allow-wifi` now *adds* the WiFi group instead of replacing the wired one.
- Send beacon requests with multicast TTL 10 (scoped to the Raymarine locator) and space consecutive beacon packets 20 ms apart.
- Repeat the WOL magic packet eight times per cycle (matching the observed Axiom burst).
- Send beacon requests only while still hunting (or in `--multiple-radar` mode); once discovered, a radar is woken on demand — a power command precedes its mode frame with the WOL burst, the same sequence an Axiom uses for "On" (and never when powering off).
- Expose Off on the Power control for Quantum radars and send the correct mode code (3).
- Send command traffic (power/controls/heartbeats) with the same relay TTL, so an Axiom forwards it to a WiFi radar — for both the multicast-report and MFD-as-AP unicast topologies.
- Re-apply Transmit once a cold radar reaches Standby, so turning a powered-off Quantum straight to Transmit is a single action (the radar drops the command while it boots for ~25-30 s). Closes #431.

Packet bytes for the wake are unchanged — mayara's WOL and wake literals were already byte-identical to the Axiom's; only group selection, TTL, cadence and triggering differed.

Relates to #160.

## Using the new power control

The radar's power is the `power` control on the Radar API. Values: `0` off, `1` standby, `2` transmit (strings `"off"`/`"standby"`/`"transmit"` are also accepted).

```
# Put the radar to sleep (full power off)
curl -X PUT \
  http://<host>:6502/signalk/v2/api/vessels/self/radars/<radar_id>/controls/power \
  -H 'Content-Type: application/json' \
  -d '{"value": 0}'

# Wake it to standby (1) or start transmitting (2)
curl -X PUT .../radars/<radar_id>/controls/power -d '{"value": 1}'
```

Waking (standby/transmit) fires the WOL burst automatically; power-off does not.

## Tested

- `cargo fmt --check`, `cargo clippy --no-deps --all-targets -- -D warnings` clean.
- `cargo test` — 324 lib tests + 15 websocket integration tests pass.
- Unit tests: default registers only the wired group; `--allow-wifi` registers exactly wired + WiFi; every Raymarine beacon group carries the MFD announce + wake literal once each plus the WOL burst with the Raymarine-scoped TTL; Quantum power mode codes are standby 0 / transmit 1 / off 3; the Power control gains Off (kept sorted, idempotent).
- **On-boat (#160): discovery, wake, control across all power states (0/1/2), and power-off are confirmed working over ~30 tested transitions, on both RayNet and WiFi-direct.** The cold-wake reliability improved markedly after moving the Axiom off a congested WiFi channel; the re-apply-transmit change (off->transmit in one step) awaits an on-boat re-test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Keeps Raymarine discovery working behind an Axiom MFD by always registering the wired RayNet beacon multicast group and adding the WiFi discovery multicast group only when `--allow-wifi` is set.  
- Applies a relay TTL (`RAYMARINE_RELAY_TTL = 10`) to Raymarine locator beacon traffic (per registered locator group), Raymarine command traffic (both multicast TTL and socket TTL), and Raymarine report sockets so frames can be forwarded through the Axiom WiFi AP.  
- Refactors Raymarine locator beacon requests to send an MFD announcement beacon, then the wake literal, then `WOL_WAKE_BURST` WOL magic packets (`WOL_WAKE_BURST + 2` total packets), spacing consecutive request packets by 20ms.  
- Sends WOL wake bursts only when powering to standby/transmit, not when powering off.  
- Limits repeated beacon requests so a radar is not re-woken every cycle after discovery: beacon requests are sent only while still hunting (or before discovery completes) and when in `--multiple-radar` mode.  
- Adds full Quantum radar power-off support by extending the Radar API power control to accept `off`, `standby`, and `transmit`, correcting the Quantum `SetRadarMode` mapping so `off` uses mode code `3`; wake bursts fire only for standby/transmit.  
- Implements “pending transmit” re-application for Quantum by deferring transmit when the radar is off/unknown and re-sending a `SET_TRANSMIT_QUANTUM` command once the radar reports `Standby`; a standby/off request cancels the pending transmit, and standby→transmit does not defer (re-apply happens once at standby).  
- Updates the GUI power toggle to flip only between standby and transmit (using explicit standby/transmit constants), preserving deliberate off behavior via the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->