### PR TITLE
chore(release): 3.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.8.0"
+version = "3.8.1"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
Release 3.8.1. Merge this PR, then the tag will be created.

Since v3.8.0:

**Fixed**
- web: make `/quit` stop the whole server (#489)

CHANGELOG.md is generated by git-cliff in CI.