### PR TITLE
fix(clippy): clean up 79 warnings from clippy 1.97

### DIFF
--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -1187,16 +1187,16 @@ impl FurunoReportReceiver {
                 self.multicast_socket = Some(sock);
                 log::debug!(
                     "{} via {}: listening for spoke data",
-                    &self.common.info.spoke_data_addr,
-                    &self.common.info.nic_addr
+                    self.common.info.spoke_data_addr,
+                    self.common.info.nic_addr
                 );
                 Ok(())
             }
             Err(e) => {
                 log::warn!(
                     "{} via {}: listen multicast failed: {}",
-                    &self.common.info.spoke_data_addr,
-                    &self.common.info.nic_addr,
+                    self.common.info.spoke_data_addr,
+                    self.common.info.nic_addr,
                     e
                 );
                 Err(e)
@@ -1214,16 +1214,16 @@ impl FurunoReportReceiver {
                 self.broadcast_socket = Some(sock);
                 log::debug!(
                     "{} via {}: listening for spoke data",
-                    &DATA_BROADCAST_ADDRESS,
-                    &self.common.info.nic_addr
+                    DATA_BROADCAST_ADDRESS,
+                    self.common.info.nic_addr
                 );
                 Ok(())
             }
             Err(e) => {
                 log::warn!(
                     "{} via {}: listen broadcast failed: {}",
-                    &DATA_BROADCAST_ADDRESS,
-                    &self.common.info.nic_addr,
+                    DATA_BROADCAST_ADDRESS,
+                    self.common.info.nic_addr,
                     e
                 );
                 Err(e)

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -259,16 +259,16 @@ impl GarminReportReceiver {
                 log::debug!(
                     "{}: {} via {}: listening for reports",
                     self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr
+                    self.common.info.report_addr,
+                    self.common.info.nic_addr
                 );
             }
             Err(e) => {
                 log::debug!(
                     "{}: {} via {}: create multicast failed: {}",
                     self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr,
+                    self.common.info.report_addr,
+                    self.common.info.nic_addr,
                     e
                 );
                 return Err(e);
@@ -287,16 +287,16 @@ impl GarminReportReceiver {
                     log::debug!(
                         "{}: {} via {}: listening for data",
                         self.common.key,
-                        &self.common.info.spoke_data_addr,
-                        &self.common.info.nic_addr
+                        self.common.info.spoke_data_addr,
+                        self.common.info.nic_addr
                     );
                 }
                 Err(e) => {
                     log::debug!(
                         "{}: {} via {}: create data multicast failed: {}",
                         self.common.key,
-                        &self.common.info.spoke_data_addr,
-                        &self.common.info.nic_addr,
+                        self.common.info.spoke_data_addr,
+                        self.common.info.nic_addr,
                         e
                     );
                     return Err(e);

--- a/src/lib/brand/koden/protocol.rs
+++ b/src/lib/brand/koden/protocol.rs
@@ -69,7 +69,7 @@ pub(crate) const RADAR_LOST_TIMEOUT_SECS: u64 = 15;
 
 pub(crate) const CONTROL_PREFIX: u8 = b'&'; // 0x26
 pub(crate) const STATUS_PREFIX: u8 = b'#'; // 0x23
-pub(crate) const IMAGE_MARKER: [u8; 4] = [b'{', b'{', b'{', b'{'];
+pub(crate) const IMAGE_MARKER: [u8; 4] = *b"{{{{";
 pub(crate) const PACKET_END: u8 = b'\r'; // 0x0D
 
 // =============================================================================

--- a/src/lib/brand/navico/command.rs
+++ b/src/lib/brand/navico/command.rs
@@ -46,8 +46,8 @@ impl Command {
                 log::debug!(
                     "{} {} via {}: sending commands",
                     self.key,
-                    &self.info.send_command_addr,
-                    &self.info.nic_addr
+                    self.info.send_command_addr,
+                    self.info.nic_addr
                 );
                 self.sock = Some(sock);
 
@@ -57,8 +57,8 @@ impl Command {
                 log::debug!(
                     "{} {} via {}: create multicast failed: {}",
                     self.key,
-                    &self.info.send_command_addr,
-                    &self.info.nic_addr,
+                    self.info.send_command_addr,
+                    self.info.nic_addr,
                     e
                 );
                 Err(RadarError::Io(e))

--- a/src/lib/brand/navico/info.rs
+++ b/src/lib/brand/navico/info.rs
@@ -140,8 +140,8 @@ impl Information {
                 log::debug!(
                     "{} {} via {}: sending info",
                     self.key,
-                    &SOCKET_ADDRESS[index],
-                    &self.nic_addr
+                    SOCKET_ADDRESS[index],
+                    self.nic_addr
                 );
                 self.sock[index] = Some(sock);
                 Ok(())
@@ -150,8 +150,8 @@ impl Information {
                 log::debug!(
                     "{} {} via {}: create multicast failed: {}",
                     self.key,
-                    &SOCKET_ADDRESS[index],
-                    &self.nic_addr,
+                    SOCKET_ADDRESS[index],
+                    self.nic_addr,
                     e
                 );
                 Err(RadarError::Io(e))

--- a/src/lib/brand/navico/info.rs
+++ b/src/lib/brand/navico/info.rs
@@ -174,7 +174,7 @@ impl Information {
             let heading = (heading * HEADING_SCALE / TAU) as u16;
             let epoch = chrono::Utc::now().timestamp_millis().to_le_bytes();
             let packet = HaloHeadingPacket {
-                marker: [b'N', b'K', b'O', b'E'],
+                marker: *b"NKOE",
                 preamble: [0, 1, 0x90, 0x02],
                 counter: self.counter.to_be_bytes(),
                 u01: U01_DEFAULT,
@@ -205,7 +205,7 @@ impl Information {
             let sog = (sog * 100.0) as u16;
             let epoch = chrono::Utc::now().timestamp_millis().to_le_bytes();
             let packet = HaloNavigationPacket {
-                marker: [b'N', b'K', b'O', b'E'],
+                marker: *b"NKOE",
                 preamble: [0, 1, 0x90, 0x02],
                 counter: self.counter.to_be_bytes(),
                 u01: U01_DEFAULT,

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -459,8 +459,8 @@ impl NavicoReportReceiver {
                 log::debug!(
                     "{}: {} via {}: listening for reports",
                     self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr
+                    self.common.info.report_addr,
+                    self.common.info.nic_addr
                 );
                 Ok(())
             }
@@ -468,8 +468,8 @@ impl NavicoReportReceiver {
                 log::debug!(
                     "{}: {} via {}: create multicast failed: {}",
                     self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr,
+                    self.common.info.report_addr,
+                    self.common.info.nic_addr,
                     e
                 );
                 Err(e)
@@ -491,8 +491,8 @@ impl NavicoReportReceiver {
                 log::debug!(
                     "{}: {} via {}: listening for info reports",
                     self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr
+                    self.common.info.report_addr,
+                    self.common.info.nic_addr
                 );
                 Ok(())
             }
@@ -500,8 +500,8 @@ impl NavicoReportReceiver {
                 log::debug!(
                     "{}: {} via {}: create multicast failed: {}",
                     self.common.key,
-                    &self.common.info.report_addr,
-                    &self.common.info.nic_addr,
+                    self.common.info.report_addr,
+                    self.common.info.nic_addr,
                     e
                 );
                 Err(e)
@@ -522,16 +522,16 @@ impl NavicoReportReceiver {
                 self.data_socket = Some(sock);
                 log::debug!(
                     "{} via {}: listening for spoke data",
-                    &self.common.info.spoke_data_addr,
-                    &self.common.info.nic_addr
+                    self.common.info.spoke_data_addr,
+                    self.common.info.nic_addr
                 );
                 Ok(())
             }
             Err(e) => {
                 log::debug!(
                     "{} via {}: create multicast failed: {}",
-                    &self.common.info.spoke_data_addr,
-                    &self.common.info.nic_addr,
+                    self.common.info.spoke_data_addr,
+                    self.common.info.nic_addr,
                     e
                 );
                 Err(e)
@@ -642,7 +642,7 @@ impl NavicoReportReceiver {
 
         let spokes_in_frame = (self.data_buf.len() - FRAME_HEADER_LENGTH) / RADAR_LINE_LENGTH;
 
-        log::trace!("Received UDP frame with {} spokes", &spokes_in_frame);
+        log::trace!("Received UDP frame with {} spokes", spokes_in_frame);
 
         self.common.new_spoke_message();
 
@@ -663,7 +663,7 @@ impl NavicoReportReceiver {
                 self.common
                     .add_spoke(range, angle, heading, self.process_spoke(spoke_slice));
             } else {
-                log::warn!("Invalid spoke: header {:02X?}", &header_slice);
+                log::warn!("Invalid spoke: header {:02X?}", header_slice);
             }
 
             offset += RADAR_LINE_LENGTH;
@@ -1344,7 +1344,7 @@ impl NavicoReportReceiver {
                     Self::validate_br24_header(&header)
                 }
                 Err(e) => {
-                    log::warn!("Illegible spoke: {} header {:02X?}", e, &header_slice);
+                    log::warn!("Illegible spoke: {} header {:02X?}", e, header_slice);
                     None
                 }
             },
@@ -1355,7 +1355,7 @@ impl NavicoReportReceiver {
                     Self::validate_4g_header(&header)
                 }
                 Err(e) => {
-                    log::warn!("Illegible spoke: {} header {:02X?}", e, &header_slice);
+                    log::warn!("Illegible spoke: {} header {:02X?}", e, header_slice);
                     None
                 }
             },

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -65,8 +65,8 @@ impl Command {
                 log::debug!(
                     "{} {} via {}: sending commands",
                     self.key,
-                    &self.info.send_command_addr,
-                    &self.info.nic_addr
+                    self.info.send_command_addr,
+                    self.info.nic_addr
                 );
                 self.sock = Some(Arc::new(sock));
 
@@ -76,8 +76,8 @@ impl Command {
                 log::debug!(
                     "{} {} via {}: create multicast failed: {}",
                     self.key,
-                    &self.info.send_command_addr,
-                    &self.info.nic_addr,
+                    self.info.send_command_addr,
+                    self.info.nic_addr,
                     e
                 );
                 Err(RadarError::Io(e))

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -338,8 +338,8 @@ impl RaymarineReportReceiver {
                         log::debug!(
                             "{}: {} via {}: unicast report socket failed: {}",
                             self.common.key,
-                            &self.common.info.report_addr,
-                            &self.common.info.nic_addr,
+                            self.common.info.report_addr,
+                            self.common.info.nic_addr,
                             e
                         );
                         return;
@@ -351,8 +351,8 @@ impl RaymarineReportReceiver {
             log::debug!(
                 "{}: {} via {}: listening for unicast reports",
                 self.common.key,
-                &self.common.info.report_addr,
-                &self.common.info.nic_addr
+                self.common.info.report_addr,
+                self.common.info.nic_addr
             );
         } else {
             // Multicast mode
@@ -366,8 +366,8 @@ impl RaymarineReportReceiver {
                     log::debug!(
                         "{}: {} via {}: listening for reports",
                         self.common.key,
-                        &self.common.info.report_addr,
-                        &self.common.info.nic_addr
+                        self.common.info.report_addr,
+                        self.common.info.nic_addr
                     );
                 }
                 Err(e) => {
@@ -375,8 +375,8 @@ impl RaymarineReportReceiver {
                     log::debug!(
                         "{}: {} via {}: create UDP listen socket failed: {}",
                         self.common.key,
-                        &self.common.info.report_addr,
-                        &self.common.info.nic_addr,
+                        self.common.info.report_addr,
+                        self.common.info.nic_addr,
                         e
                     );
                 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -154,7 +154,7 @@ impl Persistence {
 
         panic!(
             "Cannot check file modification of '{}' on this platform",
-            &self.path.display()
+            self.path.display()
         );
     }
 
@@ -163,7 +163,7 @@ impl Persistence {
             Err(e) => {
                 warn!(
                     "no config '{}' yet; starting fresh: {}",
-                    &self.path.display(),
+                    self.path.display(),
                     e
                 );
 
@@ -178,12 +178,12 @@ impl Persistence {
         match serde_json::from_reader(reader) {
             Ok(u) => {
                 self.config = u;
-                info!("Loaded config from '{}'", &self.path.display());
+                info!("Loaded config from '{}'", self.path.display());
             }
             Err(e) => {
                 warn!(
                     "Config '{}' corrupted; starting fresh: {}",
-                    &self.path.display(),
+                    self.path.display(),
                     e
                 );
             }
@@ -201,14 +201,14 @@ impl Persistence {
         writeln!(writer)?;
         writer.flush()?;
 
-        info!("Written config file '{}'", &self.path.display());
+        info!("Written config file '{}'", self.path.display());
         self.timestamp = self.get_file_time();
         Ok(())
     }
 
     fn save(&mut self) {
         if let Err(e) = self.saver() {
-            warn!("cannot store config '{}': {}", &self.path.display(), e);
+            warn!("cannot store config '{}': {}", self.path.display(), e);
         }
     }
 

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -309,7 +309,7 @@ impl Locator {
     ) {
         let mut interface_api = interface_state.interface_api.clone();
 
-        for (_, radar_interface_api) in interface_api.interfaces.iter_mut() {
+        for radar_interface_api in interface_api.interfaces.values_mut() {
             if let (Some(listeners), Some(ip)) =
                 (&mut radar_interface_api.listeners, &radar_interface_api.ip)
             {

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -216,9 +216,9 @@ impl Locator {
                             Ok(ResultType::Locator(mut locator_socket, addr, buf)) => {
                                 log::trace!(
                                     "{} via {} -> {:02X?}",
-                                    &addr,
-                                    &locator_socket.nic_addr,
-                                    &buf
+                                    addr,
+                                    locator_socket.nic_addr,
+                                    buf
                                 );
 
                                 let _ = locator_socket.state.process(
@@ -391,13 +391,13 @@ impl Locator {
                                             log::info!(
                                                 "Searching for radars on interface '{}' address {} (added/modified)",
                                                 itf.name,
-                                                &nic_ip,
+                                                nic_ip,
                                             );
                                         } else {
                                             log::info!(
                                                 "Searching for radars on interface '{}' address {}",
                                                 itf.name,
-                                                &nic_ip,
+                                                nic_ip,
                                             );
                                         }
                                         interface_state.active_nic_addresses.push(nic_ip);
@@ -459,7 +459,7 @@ impl Locator {
                                         } else {
                                             log::trace!(
                                                 "Ignoring IPv6 address {:?}",
-                                                &radar_listen_address.address
+                                                radar_listen_address.address
                                             );
                                         }
                                     }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -675,7 +675,7 @@ impl RadarInfo {
 
 impl Display for RadarInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Radar {} brand {}", &self.key, &self.brand)?;
+        write!(f, "Radar {} brand {}", self.key, self.brand)?;
         if let Some(which) = &self.dual {
             write!(f, " {}", which)?;
         }
@@ -685,11 +685,11 @@ impl Display for RadarInfo {
         write!(
             f,
             " at {} via {} data {} report {} send {}",
-            &self.addr.ip(),
-            &self.nic_addr,
-            &self.spoke_data_addr,
-            &self.report_addr,
-            &self.send_command_addr
+            self.addr.ip(),
+            self.nic_addr,
+            self.spoke_data_addr,
+            self.report_addr,
+            self.send_command_addr
         )
     }
 }
@@ -746,7 +746,7 @@ impl SharedRadars {
 
             log::info!(
                 "Found radar: key '{}' name '{}' with {} ranges",
-                &new_info.key,
+                new_info.key,
                 new_info.controls.user_name(),
                 new_info.ranges.len()
             );

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -867,7 +867,7 @@ impl SharedRadars {
 
     pub fn is_radar_active_on_nic(&self, brand: &Brand, ip: &Ipv4Addr) -> bool {
         let radars = self.radars.read().unwrap();
-        for (_, info) in radars.info.iter() {
+        for info in radars.info.values() {
             log::trace!(
                 "is_active_radar: brand {}/{} ip {}/{}",
                 info.brand,
@@ -884,7 +884,7 @@ impl SharedRadars {
 
     pub fn is_radar_active_by_addr(&self, brand: &Brand, ip: &SocketAddrV4) -> bool {
         let radars = self.radars.read().unwrap();
-        for (_, info) in radars.info.iter() {
+        for info in radars.info.values() {
             log::trace!(
                 "is_active_radar: brand {}/{} ip {}/{}",
                 info.brand,

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -1207,7 +1207,7 @@ impl SharedControls {
 
         log::debug!(
             "Sending reply {:?} to requesting JSON client",
-            &control_value,
+            control_value,
         );
 
         reply_tx


### PR DESCRIPTION
## What developers see

After bumping the Rust toolchain to 1.97, `cargo clippy --no-deps --all-targets -- -D warnings` (which CI and the pre-commit hook both enforce) failed with 79 new errors, blocking every commit that touches Rust code. This PR restores a warning-free tree.

## Technical detail

Three lints new-in-1.97, all mechanically auto-fixed via `cargo clippy --fix` and split into one commit per lint for easy review:

| Commit | Lint | Sites | Fix |
|---|---|---|---|
| `af4f653` | `clippy::useless_borrows_in_formatting` | 73 | Drop redundant `&` in `write!`/`info!`/`println!` args |
| `e80c7f1` | `clippy::for_kv_map` | 3 | `for (_, v) in map.iter()` → `for v in map.values()` |
| `af52246` | `clippy::byte_char_slices` | 3 | `&[b'a', b'b']` → `b"ab"` |

No behavioural change. Full test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates Rust code to resolve 79 Clippy warnings introduced by Rust 1.97:

- Removes redundant references in formatting and logging macros across 73 sites.
- Uses `.values()`/`.values_mut()` when map keys are unused at 3 sites.
- Replaces byte-character slices with byte-string literals at 3 sites.

Changes are mechanical, preserve behavior, and the full test suite passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->