### PR TITLE
chore(release): 3.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
Version bump to 3.7.0 for release.

Includes since 3.6.0: powered-off radar state, Navico Doppler palette + trail colour fixes, radar name cleanup, empty-serial keying, Windows locator resilience, ARPA CPU perf, and the openssl build cleanup.