### PR TITLE
chore(release): 3.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.7.0"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
Release 3.8.0. Merge this PR, then the tag will be created.

Since v3.7.0:

**Added**
- network: advertise web server via mDNS (#483)
- server: add `--parent` for running under a chart plotter (#485)

**Fixed**
- raymarine: support RD418D radomes (#465)
- raymarine: support RD418HD radomes (#470)
- raymarine: log the whole RD status datagram (#481)
- add cmake to docker build tools (#469)

CHANGELOG.md is generated by git-cliff in CI.