### PR TITLE
fix(docker): add cmake required by libz-sys zlib-ng build 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.94-alpine AS builder
 # `curl` is needed at build time by utoipa-swagger-ui's build.rs to fetch
 # the Swagger UI bundle; without it the build fails with `curl command not
 # found`. `perl` is required by openssl-sys.
-RUN apk add --no-cache build-base curl perl
+RUN apk add --no-cache build-base curl perl cmake
 
 WORKDIR /usr/src/mayara-server
 


### PR DESCRIPTION
When building the Docker image, cmake seems to be missing from rust:1.94-alpine arm64 image. 
Install it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds CMake to the Docker builder image’s Alpine packages, ensuring Rust ARM64 builds have the required tool available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->