### PR TITLE
fix(web): make /quit stop the whole server

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -257,6 +257,9 @@ impl Web {
                     let _ = shutdown_tx.send(());
                 },
                 r = axum::serve(tls_listener, app).with_graceful_shutdown(shutdown) => {
+                    // Reached only via /quit or a serve error; either way the
+                    // rest of mayara must not keep running headless.
+                    subsys.request_shutdown();
                     return r.map_err(WebError::Io);
                 }
             }
@@ -272,6 +275,9 @@ impl Web {
                     let _ = shutdown_tx.send(());
                 },
                 r = axum::serve(listener, app).with_graceful_shutdown(shutdown) => {
+                    // Reached only via /quit or a serve error; either way the
+                    // rest of mayara must not keep running headless.
+                    subsys.request_shutdown();
                     return r.map_err(WebError::Io);
                 }
             }

--- a/tests/quit.rs
+++ b/tests/quit.rs
@@ -1,0 +1,80 @@
+//! `/quit` must stop the whole process, not just the web server.
+//!
+//! Regression test: the web server used to shut down on its own broadcast
+//! channel without ever requesting a shutdown of the subsystem tree, leaving
+//! a headless process behind that still held the radar sockets and could
+//! only be killed by hand.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Start a server on an ephemeral port and return it with that port.
+///
+/// `--parent` with our own pid keeps the server on the loopback interface and
+/// off mDNS, so a test run neither exposes a port to the network nor
+/// advertises itself, and orphans die with the test process.
+fn start_server() -> (Child, u16) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mayara-server"))
+        .args(["--port", "0", "--parent", &std::process::id().to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start mayara-server");
+
+    // The startup line reports the bound address, which is where `--port 0`
+    // actually landed.
+    let stderr = child.stderr.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            if let Some(addr) = line.split("web server on ").nth(1)
+                && let Some(port) = addr.split(':').nth(1)
+                && let Some(port) = port.split_whitespace().next()
+                && let Ok(port) = port.parse::<u16>()
+            {
+                let _ = tx.send(port);
+                break;
+            }
+        }
+    });
+
+    let port = rx
+        .recv_timeout(STARTUP_TIMEOUT)
+        .expect("server did not report a listening port");
+
+    (child, port)
+}
+
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().expect("try_wait failed") {
+            return Some(status);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    None
+}
+
+#[tokio::test]
+async fn quit_stops_the_whole_process() {
+    let (mut child, port) = start_server();
+
+    let response = reqwest::get(format!("http://127.0.0.1:{}/quit", port))
+        .await
+        .expect("GET /quit failed");
+    assert!(response.status().is_success());
+
+    match wait_for_exit(&mut child, EXIT_TIMEOUT) {
+        Some(status) => assert!(status.success(), "server exited with {}", status),
+        None => {
+            let _ = child.kill();
+            panic!("server still running after /quit");
+        }
+    }
+}

--- a/tests/quit.rs
+++ b/tests/quit.rs
@@ -1,9 +1,6 @@
-//! `/quit` must stop the whole process, not just the web server.
-//!
-//! Regression test: the web server used to shut down on its own broadcast
-//! channel without ever requesting a shutdown of the subsystem tree, leaving
-//! a headless process behind that still held the radar sockets and could
-//! only be killed by hand.
+//! `/quit` stops the whole process, not just the web server. A web server
+//! that shuts down while the subsystem tree keeps running leaves a headless
+//! process holding the radar sockets that can only be killed by hand.
 
 use std::io::{BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
@@ -12,6 +9,7 @@ use std::time::{Duration, Instant};
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Start a server on an ephemeral port and return it with that port.
 ///
@@ -56,7 +54,7 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::E
         if let Some(status) = child.try_wait().expect("try_wait failed") {
             return Some(status);
         }
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(EXIT_POLL_INTERVAL);
     }
     None
 }


### PR DESCRIPTION
Asking mayara to quit left it running. `GET /quit` answered `bye` and the web interface went away, but the process stayed alive — still consuming radar and Signal K traffic, no longer reachable, and only stoppable by killing it by hand. Worse, it had released the HTTP port, so starting mayara again succeeded and left two instances competing for the same radar. The only clean way to stop mayara was Ctrl-C or a signal from the service manager.

Now `/quit` shuts the whole process down, the same way Ctrl-C does.

## Details

`quit_handler` sends on `Web::shutdown_tx`, a web-local broadcast channel whose only subscribers are the axum graceful-shutdown future and the outbound WebSocket streams. Nothing connected it to tokio-graceful-shutdown: `axum::serve` returned `Ok`, `Web::run` returned `Ok(())`, and a subsystem finishing normally is not a shutdown request. The toplevel cancellation token was never cancelled, so Locator, NavData, Radar Watchdog, AIS Broadcast/Timeout/Seed, TrackerManager and the per-radar subsystems all kept waiting on `on_shutdown_requested()`, and `handle_shutdown_requests` — which returns once a shutdown is requested *or* all subsystems have finished — waited forever.

The fix calls `subsys.request_shutdown()` where the serve future completes, cancelling the toplevel token and unwinding the tree through the path signals already use. It is placed before the error return, so a web server that dies of an I/O error also brings the process down instead of leaving the same headless state.

## Test plan

- [x] New `tests/quit.rs` starts the binary on an ephemeral port, hits `/quit`, and asserts the process exits — verified it **fails** without the fix ("server still running after /quit") and passes with it
- [x] Live: `curl /quit` against a normally started server now exits in ~2 s; before the fix the process was still alive with 20 threads and needed SIGINT
- [x] `cargo test --features pcap-replay` — 367 lib tests plus all integration tests pass
- [x] `cargo fmt --check` and `cargo clippy --no-deps --all-targets --all-features -- -D warnings` clean

The test runs the server with `--parent <test pid>`, so it binds loopback only and does not advertise on mDNS — a test run neither exposes a port nor spams the LAN, and an orphaned server dies with the test process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes `/quit` to shut down the complete Mayara process. When the web server stops or reports an I/O error, it requests subsystem shutdown and cancels the toplevel token.

Adds an integration test that starts `mayara-server`, requests `/quit`, and verifies that the process exits successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->