### PR TITLE
ci(changelog): survive rapid merges without orphaning duplicate PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [ "main" ]
 
+# Queue rather than cancel: a cancelled run can die between creating the
+# changelog PR and merging it, orphaning an open PR. Queued runs check out
+# current main, so a superseded run just sees an empty diff and exits.
 concurrency:
   group: changelog-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   changelog:
@@ -24,6 +27,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
       with:
+        # Regenerate against current main, not the triggering commit, so a
+        # queued run behind a rapid merge sequence doesn't recreate entries
+        # an earlier run already merged.
+        ref: main
         fetch-depth: 0
 
     - name: Generate changelog
@@ -47,10 +54,16 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add CHANGELOG.md
         if ! git diff --staged --quiet; then
-          BRANCH="docs-changelog-main-${{ github.run_id }}-${{ github.run_attempt }}"
+          # Fixed branch name keeps runs idempotent: if a previous run was
+          # interrupted after opening its PR, this run force-pushes the same
+          # branch and merges the existing PR instead of opening a duplicate.
+          BRANCH="docs-changelog-main"
           git switch -C "$BRANCH"
           git commit -m "docs(changelog): update CHANGELOG.md"
-          git push --set-upstream origin "$BRANCH"
-          PR_URL="$(gh pr create --title "docs(changelog): update CHANGELOG.md" --body "Auto-generated changelog update after merge to main." --base main --head "$BRANCH")"
+          git push --force --set-upstream origin "$BRANCH"
+          PR_URL="$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url')"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$(gh pr create --title "docs(changelog): update CHANGELOG.md" --body "Auto-generated changelog update after merge to main." --base main --head "$BRANCH")"
+          fi
           gh pr merge "$PR_URL" --squash --delete-branch --auto || gh pr merge "$PR_URL" --squash --delete-branch
         fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -61,7 +61,7 @@ jobs:
           git switch -C "$BRANCH"
           git commit -m "docs(changelog): update CHANGELOG.md"
           git push --force --set-upstream origin "$BRANCH"
-          PR_URL="$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url')"
+          PR_URL="$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url')"
           if [ -z "$PR_URL" ]; then
             PR_URL="$(gh pr create --title "docs(changelog): update CHANGELOG.md" --body "Auto-generated changelog update after merge to main." --base main --head "$BRANCH")"
           fi


### PR DESCRIPTION
When two PRs merge to main in quick succession, the changelog automation can leave behind an orphaned duplicate changelog PR that never merges and lingers open with no checks (most recently #458, duplicated by the merged #459).

Root cause: the workflow's concurrency group uses `cancel-in-progress: true`, so a second merge can cancel the first run in the window after it has created its changelog PR but before it merges it.

Changes:

- Queue concurrent runs (`cancel-in-progress: false`) instead of cancelling, so a run is never killed between side effects.
- Check out current `main` rather than the triggering commit, so a queued run sees the previously merged entry and exits on an empty diff.
- Use a fixed `docs-changelog-main` branch with force-push and reuse an existing open PR instead of always creating a new one, making runs idempotent and self-healing even if one is interrupted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates changelog automation to prevent duplicate PRs during rapid merges by:

- Queuing workflow runs instead of cancelling in-progress runs.
- Regenerating from the latest `main` branch for queued runs.
- Reusing the `docs-changelog-main` branch with force-push updates.
- Reusing and merging an existing open changelog PR, making the workflow idempotent and self-healing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->