### PR TITLE
feat(gui): side-by-side view for dual-range radars

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -42,6 +42,20 @@ mayara-server --openapi
 | DELETE | `/signalk/v2/api/vessels/self/radars/{id}/targets/{tid}`     | Delete tracked target                              |
 | GET    | `/signalk/v2/api/vessels/self/radars/resources/openapi.json` | OpenAPI specification                              |
 
+#### Dual-range radars
+
+A dual-range antenna (Furuno NXT, Navico 4G/HALO) appears in the radar list as
+two entries. Two optional fields on each entry identify that pairing:
+
+| Field       | Description                                                              |
+| ----------- | ------------------------------------------------------------------------ |
+| `dual`      | Which range of the antenna this entry serves — `"A"` or `"B"`             |
+| `dualGroup` | Shared key identifying the physical antenna; equal for both entries       |
+
+Both are omitted for single-range radars, so their absence means "not dual
+range" rather than "unknown". They are mayara extensions to the Signal K Radar
+API, listed as such in the API-parity allowlist.
+
 ### WebSocket Streams
 
 | Endpoint                                          | Description                                    |

--- a/docs/furuno-setup.md
+++ b/docs/furuno-setup.md
@@ -82,5 +82,16 @@ Unrecognized part codes still work with default capabilities. Please report the 
 **FAR shows "Unknown" model:**
 The part code is not in the lookup table. The radar will work with default capabilities. Report the part code from the log output so it can be added.
 
+**Controls stop working / radar flips between picture and OFF:**
+Furuno radars keep only **one control session per client IP address**. A second
+Mayara instance on the same machine (for example a containerized instance with
+host networking next to a development instance) fights the first one for that
+single slot: the radar serves each new login briefly and then closes it, both
+instances reconnect forever, and neither can hold the session. Spoke data is
+unaffected (it arrives via multicast), so the picture keeps painting while
+controls fail. Run only one Mayara instance per host when a Furuno radar is in
+use. Clients on other machines (TimeZero, MFDs) have their own IP and do not
+conflict.
+
 **Capturing traffic:**
 - For packet capture instructions used in bug reports, see [Capturing Radar Traffic](./capturing-traffic.md).

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -207,6 +207,17 @@ struct RadarApiV3 {
     /// path but they have no effect on the recorded data stream.
     #[schema(example = false)]
     replay: bool,
+    /// Which range of a dual-range antenna this radar serves ("A", "B", ...).
+    /// Absent for single-range radars.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "A")]
+    dual: Option<String>,
+    /// Group id shared by all ranges of one dual-range antenna. Clients can
+    /// pair radars carrying the same value into a combined side-by-side view.
+    /// Absent for single-range radars.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "nav2452")]
+    dual_group: Option<String>,
 }
 
 impl From<&RadarInfo> for RadarApiV3 {
@@ -217,6 +228,8 @@ impl From<&RadarInfo> for RadarApiV3 {
             model: info.controls.model_name(),
             radar_ip_address: *info.addr.ip(),
             replay: info.replay(),
+            dual: info.dual.clone(),
+            dual_group: info.dual.is_some().then(|| info.base_key().to_string()),
         }
     }
 }
@@ -1632,6 +1645,20 @@ mod tests {
             model: None,
             radar_ip_address: Ipv4Addr::new(10, 56, 0, 24),
             replay: false,
+            dual: None,
+            dual_group: None,
+        }
+    }
+
+    fn radar_api(dual: Option<&str>, dual_group: Option<&str>) -> RadarApiV3 {
+        RadarApiV3 {
+            name: "4G A".to_string(),
+            brand: "Navico".to_string(),
+            model: Some("4G".to_string()),
+            radar_ip_address: Ipv4Addr::new(10, 0, 0, 1),
+            replay: false,
+            dual: dual.map(String::from),
+            dual_group: dual_group.map(String::from),
         }
     }
 
@@ -1655,5 +1682,19 @@ mod tests {
         let a = json.find("nav1034A").expect("range A listed");
         let b = json.find("nav1034B").expect("range B listed");
         assert!(a < b, "radar ids must be serialised in order: {}", json);
+    }
+
+    #[test]
+    fn radar_api_serializes_dual_group_in_camel_case() {
+        let json = serde_json::to_value(radar_api(Some("A"), Some("nav2452"))).unwrap();
+        assert_eq!(json["dual"], "A");
+        assert_eq!(json["dualGroup"], "nav2452");
+    }
+
+    #[test]
+    fn radar_api_omits_dual_fields_for_single_range_radars() {
+        let json = serde_json::to_value(radar_api(None, None)).unwrap();
+        assert!(json.get("dual").is_none());
+        assert!(json.get("dualGroup").is_none());
     }
 }

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -41,6 +41,17 @@ const CONTROL_KEEPALIVE_IDLE: Duration = Duration::from_secs(30);
 const CONTROL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const CONTROL_KEEPALIVE_RETRIES: u32 = 3;
 
+/// Reconnect backoff after the radar drops the control session. Every login
+/// consumes a session slot in the radar's firmware; hammering relogins at a
+/// fixed short interval can exhaust the slot table and lock ALL clients out
+/// until the radar garbage-collects (observed on DRS4D-NXT: churn every ~6 s
+/// kept the table full indefinitely). Back off exponentially and reset only
+/// after a connection has proven stable.
+const RECONNECT_BACKOFF_MIN: Duration = Duration::from_secs(1);
+const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
+/// A session that survived this long counts as stable: reset the backoff.
+const RECONNECT_STABLE_AFTER: Duration = Duration::from_secs(60);
+
 /// Furuno wire-format decoding mode. When Target Analyzer is active on NXT
 /// radars, each echo byte encodes `[dopplerClass:2 | intensity:4 | 00:2]`
 /// rather than a plain intensity in 0..PIXEL_VALUES. The report receiver
@@ -427,6 +438,7 @@ impl FurunoReportReceiver {
     }
 
     pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
+        let mut backoff = RECONNECT_BACKOFF_MIN;
         loop {
             // Each time we start the loop, there is no stream
             // and none of the data sockets are open.
@@ -440,14 +452,31 @@ impl FurunoReportReceiver {
                 log::warn!("{}: Failed to login to radar: {}", self.common.key, e);
             } else if let Err(e) = self.start_command_stream().await {
                 log::warn!("{}: Failed to start command stream: {}", self.common.key, e);
-            } else if let Err(RadarError::Shutdown) = self.data_loop(subsys).await {
-                return Ok(());
+            } else {
+                let started = Instant::now();
+                match self.data_loop(subsys).await {
+                    Err(RadarError::Shutdown) => return Ok(()),
+                    Err(e) => {
+                        log::warn!(
+                            "{}: Radar control session ended after {:?}: {}; reconnecting in {:?}",
+                            self.common.key,
+                            started.elapsed(),
+                            e,
+                            backoff
+                        );
+                    }
+                    Ok(()) => {}
+                }
+                if started.elapsed() >= RECONNECT_STABLE_AFTER {
+                    backoff = RECONNECT_BACKOFF_MIN;
+                }
             }
 
             tokio::select! {
                 _ = subsys.on_shutdown_requested() => return Ok(()),
-                _ = sleep(Duration::from_millis(1000)) => {}
+                _ = sleep(backoff) => {}
             }
+            backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
         }
     }
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -52,11 +52,8 @@ const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// A session that survived this long counts as stable: reset the backoff.
 const RECONNECT_STABLE_AFTER: Duration = Duration::from_secs(60);
 
-/// How the reconnect delay evolves after a control session ends.
-///
 /// Split out from the connection loop so the policy can be exercised without a
-/// radar: the loop supplies real elapsed times and sleeps, this decides what
-/// the next delay and short-lived-session count should be.
+/// radar: the loop supplies real elapsed times and sleeps.
 fn next_reconnect_backoff(
     current: Duration,
     session_lasted: Duration,
@@ -525,16 +522,18 @@ impl FurunoReportReceiver {
                 }
             }
 
+            // A setup failure (socket, login or command stream) never reached
+            // data_loop, so nothing escalated the backoff above. Treat it as a
+            // zero-length session — otherwise a radar refusing logins would be
+            // retried every second forever.
+            if !reached_data_loop {
+                (backoff, short_lived_sessions) =
+                    next_reconnect_backoff(backoff, Duration::ZERO, short_lived_sessions);
+            }
+
             tokio::select! {
                 _ = subsys.on_shutdown_requested() => return Ok(()),
                 _ = sleep(backoff) => {}
-            }
-            // A session that never reached data_loop (socket, login or command
-            // stream failed) has not updated the backoff above, so escalate
-            // here — otherwise a radar refusing logins would be retried every
-            // second forever.
-            if !reached_data_loop {
-                backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
             }
         }
     }
@@ -2187,6 +2186,26 @@ mod tests {
         let short = Duration::from_secs(1);
         let (capped, _) = next_reconnect_backoff(RECONNECT_BACKOFF_MAX, short, 9);
         assert_eq!(capped, RECONNECT_BACKOFF_MAX);
+    }
+
+    /// A radar that refuses the login, or whose sockets will not open, never
+    /// reaches the data loop. That path must still back off — retrying a
+    /// refusing radar every second is exactly the churn that exhausts the
+    /// firmware's session slots.
+    #[test]
+    fn reconnect_backoff_escalates_when_setup_never_reaches_the_data_loop() {
+        let mut backoff = RECONNECT_BACKOFF_MIN;
+        let mut count = 0;
+        for expected in [2u64, 4, 8, 16] {
+            // Duration::ZERO is how the loop reports "no session happened".
+            (backoff, count) = next_reconnect_backoff(backoff, Duration::ZERO, count);
+            assert_eq!(backoff, Duration::from_secs(expected));
+        }
+        // And it is still bounded.
+        for _ in 0..10 {
+            (backoff, count) = next_reconnect_backoff(backoff, Duration::ZERO, count);
+        }
+        assert_eq!(backoff, RECONNECT_BACKOFF_MAX);
     }
 
     /// Once a session has proven stable the next blip should reconnect

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -953,46 +953,47 @@ impl FurunoReportReceiver {
                     2.0 // Rain
                 };
 
-                let drid = self.extract_drid(&command_id, &numbers);
-                let range_idx = if drid == 1 && self.common_b.is_some() {
-                    1
+                // Target Analyzer is shared between the ranges of a dual-range
+                // antenna: the firmware mirrors the state, and the radar only
+                // reports it for the range the controlling client addressed.
+                // Apply the report to both ranges so Range B's emission gate
+                // lifts even when the confirmation arrives as Range A.
+                let range_indices: &[u8] = if self.common_b.is_some() {
+                    &[0, 1]
                 } else {
-                    0
+                    &[0]
                 };
-                let old_mode = self.doppler_wire_mode_for(range_idx);
-                self.common_for_range(drid)
-                    .set_value(&ControlId::Doppler, value);
-                let new_mode = self.doppler_wire_mode_for(range_idx);
-                if old_mode != new_mode {
-                    let low_power = self.model.is_low_power();
-                    let legend = if range_idx == 1 {
-                        self.common_b.as_ref().unwrap().info.get_legend()
-                    } else {
-                        self.common.info.get_legend()
-                    };
-                    self.wire_to_legend[range_idx] =
-                        Self::wire_to_legend(&legend, new_mode, low_power);
+                for &range_idx in range_indices {
+                    let old_mode = self.doppler_wire_mode_for(range_idx as usize);
+                    self.common_for_range(range_idx)
+                        .set_value(&ControlId::Doppler, value);
+                    let new_mode = self.doppler_wire_mode_for(range_idx as usize);
                     let key = if range_idx == 1 {
                         &self.common_b.as_ref().unwrap().key
                     } else {
                         &self.common.key
                     };
-                    log::debug!("{}: Doppler wire mode changed to {:?}", key, new_mode);
-                }
-                // First `$NEF` for this range confirms the TA state, so the
-                // LUT is now trustworthy and spoke emission can resume.
-                if !self.target_analyzer_known[range_idx] {
-                    self.target_analyzer_known[range_idx] = true;
-                    let key = if range_idx == 1 {
-                        &self.common_b.as_ref().unwrap().key
-                    } else {
-                        &self.common.key
-                    };
-                    log::info!(
-                        "{}: Target Analyzer state confirmed (mode {:?}), spoke output enabled",
-                        key,
-                        self.doppler_wire_mode_for(range_idx)
-                    );
+                    if old_mode != new_mode {
+                        let low_power = self.model.is_low_power();
+                        let legend = if range_idx == 1 {
+                            self.common_b.as_ref().unwrap().info.get_legend()
+                        } else {
+                            self.common.info.get_legend()
+                        };
+                        self.wire_to_legend[range_idx as usize] =
+                            Self::wire_to_legend(&legend, new_mode, low_power);
+                        log::debug!("{}: Doppler wire mode changed to {:?}", key, new_mode);
+                    }
+                    // First `$NEF` confirms the TA state, so the LUT is now
+                    // trustworthy and spoke emission can resume.
+                    if !self.target_analyzer_known[range_idx as usize] {
+                        self.target_analyzer_known[range_idx as usize] = true;
+                        log::info!(
+                            "{}: Target Analyzer state confirmed (mode {:?}), spoke output enabled",
+                            key,
+                            self.doppler_wire_mode_for(range_idx as usize)
+                        );
+                    }
                 }
             }
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -390,6 +390,14 @@ impl FurunoReportReceiver {
                     match r {
                         Ok((len, addr)) => {
                             if self.verify_source_address(&addr) {
+                                // Spoke traffic proves the radar is alive even
+                                // while the TCP report session is down — keep
+                                // the silence watchdog from decaying a
+                                // transmitting radar to Off.
+                                self.common.info.mark_input();
+                                if let Some(ref cb) = self.common_b {
+                                    cb.info.mark_input();
+                                }
                                 // Idle mode: drain the recv but skip decoding.
                                 // Furuno radars emit spokes even in Standby;
                                 // when nobody is watching, decoding them costs
@@ -418,6 +426,10 @@ impl FurunoReportReceiver {
                     match r {
                         Ok((len, addr)) => {
                             if self.verify_source_address(&addr) {
+                                self.common.info.mark_input();
+                                if let Some(ref cb) = self.common_b {
+                                    cb.info.mark_input();
+                                }
                                 if !self.both_ranges_idle() {
                                     self.process_frame(&buf2[..len]);
                                 }

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -52,6 +52,27 @@ const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// A session that survived this long counts as stable: reset the backoff.
 const RECONNECT_STABLE_AFTER: Duration = Duration::from_secs(60);
 
+/// How the reconnect delay evolves after a control session ends.
+///
+/// Split out from the connection loop so the policy can be exercised without a
+/// radar: the loop supplies real elapsed times and sleeps, this decides what
+/// the next delay and short-lived-session count should be.
+fn next_reconnect_backoff(
+    current: Duration,
+    session_lasted: Duration,
+    short_lived_sessions: u32,
+) -> (Duration, u32) {
+    if session_lasted >= RECONNECT_STABLE_AFTER {
+        // Proven stable — start from scratch so a later blip reconnects fast.
+        (RECONNECT_BACKOFF_MIN, 0)
+    } else {
+        (
+            (current * 2).min(RECONNECT_BACKOFF_MAX),
+            short_lived_sessions + 1,
+        )
+    }
+}
+
 /// Furuno wire-format decoding mode. When Target Analyzer is active on NXT
 /// radars, each echo byte encodes `[dopplerClass:2 | intensity:4 | 00:2]`
 /// rather than a plain intensity in 0..PIXEL_VALUES. The report receiver
@@ -459,6 +480,7 @@ impl FurunoReportReceiver {
             self.multicast_socket = None;
             self.broadcast_socket = None;
 
+            let mut reached_data_loop = false;
             if let Err(e) = self.start_data_socket().await {
                 log::warn!("{}: Failed to start data sockets: {}", self.common.key, e);
             } else if let Err(e) = self.login_to_radar() {
@@ -466,6 +488,7 @@ impl FurunoReportReceiver {
             } else if let Err(e) = self.start_command_stream().await {
                 log::warn!("{}: Failed to start command stream: {}", self.common.key, e);
             } else {
+                reached_data_loop = true;
                 let started = Instant::now();
                 match self.data_loop(subsys).await {
                     Err(RadarError::Shutdown) => return Ok(()),
@@ -480,16 +503,15 @@ impl FurunoReportReceiver {
                     }
                     Ok(()) => {}
                 }
-                if started.elapsed() >= RECONNECT_STABLE_AFTER {
-                    backoff = RECONNECT_BACKOFF_MIN;
-                    short_lived_sessions = 0;
-                } else {
+                let was_stable = started.elapsed() >= RECONNECT_STABLE_AFTER;
+                (backoff, short_lived_sessions) =
+                    next_reconnect_backoff(backoff, started.elapsed(), short_lived_sessions);
+                if !was_stable {
                     // Furuno radars keep one control session per client IP.
                     // A pattern of sessions that die right after the radar has
                     // answered the initial requests means another client on
                     // THIS host (e.g. a second mayara instance) keeps taking
                     // the slot — name the cause instead of churning silently.
-                    short_lived_sessions += 1;
                     if short_lived_sessions == 3 {
                         log::error!(
                             "{}: three control sessions in a row died within seconds — \
@@ -507,7 +529,13 @@ impl FurunoReportReceiver {
                 _ = subsys.on_shutdown_requested() => return Ok(()),
                 _ = sleep(backoff) => {}
             }
-            backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+            // A session that never reached data_loop (socket, login or command
+            // stream failed) has not updated the backoff above, so escalate
+            // here — otherwise a radar refusing logins would be retried every
+            // second forever.
+            if !reached_data_loop {
+                backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+            }
         }
     }
 
@@ -2137,6 +2165,39 @@ async fn conditional_read(
 mod tests {
     use super::*;
     use crate::radar::Legend;
+
+    /// A radar that keeps dropping the control session must be backed off
+    /// exponentially: hammering relogins exhausts the firmware's session slot
+    /// table and locks out every client, which is the failure this policy
+    /// exists to avoid.
+    #[test]
+    fn reconnect_backoff_escalates_while_sessions_are_short_lived() {
+        let short = Duration::from_secs(1);
+        let (b1, n1) = next_reconnect_backoff(RECONNECT_BACKOFF_MIN, short, 0);
+        assert_eq!(b1, Duration::from_secs(2));
+        assert_eq!(n1, 1);
+
+        let (b2, n2) = next_reconnect_backoff(b1, short, n1);
+        assert_eq!(b2, Duration::from_secs(4));
+        assert_eq!(n2, 2);
+    }
+
+    #[test]
+    fn reconnect_backoff_is_capped() {
+        let short = Duration::from_secs(1);
+        let (capped, _) = next_reconnect_backoff(RECONNECT_BACKOFF_MAX, short, 9);
+        assert_eq!(capped, RECONNECT_BACKOFF_MAX);
+    }
+
+    /// Once a session has proven stable the next blip should reconnect
+    /// immediately rather than inherit a minute-long delay.
+    #[test]
+    fn reconnect_backoff_resets_after_a_stable_session() {
+        let (reset, count) =
+            next_reconnect_backoff(Duration::from_secs(32), RECONNECT_STABLE_AFTER, 5);
+        assert_eq!(reset, RECONNECT_BACKOFF_MIN);
+        assert_eq!(count, 0, "a stable session clears the churn counter");
+    }
 
     /// Minimal `Legend` shaped like a post-TA NXT: 120 intensity slots,
     /// 1 approaching slot, 1 receding slot, 1 rain slot, mirroring what

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -451,6 +451,7 @@ impl FurunoReportReceiver {
 
     pub(super) async fn run(mut self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
         let mut backoff = RECONNECT_BACKOFF_MIN;
+        let mut short_lived_sessions = 0u32;
         loop {
             // Each time we start the loop, there is no stream
             // and none of the data sockets are open.
@@ -481,6 +482,24 @@ impl FurunoReportReceiver {
                 }
                 if started.elapsed() >= RECONNECT_STABLE_AFTER {
                     backoff = RECONNECT_BACKOFF_MIN;
+                    short_lived_sessions = 0;
+                } else {
+                    // Furuno radars keep one control session per client IP.
+                    // A pattern of sessions that die right after the radar has
+                    // answered the initial requests means another client on
+                    // THIS host (e.g. a second mayara instance) keeps taking
+                    // the slot — name the cause instead of churning silently.
+                    short_lived_sessions += 1;
+                    if short_lived_sessions == 3 {
+                        log::error!(
+                            "{}: three control sessions in a row died within seconds — \
+                             another client on this machine (a second mayara instance?) \
+                             is likely competing for the radar's single per-host control \
+                             session. Spoke data still flows; controls will not work \
+                             until only one instance talks to this radar.",
+                            self.common.key
+                        );
+                    }
                 }
             }
 

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -71,7 +71,7 @@ pub const BYTE_LOOKUP_LENGTH: usize = (u8::MAX as usize) + 1;
 
 #[derive(Error, Debug)]
 pub enum RadarError {
-    #[error("I/O operation failed")]
+    #[error("I/O operation failed: {0}")]
     Io(#[from] std::io::Error),
     #[error("Axum operation failed")]
     Axum(#[from] axum::Error),

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -464,6 +464,15 @@ fn radar_key(
     key
 }
 
+/// The radar key without the dual-range suffix appended by [`radar_key`]:
+/// identical for all ranges of one physical antenna.
+fn base_key<'a>(key: &'a str, dual: Option<&str>) -> &'a str {
+    match dual {
+        Some(dual) => key.strip_suffix(dual).unwrap_or(key),
+        None => key,
+    }
+}
+
 impl RadarInfo {
     #[allow(clippy::too_many_arguments)] // every radar field comes flat from per-brand discovery; the brands are the only callers
     pub fn new<F>(
@@ -563,6 +572,12 @@ impl RadarInfo {
     /// want the default user-visible name to match the key.
     pub(crate) fn discriminator(&self) -> Option<&str> {
         identity_discriminator(self.serial_no.as_deref(), self.hardware_id.as_deref())
+    }
+
+    /// The key without the dual-range suffix: identical for all ranges of one
+    /// physical antenna, so clients can group them into a combined view.
+    pub fn base_key(&self) -> &str {
+        base_key(&self.key, self.dual.as_deref())
     }
 
     /// True when this radar's data_loop is currently dropping decoded frames
@@ -2406,6 +2421,14 @@ mod tests {
             mac_identity(&[0x00, 0xd0, 0x1d, 0x05, 0x79, 0x03]).as_deref(),
             Some("00d01d057903")
         );
+    }
+
+    #[test]
+    fn base_key_strips_dual_suffix() {
+        // Both ranges of one antenna collapse onto the same base key.
+        assert_eq!(base_key("nav2452A", Some("A")), "nav2452");
+        assert_eq!(base_key("nav2452B", Some("B")), "nav2452");
+        assert_eq!(base_key("nav2452", None), "nav2452");
     }
 
     #[test]

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -1220,7 +1220,14 @@ impl SharedControls {
         if let Some(control) = self.get(&cv.id) {
             self.send_reply_to_client(reply_tx, &control, Some(e.to_string()))
                 .await?;
-            log::warn!("User tried to set invalid {}: {}", cv.id, e);
+            // An I/O error means the radar connection failed, not that the
+            // user's value was invalid — word the log accordingly.
+            match e {
+                RadarError::Io(_) => {
+                    log::warn!("Failed to send {} to radar: {}", cv.id, e)
+                }
+                _ => log::warn!("User tried to set invalid {}: {}", cv.id, e),
+            }
             Ok(())
         } else {
             Err(RadarError::CannotSetControlId(cv.id))

--- a/tests/api_surface_parity.rs
+++ b/tests/api_surface_parity.rs
@@ -37,8 +37,7 @@ use std::{
 /// mayara's documented `RadarInfo` extensions: present in mayara, but not part
 /// of the shared surface (and absent from signalk-server). Clients ignore them.
 /// `dual`/`dualGroup` pair the ranges of a dual-range antenna for the GUI's
-/// side-by-side view; promote them to the shared surface once signalk-server
-/// adopts them.
+/// side-by-side view.
 const MAYARA_RADARINFO_EXTENSIONS: &[&str] = &["replay", "dual", "dualGroup"];
 
 #[test]

--- a/tests/api_surface_parity.rs
+++ b/tests/api_surface_parity.rs
@@ -36,7 +36,10 @@ use std::{
 
 /// mayara's documented `RadarInfo` extensions: present in mayara, but not part
 /// of the shared surface (and absent from signalk-server). Clients ignore them.
-const MAYARA_RADARINFO_EXTENSIONS: &[&str] = &["replay"];
+/// `dual`/`dualGroup` pair the ranges of a dual-range antenna for the GUI's
+/// side-by-side view; promote them to the shared surface once signalk-server
+/// adopts them.
+const MAYARA_RADARINFO_EXTENSIONS: &[&str] = &["replay", "dual", "dualGroup"];
 
 #[test]
 fn radar_api_surface_identical_across_projects() {

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -90,6 +90,14 @@ async fn replay_navico_4g() {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
 
+                // The 4G beacon advertises two scanners. Replay keeps only
+                // range A (see SharedRadars::add), but that instance must
+                // carry the dual-range antenna grouping data.
+                let a = radars.get_by_key("nav2452A").expect("range A discovered");
+                assert!(a.dual_range, "4G should be dual-range capable");
+                assert_eq!(a.dual.as_deref(), Some("A"));
+                assert_eq!(a.base_key(), "nav2452");
+
                 subsys.request_shutdown();
                 Ok::<(), miette::Report>(())
             },

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1993,6 +1993,13 @@ function zoomIn() {
     (v) => Number(v) === Number(currentValue)
   );
 
+  // No range reported yet (range B of a dual-range radar stays unknown until
+  // its first command activates it) — send the shortest range to start from.
+  if (currentIndex === -1) {
+    sendControlToServer(controlId, { value: validValues[0] });
+    return;
+  }
+
   // Go to previous (shorter) range
   if (currentIndex > 0) {
     const newValue = validValues[currentIndex - 1];
@@ -2013,6 +2020,13 @@ function zoomOut() {
   const currentIndex = validValues.findIndex(
     (v) => Number(v) === Number(currentValue)
   );
+
+  // No range reported yet (range B of a dual-range radar stays unknown until
+  // its first command activates it) — send the shortest range to start from.
+  if (currentIndex === -1) {
+    sendControlToServer(controlId, { value: validValues[0] });
+    return;
+  }
 
   // Go to next (longer) range
   if (currentIndex < validValues.length - 1) {

--- a/web/gui/dual.css
+++ b/web/gui/dual.css
@@ -1,0 +1,40 @@
+/* ============================================
+   Dual Range View - two viewers side by side
+   ============================================ */
+
+.myr_dual_container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+  height: 100%;
+}
+
+.myr_dual_pane {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+
+.myr_dual_pane + .myr_dual_pane {
+  border-left: 1px solid rgb(3, 37, 37);
+}
+
+/* Stacking is keyed on orientation, not width: in narrow landscape two
+   short stacked panes would be worse than two narrow side-by-side ones,
+   since each pane's own responsive layout already handles narrow widths. */
+@media (orientation: portrait) {
+  .myr_dual_container {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  .myr_dual_pane + .myr_dual_pane {
+    border-left: none;
+    border-top: 1px solid rgb(3, 37, 37);
+  }
+}
+
+.myr_dual_error {
+  padding: 1em;
+}

--- a/web/gui/dual.css
+++ b/web/gui/dual.css
@@ -1,6 +1,6 @@
-/* ============================================
-   Dual Range View - two viewers side by side
-   ============================================ */
+/* Each pane hosts a full viewer in an iframe rather than a shared canvas: the
+   two ranges are independent radars with their own spoke streams, controls and
+   legends, so isolating them avoids one range's state leaking into the other. */
 
 .myr_dual_container {
   display: grid;

--- a/web/gui/dual.html
+++ b/web/gui/dual.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Mayara - Dual Range Radar</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link type="text/css" rel="stylesheet" href="base.css?v=1" />
+    <link type="text/css" rel="stylesheet" href="dual.css?v=1" />
+    <script type="module" src="dual.js?v=1"></script>
+</head>
+<body>
+    <div id="myr_dual" class="myr_dual_container"></div>
+</body>
+</html>

--- a/web/gui/dual.js
+++ b/web/gui/dual.js
@@ -2,16 +2,54 @@
 // the normal viewer in an iframe, so controls, rendering and streams behave
 // exactly as in a single-radar window.
 
-window.onload = function () {
+import { fetchRadars } from "./api.js";
+
+function fail(container, message) {
+  container.setAttribute("role", "alert");
+  container.className = "myr_dual_error";
+  container.textContent = message;
+}
+
+window.onload = async function () {
   const params = new URLSearchParams(window.location.search);
   const container = document.getElementById("myr_dual");
 
   const ids = ["a", "b"].map((k) => params.get(k)?.trim()).filter(Boolean);
   if (ids.length !== 2 || ids[0] === ids[1]) {
-    container.setAttribute("role", "alert");
-    container.className = "myr_dual_error";
-    container.textContent =
-      "Dual view needs two distinct radar ids: dual.html?a=<id>&b=<id>";
+    fail(
+      container,
+      "Dual view needs two distinct radar ids: dual.html?a=<id>&b=<id>"
+    );
+    return;
+  }
+
+  // The ids arrive from the URL, so they may be stale or hand-edited. Without
+  // checking them against the server, two unrelated radars — or ids that no
+  // longer exist — would load as panes and sit retrying failed capability
+  // requests, with nothing on screen to explain why.
+  let radars;
+  try {
+    radars = await fetchRadars();
+  } catch (e) {
+    fail(container, `Could not load the radar list: ${e.message}`);
+    return;
+  }
+
+  const missing = ids.filter((id) => !radars[id]);
+  if (missing.length) {
+    fail(container, `Unknown radar id: ${missing.join(", ")}`);
+    return;
+  }
+
+  // dualGroup is only set for dual-range radars, and is the shared key of the
+  // physical antenna — so equal non-empty groups is exactly "these two are the
+  // ranges of one antenna".
+  const [groupA, groupB] = ids.map((id) => radars[id].dualGroup);
+  if (!groupA || groupA !== groupB) {
+    fail(
+      container,
+      `${ids[0]} and ${ids[1]} are not two ranges of the same antenna`
+    );
     return;
   }
 

--- a/web/gui/dual.js
+++ b/web/gui/dual.js
@@ -1,0 +1,25 @@
+// Side-by-side view for the two ranges of a dual-range antenna. Each pane is
+// the normal viewer in an iframe, so controls, rendering and streams behave
+// exactly as in a single-radar window.
+
+window.onload = function () {
+  const params = new URLSearchParams(window.location.search);
+  const container = document.getElementById("myr_dual");
+
+  const ids = ["a", "b"].map((k) => params.get(k)?.trim()).filter(Boolean);
+  if (ids.length !== 2 || ids[0] === ids[1]) {
+    container.setAttribute("role", "alert");
+    container.className = "myr_dual_error";
+    container.textContent =
+      "Dual view needs two distinct radar ids: dual.html?a=<id>&b=<id>";
+    return;
+  }
+
+  for (const id of ids) {
+    const pane = document.createElement("iframe");
+    pane.className = "myr_dual_pane";
+    pane.src = "viewer.html?id=" + encodeURIComponent(id);
+    pane.title = "Radar " + id;
+    container.appendChild(pane);
+  }
+};

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -439,46 +439,65 @@ const RadarEntry = (radar) => {
     displayName = `${brand} ${name}`;
   }
 
-  // Show different links based on WebGPU availability
+  const actions = [
+    a(
+      {
+        href: "viewer.html?id=" + encodeURIComponent(radar.id),
+        class: "myr_radar_link myr_radar_link_primary",
+      },
+      "Open Radar Display"
+    ),
+  ];
+
+  // WebGL is only offered as an alternative when WebGPU is the default
   if (webGPUAvailable) {
-    return tr(
-      { class: "myr_radar_row" },
-      td({ class: "myr_radar_name" }, displayName),
-      td(
-        { class: "myr_radar_actions" },
-        a(
-          {
-            href: "viewer.html?id=" + radar.id,
-            class: "myr_radar_link myr_radar_link_primary",
-          },
-          "Open Radar Display"
-        ),
-        a(
-          {
-            href: "viewer.html?id=" + radar.id + "&renderer=webgl",
-            class: "myr_radar_link myr_radar_link_secondary",
-          },
-          "Alternate Display"
-        )
-      )
-    );
-  } else {
-    return tr(
-      { class: "myr_radar_row" },
-      td({ class: "myr_radar_name" }, displayName),
-      td(
-        { class: "myr_radar_actions" },
-        a(
-          {
-            href: "viewer.html?id=" + radar.id,
-            class: "myr_radar_link myr_radar_link_primary",
-          },
-          "Open Radar Display"
-        )
+    actions.push(
+      a(
+        {
+          href:
+            "viewer.html?id=" + encodeURIComponent(radar.id) + "&renderer=webgl",
+          class: "myr_radar_link myr_radar_link_secondary",
+        },
+        "Alternate Display"
       )
     );
   }
+
+  // Both ranges of a dual-range antenna side by side, this radar on the left
+  if (radar.dualSibling) {
+    actions.push(
+      a(
+        {
+          href:
+            "dual.html?a=" +
+            encodeURIComponent(radar.id) +
+            "&b=" +
+            encodeURIComponent(radar.dualSibling),
+          class: "myr_radar_link myr_radar_link_secondary",
+        },
+        "Dual Range Display"
+      )
+    );
+  }
+
+  return tr(
+    { class: "myr_radar_row" },
+    td({ class: "myr_radar_name" }, displayName),
+    td({ class: "myr_radar_actions" }, ...actions)
+  );
 };
+
+// The other range of `id`'s dual-range antenna, or null. Radars report a
+// shared dualGroup id per physical antenna; a pane pair only makes sense
+// when the group has exactly two members.
+function dualSiblingId(radars, id) {
+  const group = radars[id].dualGroup;
+  if (!group) return null;
+  const members = Object.keys(radars).filter(
+    (k) => radars[k].dualGroup === group
+  );
+  return members.length === 2 ? members.find((k) => k !== id) : null;
+}
 
 // Track previous radar count to avoid unnecessary DOM rebuilds
 let previousRadarCount = -1;
@@ -515,7 +534,7 @@ function radarsLoaded(d) {
 
     radarIds.sort().forEach(function (v, i) {
       // Pass the full radar object (includes id, name, brand, model)
-      const radar = { ...d[v], id: v };
+      const radar = { ...d[v], id: v, dualSibling: dualSiblingId(d, v) };
       van.add(table, RadarEntry(radar));
     });
 


### PR DESCRIPTION
Dual-range radars (Furuno NXT, Navico 4G/HALO) appear in mayara as two radars sharing one antenna, but until now they could only be watched one at a time — and on a Furuno NXT the second range never showed a picture at all. This adds a side-by-side dual view and fixes everything that kept range B dark, verified live against a DRS4D-NXT with both ranges painting and range B commanded from mayara (range confirmed by the radar's report loop).

- The radar list pairs the ranges of one antenna (new optional `dual` and `dualGroup` fields, documented as mayara extensions in the API-parity allowlist) and links a new `dual.html` that shows both ranges as two full viewers side by side, stacked in portrait.
- Range B spokes were decoded but discarded: the Target Analyzer confirmation only ever arrives for the range the controlling client addressed, so range B's emission gate never lifted. TA is firmware-shared between ranges, so one confirmation now lifts both gates.
- A radar whose control TCP session dropped was shown as OFF while its spokes were streaming in; spoke traffic now counts as liveness for the silence watchdog.
- Furuno radars keep one control session per client IP: a second mayara instance on the same host steals the slot back and forth with the first, controls fail on both while the picture keeps painting. This is now documented in the setup guide, and the reconnect loop detects the churn pattern and names the cause. Reconnects also back off exponentially instead of hammering (which made the fight worse), and session drops are logged with their reason instead of surfacing as a misleading "invalid range" error.
- The GUI range buttons now work before the radar has reported a range, sending the shortest supported range — which doubles as the dual-range activation command on Furuno NXT.

Known follow-up, tracked in #54: distinguish shared vs per-range controls in the UI (gain/sea/rain are firmware-shared on NXT; range, pulse width, ATF, MBS are per-range).

First working milestone of #54.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds dual-range radar support across the API and GUI. The API exposes optional `dual` and `dualGroup` fields, and the GUI displays paired ranges side by side in landscape mode or stacked in portrait mode.

Improves Furuno radar handling by fixing Range B activation, synchronizing dual-range Target Analyzer state, tracking spoke traffic as liveness, adding reconnect backoff, and improving connection error reporting.

Initializes range controls when no range is reported and documents Furuno’s one-control-session-per-host limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->