### PR TITLE
feat(server): add --parent for running under a chart plotter

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -48,6 +48,7 @@ Command Line Options
 | `--tls-key <FILE>`            | TLS private key file (PEM format). Enables HTTPS when set with `--tls-cert`.                            |
 | `-i, --interface <INTERFACE>` | Limit radar discovery to a specific network interface                                                   |
 | `--allow-wifi`                | Allow radar discovery on WiFi interfaces (not recommended for most brands due to multicast limitations) |
+| `--parent <PID>`              | Run as a helper process of a chart plotter; see [Running under a chart plotter](#running-under-a-chart-plotter) |
 
 ### Radar Selection
 
@@ -194,11 +195,34 @@ mayara-server --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
 mayara-server --nmea0183 -n udp:0.0.0.0:10110
 ```
 
+### Running under a chart plotter
+
+A chart plotter such as OpenCPN can start mayara for its own use, passing its
+own process id:
+
+```bash
+# Started by the plotter, which passes its pid
+mayara-server --parent 12345
+```
+
+In this mode mayara:
+
+- serves the web interface on `127.0.0.1` only, so it is not reachable from the
+  rest of the network,
+- does not advertise itself on mDNS, so it does not turn up in other machines'
+  network browsers,
+- exits as soon as process 12345 is gone, so a plotter that crashes or is killed
+  does not leave mayara behind holding the radar sockets and the server port.
+
+Radar discovery itself is unaffected and still uses the real network interfaces.
+The parent is checked every two seconds; mayara exits straight away if the pid is
+already gone at startup.
+
 ## Web Interface
 
 The built-in web interface is available at `http://localhost:6502` (or your configured port).
 
-Mayara announces itself on the local network with mDNS (Bonjour/Avahi), so from
+Unless `--parent` is used, mayara announces itself on the local network with mDNS (Bonjour/Avahi), so from
 another computer, tablet or phone on the same network the web interface is
 reachable at `http://mayara.local:6502` without knowing the server's IP address.
 The announcement is the DNS-SD service type `_mayara-http._tcp`, with TXT keys

--- a/src/bin/mayara-server/main.rs
+++ b/src/bin/mayara-server/main.rs
@@ -17,6 +17,27 @@ use mayara::recording::RecordingManager;
 use mayara::replay;
 use mayara::{Cli, network};
 
+/// Shut down the whole server once the `--parent` process is gone, so a
+/// crashed chart plotter does not leave mayara behind holding its port.
+async fn watch_parent(
+    subsys: &mut SubsystemHandle,
+    pid: u32,
+) -> std::result::Result<(), web::WebError> {
+    if !mayara::process::is_alive(pid) {
+        warn!("Parent process {} is not running", pid);
+    }
+
+    tokio::select! {
+        _ = subsys.on_shutdown_requested() => {}
+        _ = mayara::process::wait_for_exit(pid) => {
+            info!("Parent process {} has gone away, shutting down", pid);
+            subsys.request_shutdown();
+        }
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
@@ -67,6 +88,12 @@ async fn main() -> Result<()> {
     if args.output {
         warn!("Output mode activated; 'protobuf' formatted RadarMessage sent to stdout");
     }
+    if let Some(pid) = args.parent {
+        warn!("Child process mode activated, this does the following:");
+        warn!(" * The web server listens on localhost only");
+        warn!(" * The web server is not advertised on mDNS");
+        warn!(" * Mayara stops as soon as process {} is gone", pid);
+    }
     if args.nmea0183 {
         warn!(
             "NMEA0183 mode activated; will load GPS position, heading and date/time from {}",
@@ -78,7 +105,15 @@ async fn main() -> Result<()> {
 
     RecordingManager::new().cleanup_orphaned_uploads();
 
+    let parent_pid = args.parent;
+
     Toplevel::new(async move |s: &mut SubsystemHandle| {
+        if let Some(pid) = parent_pid {
+            s.start(SubsystemBuilder::new(
+                "ParentWatch",
+                async move |a: &mut SubsystemHandle| watch_parent(a, pid).await,
+            ));
+        }
         let web = Web::new(&*s, args).await;
         s.start(SubsystemBuilder::new(
             "Webserver",

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     io,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
 };
 use thiserror::Error;
@@ -141,14 +141,28 @@ impl Web {
 
     pub async fn run(self, subsys: &mut SubsystemHandle) -> Result<(), WebError> {
         let port = self.args.port;
-        let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port);
-        let socket = socket2::Socket::new(
-            socket2::Domain::IPV6,
-            socket2::Type::STREAM,
-            Some(socket2::Protocol::TCP),
-        )
-        .map_err(WebError::Io)?;
-        socket.set_only_v6(false).map_err(WebError::Io)?;
+        // `--parent` means we serve one local chart plotter, so the web server
+        // stays on the loopback interface. IPv4 loopback rather than IPv6:
+        // clients asking for `localhost` fall back from ::1 to 127.0.0.1 on
+        // their own, and a v6 socket cannot answer a v4 client.
+        let embedded = self.args.parent.is_some();
+        let (domain, addr) = if embedded {
+            (
+                socket2::Domain::IPV4,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            )
+        } else {
+            (
+                socket2::Domain::IPV6,
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port),
+            )
+        };
+        let socket =
+            socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))
+                .map_err(WebError::Io)?;
+        if !embedded {
+            socket.set_only_v6(false).map_err(WebError::Io)?;
+        }
         socket.set_reuse_address(true).map_err(WebError::Io)?;
         socket.set_nonblocking(true).map_err(WebError::Io)?;
         socket.bind(&addr.into()).map_err(|e| {
@@ -164,9 +178,13 @@ impl Web {
         // Announce the bound port, not the requested one: `--port 0` asks the
         // kernel for a free port, and clients need the one we actually got.
         // Discovery is a convenience, so a failure here must not stop the web
-        // server.
-        let bound_port = listener.local_addr().map_err(WebError::Io)?.port();
-        let _advertiser =
+        // server. Nothing to announce when embedded: the server is not
+        // reachable from the network at all.
+        let bound_addr = listener.local_addr().map_err(WebError::Io)?;
+        let bound_port = bound_addr.port();
+        let _advertiser = if embedded {
+            None
+        } else {
             match mayara::network::mdns_advertise::Advertiser::start(bound_port, self.tls) {
                 Ok(advertiser) => {
                     log::info!(
@@ -180,7 +198,8 @@ impl Web {
                     log::warn!("Cannot advertise web server on mDNS: {}", e);
                     None
                 }
-            };
+            }
+        };
 
         let tls_acceptor = match (&self.args.tls_cert, &self.args.tls_key) {
             (Some(cert), Some(key)) => {
@@ -228,8 +247,8 @@ impl Web {
         if let Some(acceptor) = tls_acceptor {
             let app = router.into_make_service();
             log::info!(
-                "Starting HTTPS web server on port {} (pid {})",
-                port,
+                "Starting HTTPS web server on {} (pid {})",
+                bound_addr,
                 std::process::id()
             );
             let tls_listener = TlsListener { listener, acceptor };
@@ -244,8 +263,8 @@ impl Web {
         } else {
             let app = router.into_make_service();
             log::info!(
-                "Starting HTTP web server on port {} (pid {})",
-                port,
+                "Starting HTTP web server on {} (pid {})",
+                bound_addr,
                 std::process::id()
             );
             tokio::select! { biased;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -24,6 +24,7 @@ pub mod network;
 pub(crate) mod nnd;
 #[cfg(feature = "pcap-replay")]
 pub mod pcap;
+pub mod process;
 pub mod protos;
 pub mod radar;
 pub mod recording;
@@ -65,6 +66,12 @@ pub struct Cli {
     /// TLS private key file (PEM format). Enables HTTPS when set with --tls-cert.
     #[arg(long, requires = "tls_cert")]
     pub tls_key: Option<std::path::PathBuf>,
+
+    /// Run as a helper process of a chart plotter such as OpenCPN, given its
+    /// process id. The web server then listens on localhost only and is not
+    /// advertised on mDNS, and mayara exits once that process is gone.
+    #[arg(long, value_name = "PID")]
+    pub parent: Option<u32>,
 
     /// Limit radar location to a single interface
     #[arg(short, long)]

--- a/src/lib/process.rs
+++ b/src/lib/process.rs
@@ -1,0 +1,93 @@
+//! Liveness of another process, used by `--parent`.
+//!
+//! When a chart plotter such as OpenCPN starts mayara as a helper process it
+//! cannot always clean up after itself: a crash or a kill leaves the child
+//! running, holding the radar sockets and the web server port. Watching the
+//! plotter's process id lets mayara exit on its own in that case.
+
+use std::time::Duration;
+
+/// How often [`wait_for_exit`] samples the process. Frequent enough that a
+/// restarting plotter does not trip over the old web server port, cheap
+/// enough to be irrelevant next to the radar traffic.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Returns true while the process is running. A process owned by another
+/// user counts as running; one that has exited but not yet been reaped does
+/// not.
+pub fn is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // Signal 0 does the existence and permission checks without
+        // delivering anything. Pid 0 and anything beyond `pid_t` would be
+        // read as "my process group" or a group id, so reject those outright
+        // rather than have `kill` answer a different question than we asked.
+        if pid == 0 || pid > i32::MAX as u32 {
+            return false;
+        }
+        if unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
+            return true;
+        }
+        // EPERM: the process exists, it just isn't ours to signal.
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+
+    #[cfg(windows)]
+    {
+        use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+        use windows::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        unsafe {
+            // A handle can outlive the process it refers to, so the exit code
+            // decides; opening alone does not prove the process is running.
+            let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+                return false;
+            };
+            let mut exit_code = 0u32;
+            // STILL_ACTIVE is an NTSTATUS; exit codes are unsigned.
+            let alive = GetExitCodeProcess(handle, &mut exit_code).is_ok()
+                && exit_code == STILL_ACTIVE.0 as u32;
+            let _ = CloseHandle(handle);
+            alive
+        }
+    }
+}
+
+/// Resolves once the process is gone; returns immediately if it never was.
+pub async fn wait_for_exit(pid: u32) {
+    while is_alive(pid) {
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn own_process_is_alive() {
+        assert!(is_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_group_ids_are_not_processes() {
+        assert!(!is_alive(0));
+        assert!(!is_alive(i32::MAX as u32 + 1));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reaped_child_is_not_alive() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        child.wait().unwrap();
+
+        assert!(!is_alive(pid));
+    }
+}

--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Furuno),
         targets: mayara::TargetMode::None,

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -19,6 +19,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Furuno),
         targets: mayara::TargetMode::None,

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Furuno),
         targets: mayara::TargetMode::None,

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Garmin),
         targets: mayara::TargetMode::None,

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Navico),
         targets: mayara::TargetMode::None,

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Navico),
         targets: mayara::TargetMode::None,

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Navico),
         targets: mayara::TargetMode::None,

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Navico),
         targets: mayara::TargetMode::None,

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Navico),
         targets: mayara::TargetMode::None,

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -16,6 +16,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Raymarine),
         targets: mayara::TargetMode::None,

--- a/tests/replay_raymarine_rd418d.rs
+++ b/tests/replay_raymarine_rd418d.rs
@@ -20,6 +20,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Raymarine),
         targets: mayara::TargetMode::None,

--- a/tests/replay_raymarine_rd418hd.rs
+++ b/tests/replay_raymarine_rd418hd.rs
@@ -23,6 +23,7 @@ fn test_args() -> Cli {
         port: 0,
         tls_cert: None,
         tls_key: None,
+        parent: None,
         interface: None,
         brand: Some(mayara::Brand::Raymarine),
         targets: mayara::TargetMode::None,


### PR DESCRIPTION
A chart plotter such as OpenCPN can now start mayara as its own helper process and have it behave like part of the application: the radar web interface is private to that computer, mayara does not show up in other machines' network browsers, and it shuts itself down when the plotter does. Today a plotter that crashes or is killed leaves mayara running in the background, still holding the radar sockets and the server port — so the next start of the plotter fails to bring up its radar.

Usage: the plotter passes its own process id.

```bash
mayara-server --parent 12345
```

With `--parent` set, mayara:

- binds the web server to `127.0.0.1` instead of all interfaces,
- does not advertise `_mayara-http._tcp` on mDNS,
- exits as soon as that pid is gone (checked every 2 s), including immediately at startup if it is already gone.

Radar discovery is unaffected and still uses the real network interfaces. Without `--parent` nothing changes.

## Details

- `mayara::process::is_alive` uses `kill(pid, 0)` on Unix (treating `EPERM` as alive, rejecting pid 0 and out-of-`pid_t` values so `kill` cannot be tricked into answering a process-group question) and `OpenProcess` + `GetExitCodeProcess` on Windows.
- The watcher is a `ParentWatch` subsystem that calls `request_shutdown()`, so the whole subsystem tree unwinds through the existing graceful-shutdown path.
- The loopback listener is IPv4; a v6 socket cannot serve a v4 client, and clients resolving `localhost` fall back from `::1` to `127.0.0.1` themselves.
- The startup log now prints the bound address (`127.0.0.1:6502`, `[::]:6502`) rather than the requested port.

## Test plan

- [x] `cargo test` — 358 lib tests + integration pass, including 3 new tests for `is_alive`
- [x] `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D warnings` clean
- [x] `cargo check --target x86_64-pc-windows-gnu` passes, covering the Windows branch that cannot run in the macOS test suite
- [x] Live: with `--parent <pid>`, `lsof` shows a single `127.0.0.1:6598` listener, a LAN-address request is refused, no mDNS registration appears, and mayara exits ~1 s after the parent is killed
- [x] Live: `--parent` with an already-dead pid exits at once; without `--parent` the server still binds `[::]` and advertises on mDNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `--parent <PID>` support for chart plotter helper processes.

- Binds the web server to `127.0.0.1`.
- Disables `_mayara-http._tcp` mDNS advertising.
- Preserves radar discovery on network interfaces.
- Monitors the parent process every two seconds.
- Shuts down when the parent process exits.
- Performs an immediate parent-process check at startup.
- Uses Unix `kill(pid, 0)` and Windows `OpenProcess`/`GetExitCodeProcess` checks.
- Reports the actual bound address in startup logs.
- Documents the new option and adds platform-specific process, formatting, clippy, compilation, and live behavior tests.

Without `--parent`, existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->