### PR TITLE
feat(network): advertise web server via mDNS

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -198,6 +198,15 @@ mayara-server --nmea0183 -n udp:0.0.0.0:10110
 
 The built-in web interface is available at `http://localhost:6502` (or your configured port).
 
+Mayara announces itself on the local network with mDNS (Bonjour/Avahi), so from
+another computer, tablet or phone on the same network the web interface is
+reachable at `http://mayara.local:6502` without knowing the server's IP address.
+The announcement is the DNS-SD service type `_mayara-http._tcp`, with TXT keys
+`version`, `api` (Signal K radar API version), `path` and `scheme`
+(`http` or `https`, depending on whether TLS is configured). Browse for other
+mayara servers with, for example, `dns-sd -B _mayara-http._tcp` (macOS) or
+`avahi-browse -r _mayara-http._tcp` (Linux).
+
 Features:
 - Real-time radar display (PPI view)
 - Range and control adjustments

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -161,6 +161,19 @@ impl Web {
         socket.listen(1024).map_err(WebError::Io)?;
         let listener = TcpListener::from_std(socket.into()).map_err(WebError::Io)?;
 
+        // Only announced once the port is actually ours. Discovery is a
+        // convenience, so a failure here must not stop the web server.
+        let _advertiser = match mayara::network::mdns_advertise::Advertiser::start(port, self.tls) {
+            Ok(advertiser) => {
+                log::info!("Advertising {} on mDNS", advertiser.fullname());
+                Some(advertiser)
+            }
+            Err(e) => {
+                log::warn!("Cannot advertise web server on mDNS: {}", e);
+                None
+            }
+        };
+
         let tls_acceptor = match (&self.args.tls_cert, &self.args.tls_key) {
             (Some(cert), Some(key)) => {
                 let config = load_tls_config(cert, key)?;

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -161,18 +161,26 @@ impl Web {
         socket.listen(1024).map_err(WebError::Io)?;
         let listener = TcpListener::from_std(socket.into()).map_err(WebError::Io)?;
 
-        // Only announced once the port is actually ours. Discovery is a
-        // convenience, so a failure here must not stop the web server.
-        let _advertiser = match mayara::network::mdns_advertise::Advertiser::start(port, self.tls) {
-            Ok(advertiser) => {
-                log::info!("Advertising {} on mDNS", advertiser.fullname());
-                Some(advertiser)
-            }
-            Err(e) => {
-                log::warn!("Cannot advertise web server on mDNS: {}", e);
-                None
-            }
-        };
+        // Announce the bound port, not the requested one: `--port 0` asks the
+        // kernel for a free port, and clients need the one we actually got.
+        // Discovery is a convenience, so a failure here must not stop the web
+        // server.
+        let bound_port = listener.local_addr().map_err(WebError::Io)?.port();
+        let _advertiser =
+            match mayara::network::mdns_advertise::Advertiser::start(bound_port, self.tls) {
+                Ok(advertiser) => {
+                    log::info!(
+                        "Advertising {} port {} on mDNS",
+                        advertiser.fullname(),
+                        bound_port
+                    );
+                    Some(advertiser)
+                }
+                Err(e) => {
+                    log::warn!("Cannot advertise web server on mDNS: {}", e);
+                    None
+                }
+            };
 
         let tls_acceptor = match (&self.args.tls_cert, &self.args.tls_key) {
             (Some(cert), Some(key)) => {

--- a/src/lib/network/mdns_advertise.rs
+++ b/src/lib/network/mdns_advertise.rs
@@ -1,0 +1,111 @@
+//! mDNS advertisement of the mayara web server.
+//!
+//! Publishes `_mayara-http._tcp.local.` so clients (browsers, Signal K
+//! servers, plotters) can find mayara without being told its IP address.
+//! The service is registered under the hostname `mayara.local.`, so the GUI
+//! is also reachable at `http://mayara.local:<port>/` from any host with an
+//! mDNS resolver.
+//!
+//! The daemon probes both names before announcing them, so a second mayara
+//! on the same LAN is renamed rather than clashing with the first.
+
+use std::time::Duration;
+
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+
+use crate::{SIGNALK_RADAR_API_VERSION, VERSION};
+
+/// DNS-SD service type; the name is within the 15-character limit of RFC 6763.
+const SERVICE_TYPE: &str = "_mayara-http._tcp.local.";
+const INSTANCE_NAME: &str = "mayara";
+const HOSTNAME: &str = "mayara.local.";
+
+/// How long to wait for the daemon to multicast the goodbye packets.
+const UNREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// A live mDNS registration for the web server. Unregisters on drop.
+pub struct Advertiser {
+    daemon: ServiceDaemon,
+    fullname: String,
+}
+
+impl Advertiser {
+    /// Announce a web server listening on `port`; `tls` selects the scheme
+    /// clients should use.
+    pub fn start(port: u16, tls: bool) -> Result<Self, mdns_sd::Error> {
+        let daemon = ServiceDaemon::new()?;
+        let info = service_info(port, tls)?;
+        let fullname = info.get_fullname().to_string();
+        daemon.register(info)?;
+
+        Ok(Advertiser { daemon, fullname })
+    }
+
+    /// The instance name as registered, e.g. `mayara._mayara-http._tcp.local.`.
+    pub fn fullname(&self) -> &str {
+        &self.fullname
+    }
+}
+
+impl Drop for Advertiser {
+    fn drop(&mut self) {
+        // Wait for the goodbye packets so clients drop the service straight
+        // away instead of waiting out the record TTL.
+        if let Ok(status) = self.daemon.unregister(&self.fullname) {
+            let _ = status.recv_timeout(UNREGISTER_TIMEOUT);
+        }
+        let _ = self.daemon.shutdown();
+    }
+}
+
+/// The addresses are left to the daemon: `enable_addr_auto` fills in every
+/// host address and keeps the records in step as interfaces come and go.
+fn service_info(port: u16, tls: bool) -> Result<ServiceInfo, mdns_sd::Error> {
+    let properties = [
+        ("version", VERSION),
+        ("api", SIGNALK_RADAR_API_VERSION),
+        ("path", "/signalk"),
+        ("scheme", if tls { "https" } else { "http" }),
+    ];
+
+    Ok(ServiceInfo::new(
+        SERVICE_TYPE,
+        INSTANCE_NAME,
+        HOSTNAME,
+        (),
+        port,
+        &properties[..],
+    )?
+    .enable_addr_auto())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_info_names_and_port() {
+        let info = service_info(6502, false).unwrap();
+
+        assert_eq!(info.get_type(), SERVICE_TYPE);
+        assert_eq!(info.get_fullname(), "mayara._mayara-http._tcp.local.");
+        assert_eq!(info.get_hostname(), HOSTNAME);
+        assert_eq!(info.get_port(), 6502);
+        assert!(info.is_addr_auto());
+    }
+
+    #[test]
+    fn service_info_advertises_scheme_and_versions() {
+        let plain = service_info(6502, false).unwrap();
+        assert_eq!(plain.get_property_val_str("scheme"), Some("http"));
+        assert_eq!(plain.get_property_val_str("version"), Some(VERSION));
+        assert_eq!(
+            plain.get_property_val_str("api"),
+            Some(SIGNALK_RADAR_API_VERSION)
+        );
+        assert_eq!(plain.get_property_val_str("path"), Some("/signalk"));
+
+        let tls = service_info(443, true).unwrap();
+        assert_eq!(tls.get_property_val_str("scheme"), Some("https"));
+    }
+}

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod windows;
 
 pub mod arp;
 pub mod devices;
+pub mod mdns_advertise;
 pub mod mdns_browse;
 pub mod passive_capture;
 


### PR DESCRIPTION
Mayara is now discoverable on the local network. From any computer, tablet or phone on the same network the web interface can be opened at `http://mayara.local:6502` — no need to look up the server's IP address first — and network browsers (Bonjour/Avahi, Signal K servers, other tooling) can find mayara automatically.

## Details

Registers the DNS-SD service `_mayara-http._tcp.local.` under hostname `mayara.local.`, using the `mdns-sd` crate that was already a dependency (until now only used for browsing).

- TXT records: `version` (mayara), `api` (Signal K radar API), `path=/signalk`, `scheme` (`http`/`https`, following `--tls-cert`/`--tls-key`).
- `enable_addr_auto()` keeps the address records in step as interfaces and IPs come and go.
- The daemon probes both names, so a second mayara on the same LAN is renamed rather than clashing.
- Registration happens after the listener binds, so a port that is already in use is never announced. Any mDNS error is logged as a warning and the web server continues.
- Dropping the advertiser unregisters (waiting briefly for the goodbye packets) and shuts the daemon down, so clients drop the service immediately instead of waiting out the TTL.

There is no flag to disable the announcement, and it is not scoped to `--interface` — that flag limits radar discovery, whereas the web server listens on all interfaces.

## Test plan

- [x] `cargo test` — 355 lib tests + integration tests pass, including two new unit tests over the generated `ServiceInfo`
- [x] `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D warnings` clean
- [x] Live run on macOS: `dns-sd -B _mayara-http._tcp` finds `mayara`; `dns-sd -L` resolves `mayara.local.:6599` with the expected TXT records; `curl http://mayara.local:6599/signalk` returns the endpoints document; Ctrl-C makes the service disappear from the browser immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds always-enabled mDNS/DNS-SD advertising for the Mayara web server.

- Registers `_mayara-http._tcp.local.` under `mayara.local.` after the web listener binds.
- Advertises the Mayara version, Signal K radar API, `/signalk` path, HTTP/HTTPS scheme, and port.
- Updates address records when network interfaces change.
- Handles hostname conflicts through probing and renaming.
- Logs advertising errors without stopping the web server.
- Unregisters the service and shuts down mDNS when the advertiser is dropped.
- Documents discovery commands for macOS and Linux.
- Adds unit tests for service identity, addresses, port, and TXT properties.
- Passes tests, formatting, clippy, and live macOS discovery checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->