### PR TITLE
feat(radar): show powered-off radars as off when they go silent

### DIFF
--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -310,6 +310,12 @@ impl FurunoReportReceiver {
                     match r {
                         Ok(len) => {
                             if len > 2 {
+                                // The report stream is shared by both ranges of a
+                                // dual-range radar, so a report keeps both alive.
+                                self.common.info.mark_input();
+                                if let Some(ref cb) = self.common_b {
+                                    cb.info.mark_input();
+                                }
                                 if let Err(e) = self.process_report(&line) {
                                     log::error!("{}: {}", self.common.key, e);
                                 } else if !first_report_received {

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -333,6 +333,7 @@ impl GarminReportReceiver {
                 } => {
                     match r {
                         Ok((_len, _addr)) => {
+                            self.common.info.mark_input();
                             if let Err(e) = self.process_report(&report_buf) {
                                 log::error!("{}: {}", self.common.key, e);
                             }

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -575,6 +575,7 @@ impl NavicoReportReceiver {
                 r = self.report_socket.as_mut().unwrap().recv_buf_from(&mut self.report_buf)  => {
                     match r {
                         Ok((_len, _addr)) => {
+                            self.common.info.mark_input();
                             if let Err(e) = self.process_report().await {
                                 log::error!("{}: {}", self.common.key, e);
                             }

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -419,6 +419,7 @@ impl RaymarineReportReceiver {
                 r = self.report_socket.as_mut().unwrap().recv_buf_from(&mut buf)  => {
                     match r {
                         Ok((_len, _addr)) => {
+                            self.common.info.mark_input();
                             if buf.len() == buf.capacity() {
                                 let old = buf.capacity();
                                 buf.reserve(1024);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -640,6 +640,29 @@ pub async fn start_session(
         },
     ));
 
+    // Decay a radar's power state to Off once it stops sending (issue #432): a
+    // powered-off radar goes silent, so without this its GUI icon would hold the
+    // last state it reported (standby/transmit) forever.
+    let watchdog_radars = radars.clone();
+    subsystem.start(SubsystemBuilder::new(
+        "Radar Watchdog",
+        async move |subsys: &mut SubsystemHandle| {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+            loop {
+                tokio::select! { biased;
+                    _ = subsys.on_shutdown_requested() => {
+                        log::debug!("Radar watchdog shutdown");
+                        break;
+                    },
+                    _ = interval.tick() => {
+                        watchdog_radars.mark_silent_radars_off();
+                    }
+                }
+            }
+            Ok::<(), miette::Report>(())
+        },
+    ));
+
     let locator = Locator::new(args.clone(), radars.clone());
 
     let (tx_ip_change, _rx_ip_change) = broadcast::channel(1);

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -13,8 +13,8 @@ use std::{
     fmt::{self, Display, Write},
     net::{Ipv4Addr, SocketAddrV4},
     sync::{
-        Arc, RwLock,
-        atomic::{AtomicBool, Ordering},
+        Arc, LazyLock, RwLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
 };
 use thiserror::Error;
@@ -311,6 +311,15 @@ impl fmt::Display for GeoPosition {
     }
 }
 
+/// Monotonic epoch for the cheap `AtomicU64` millisecond timestamps shared
+/// across `RadarInfo` clones (see [`RadarInfo::last_input`]). `Instant` is not
+/// itself storable in an atomic, so timestamps are milliseconds since this base.
+static RADAR_EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+fn now_millis() -> u64 {
+    RADAR_EPOCH.elapsed().as_millis() as u64
+}
+
 #[derive(Clone, Debug)]
 pub struct RadarInfo {
     key: String,
@@ -367,6 +376,14 @@ pub struct RadarInfo {
     /// load/store contract stays narrow; callers use `is_idle()` and
     /// `wake_up()` below.
     is_idle: Arc<AtomicBool>,
+
+    /// Milliseconds since [`RADAR_EPOCH`] of the last packet received from this
+    /// radar on its report socket. A powered-off radar stops sending, so the
+    /// central watchdog (`mark_silent_radars_off`) decays its power state to
+    /// `Off` after [`SharedRadars::RADAR_SILENCE_TIMEOUT`]. Shared via `Arc` so
+    /// brand receivers (which hold a clone) and the watchdog (reading the map)
+    /// observe the same value. Updated via `mark_input`, read via `input_silence`.
+    last_input: Arc<AtomicU64>,
 }
 
 impl RadarInfo {
@@ -444,6 +461,9 @@ impl RadarInfo {
             // frames; the data_loop's periodic re-check will flip it once
             // power and subscriber count have settled.
             is_idle: Arc::new(AtomicBool::new(false)),
+            // Seed with "now" so a freshly discovered radar isn't immediately
+            // considered silent before its first report arrives.
+            last_input: Arc::new(AtomicU64::new(now_millis())),
         };
 
         log::trace!("Created RadarInfo {:?}", info);
@@ -480,6 +500,18 @@ impl RadarInfo {
     /// periodic refresh; external callers should prefer `wake_up()`.
     pub(crate) fn set_idle(&self, idle: bool) {
         self.is_idle.store(idle, Ordering::Relaxed);
+    }
+
+    /// Record that a packet was just received from this radar. Brand report
+    /// receivers call this on every report-socket receive; the watchdog reads
+    /// [`input_silence`](Self::input_silence) to detect a radar gone silent.
+    pub(crate) fn mark_input(&self) {
+        self.last_input.store(now_millis(), Ordering::Relaxed);
+    }
+
+    /// How long it has been since the last packet was received from this radar.
+    pub(crate) fn input_silence(&self) -> Duration {
+        Duration::from_millis(now_millis().saturating_sub(self.last_input.load(Ordering::Relaxed)))
     }
 
     /// Recompute the idle flag from this radar's live power state and spoke
@@ -820,6 +852,38 @@ impl SharedRadars {
             > 0
     }
 
+    /// A radar is considered powered off once no packet has been received from
+    /// it for this long. A standby radar still emits periodic status reports, so
+    /// only a genuinely silent (powered-off or disconnected) radar decays to
+    /// [`Power::Off`]. See issue #432.
+    pub(crate) const RADAR_SILENCE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Decay the power state of any radar gone silent to [`Power::Off`], so the
+    /// GUI reflects a powered-off radar instead of holding its last reported
+    /// state. Called on a fixed cadence by the radar watchdog. The next report
+    /// from a radar that comes back overwrites this with its real state.
+    pub(crate) fn mark_silent_radars_off(&self) {
+        let radars = self.radars.read().unwrap();
+        for info in radars.info.values() {
+            let current = info
+                .controls
+                .get(&ControlId::Power)
+                .and_then(|c| c.value)
+                .map(|v| v as i32);
+            if !should_power_off(info.input_silence(), current) {
+                continue;
+            }
+            log::debug!(
+                "{}: no data for {}s, marking powered off",
+                info.key,
+                info.input_silence().as_secs()
+            );
+            let _ = info
+                .controls
+                .set_value(&ControlId::Power, Value::from(Power::Off as i32));
+        }
+    }
+
     ///
     /// Return every radar that has been discovered, including those that have
     /// not yet reported their ranges. Use this where a radar should surface as
@@ -1098,6 +1162,16 @@ impl Power {
 pub(crate) fn should_idle(power: Option<i32>, spoke_receiver_count: usize) -> bool {
     let standby = power.map(|p| p == Power::Standby as i32).unwrap_or(false);
     standby && spoke_receiver_count == 0
+}
+
+/// Decide whether a radar that has been silent for `silence` should have its
+/// power state forced to [`Power::Off`]. True once the silence reaches
+/// [`SharedRadars::RADAR_SILENCE_TIMEOUT`] and the radar is not already Off.
+/// `current_power` is `None` when the Power control has never been reported —
+/// still forced Off, since a radar that has said nothing at all for that long
+/// is powered off from the operator's point of view.
+fn should_power_off(silence: Duration, current_power: Option<i32>) -> bool {
+    silence >= SharedRadars::RADAR_SILENCE_TIMEOUT && current_power != Some(Power::Off as i32)
 }
 
 // The actual values are not arbitrary: these are the exact values as reported
@@ -2249,6 +2323,40 @@ mod tests {
         // know its state. Default to processing frames so we never blank
         // the PPI for a viewer that connects very early in startup.
         assert!(!should_idle(None, 0));
+    }
+
+    #[test]
+    fn should_power_off_no_before_timeout() {
+        let recent = SharedRadars::RADAR_SILENCE_TIMEOUT - Duration::from_secs(1);
+        assert!(!should_power_off(recent, Some(Power::Transmit as i32)));
+        assert!(!should_power_off(recent, Some(Power::Standby as i32)));
+    }
+
+    #[test]
+    fn should_power_off_yes_from_transmit_and_standby_after_timeout() {
+        // A silent radar decays to Off from any live state, including Standby.
+        assert!(should_power_off(
+            SharedRadars::RADAR_SILENCE_TIMEOUT,
+            Some(Power::Transmit as i32)
+        ));
+        assert!(should_power_off(
+            SharedRadars::RADAR_SILENCE_TIMEOUT,
+            Some(Power::Standby as i32)
+        ));
+    }
+
+    #[test]
+    fn should_power_off_no_when_already_off() {
+        assert!(!should_power_off(
+            SharedRadars::RADAR_SILENCE_TIMEOUT * 10,
+            Some(Power::Off as i32)
+        ));
+    }
+
+    #[test]
+    fn should_power_off_yes_when_power_never_reported() {
+        // A radar that has said nothing at all for the whole timeout is off.
+        assert!(should_power_off(SharedRadars::RADAR_SILENCE_TIMEOUT, None));
     }
 
     mod test_helpers {


### PR DESCRIPTION
When a radar is powered fully off, the GUI power icon used to keep showing its last state (amber/standby or green/transmit) forever — even across a page refresh — because a powered-off radar stops sending reports and mayara held the last value it saw. Now a radar that has gone silent is shown as off (red), and turns amber/green again as soon as it comes back.

Verified on **Navico**. **Garmin still needs on-water testing** — its report cadence in Standby is unconfirmed, so a genuinely silent Garmin standby could read as off.

Closes #432.

## Approach

This is the cross-brand status/staleness model from #432, not a per-brand fix:

- Each radar carries a shared last-input timestamp, bumped whenever its **report socket** receives a packet. Reports are the reliable heartbeat — a standby radar still sends periodic status, a powered-off one sends nothing. Hooked into Navico, Furuno (both dual-range partners), Raymarine, and Garmin. Koden is intentionally excluded: its broadcast recv socket isn't a trustworthy per-radar liveness signal.
- A central **watchdog** subsystem runs every 5s and decays any radar silent for ≥30s to `Power::Off`, pushing the change to the GUI/Signal K exactly like a real report. The decay applies from any live state, including Standby.

The 30s threshold assumes a standby radar reports at least that often (true for Navico/Raymarine/Furuno).

## Test plan

- [x] Unit tests for the `should_power_off` decision (before timeout, Standby→Off and Transmit→Off after timeout, already-off no-op, never-reported→Off)
- [x] Verified on Navico hardware (powered-off radar now shows red)

**Follow-up before release:** confirm Garmin standby report cadence on real hardware so a silent standby Garmin isn't misreported as off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)