### PR TITLE
feat(output): show any radar brand on a Garmin chartplotter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,8 @@ jobs:
       run: cargo clippy --no-deps --all-targets -- -D warnings
     - name: cargo clippy (--features pcap-replay)
       run: cargo clippy --no-deps --all-targets --features pcap-replay -- -D warnings
+    - name: cargo clippy (--features garmin-xhd-output)
+      run: cargo clippy --no-deps --all-targets --features garmin-xhd-output -- -D warnings
 
   build:
     name: Build ${{ matrix.target }}
@@ -74,7 +76,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: swatinem/rust-cache@v2
     - name: Run tests
-      run: cargo test --features pcap-replay --release
+      run: cargo test --features pcap-replay,garmin-xhd-output --release
     - name: Build
       run: cargo build --release
     - name: Upload artifacts
@@ -93,7 +95,7 @@ jobs:
       with:
         tool: nextest
     - name: Run tests
-      run: cargo nextest run --features pcap-replay
+      run: cargo nextest run --features pcap-replay,garmin-xhd-output
     - name: Build
       run: cargo build --release
     - name: Upload artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ koden = []
 raymarine = []
 emulator = []
 pcap-replay = []
+# Emulate a Garmin GMR xHD radar so a Garmin chartplotter can display any
+# radar mayara has found. Built on the `garmin` brand's protocol definitions.
+garmin-xhd-output = ["garmin"]
 # default = ["navico", "furuno", "raymarine"]
 default = ["navico", "furuno", "garmin", "koden", "raymarine", "emulator"]
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Implemented but awaiting real-hardware validation:
 
 If your radar is not on the fully supported list, contact us to help with testing!
 
+Mayara can also work the other way around: an optional build feature makes it
+[emulate a Garmin radar](docs/garmin-xhd-output.md), so a Garmin chartplotter
+can display the picture of a radar of any other supported brand.
+
 ## End users
 
 Mayara runs on Windows, macOS, and Linux (including Raspberry Pi). Download a pre-built binary, start it, and open a web browser — no programming required.

--- a/docs/garmin-xhd-output.md
+++ b/docs/garmin-xhd-output.md
@@ -1,0 +1,141 @@
+# Showing Any Radar on a Garmin Chartplotter
+
+A Garmin GPSMAP chartplotter only draws radar from a Garmin radar. Mayara can
+close that gap: built with the `garmin-xhd-output` feature it emulates a Garmin
+GMR xHD on the Garmin Marine Network, and feeds it the picture of whichever
+radar it found — a Furuno DRS, a Navico HALO, a Raymarine Quantum, a Koden, or
+the built-in emulator. The plotter discovers it by itself and shows it in the
+radar list as a GMR xHD.
+
+The controls work in both directions. Range, gain, sea clutter, rain clutter,
+and the transmit button on the plotter change the setting on the real radar,
+and a change made from Mayara's own GUI or another display shows up on the
+plotter.
+
+> **Not yet validated on a chartplotter.** The bridge has been verified against
+> Mayara's own Garmin receiver over loopback — discovery, the report stream,
+> controls and spoke data all check out — but nobody has yet put it in front of
+> a physical Garmin GPSMAP. If you try it, please report how it goes.
+
+## What you need
+
+- Mayara built with the feature (it is not in the standard binaries):
+
+  ```sh
+  cargo build --release --features garmin-xhd-output
+  ```
+
+- An address on the Garmin Marine Network, `172.16.x.x` with netmask
+  `255.240.0.0`, on the interface the plotter is reachable through. If the
+  radar is on a different subnet — a Furuno on `172.31.x.x`, say — give the
+  same interface both addresses:
+
+  ```text
+  enp0s13f0u2
+    172.31.254.217/16   Furuno radar
+    172.16.254.217/12   Garmin Marine Network
+  ```
+
+  Mayara picks the Garmin address on the radar's own interface. When the
+  plotter is on an interface of its own, any `172.16.x.x` address will do;
+  addresses in `172.17`–`172.31` are skipped, because that is where Docker and
+  similar bridges live rather than Garmin equipment.
+
+- Mayara and the plotter on the same network segment. Multicast is sent with a
+  TTL of 1, so nothing crosses a router.
+
+The log says which radar is being emulated and from where:
+
+```text
+Furuno-1234: Garmin xHD output emulating a GMR xHD on 172.16.254.217
+```
+
+## One radar at a time
+
+An emulated xHD occupies the fixed addresses and ports a real one does, so
+Mayara emulates exactly one — the first radar it discovers. On a boat with more
+than one radar, `--brand furuno` (or `navico`, `raymarine`, …) picks which one
+that is. The other radars stay available through Mayara's own GUI and the
+Signal K API as usual.
+
+A Garmin radar is never bridged: the plotter can already talk to it directly.
+For the same reason, do not enable the feature on a boat that has a real Garmin
+radar on the network — the emulated one uses the addresses and ports the real
+one does, and the plotter would see the two pictures interleaved.
+
+## What the plotter shows
+
+The emulated radar reports itself as a GMR xHD, so the plotter offers the
+controls an xHD has:
+
+| Control       | Effect on the source radar                                     |
+| ------------- | -------------------------------------------------------------- |
+| Transmit      | Standby / Transmit                                              |
+| Range         | Range, snapped by the radar to the nearest range it supports    |
+| Gain          | Gain, manual or automatic                                       |
+| Sea clutter   | Sea clutter: off, manual, or automatic                          |
+| Rain clutter  | Rain clutter: off, or a level. Switching it on uses 50%         |
+
+Those five are all the plotter offers. The emulated radar reports only the
+features the bridge can actually pass on, so a control that would do nothing —
+timed transmit, no-transmit zones, antenna rotation speed, a second range — is
+absent rather than dead. Use Mayara's GUI or the Signal K API for those.
+
+Ranges come from the xHD's own table (1/8 NM to 48 NM). The plotter can only
+choose from that list; the radar then picks whatever it supports that is
+closest. On a radar set to metric ranges the two ladders do not line up, and
+the range ring the plotter draws can be a few percent off. The echoes stay in
+the right place regardless — the picture is scaled by the distance the radar
+says its samples cover, not by the range the plotter displays. Switching the
+radar to nautical ranges in Mayara makes the two agree.
+
+Radars that classify moving targets — Navico Doppler, Furuno Target Analyzer,
+Garmin MotionScope — have nowhere to put that on an xHD, which knows only echo
+strength. Approaching and receding targets are drawn as strong echoes, and
+Furuno's rain classification as a moderate one.
+
+## Trying it without a plotter
+
+A second mayara makes a serviceable stand-in for the chartplotter, on the same
+machine. Give the loopback interface an address on the Garmin network, run the
+bridge against the built-in emulator, and point a second mayara at it:
+
+```sh
+sudo ifconfig lo0 alias 172.16.99.1     # Linux: sudo ip addr add 172.16.99.1/16 dev lo
+mayara-server --emulator -i lo0 --port 6602
+mayara-server -i lo0 --brand garmin --port 6603
+```
+
+The second one logs `Garmin CDM heartbeat: product_id=0x06d0 (GMR xHD)` and
+then finds the radar; open its GUI on port 6603 to see the emulator's picture
+arriving over the Garmin protocol.
+
+## Troubleshooting
+
+**The plotter never lists the radar.**
+Check the log for `Garmin xHD output emulating a GMR xHD on …`. If it says no
+address on the Garmin Marine Network was found, the host has no `172.16.x.x`
+address. Otherwise, confirm the announcement is going out on the right
+interface:
+
+```sh
+sudo tcpdump -i <interface> udp port 50050
+```
+
+There should be a packet to `239.254.2.2` every second for the first half
+minute, then every five seconds.
+
+**The radar is listed but stays blank.**
+The source radar has to be transmitting: press Transmit on the plotter, or
+check the radar's power state in Mayara's GUI. If it is transmitting, watch the
+sweep data with `tcpdump -i <interface> udp port 50102`.
+
+**Range or gain buttons do nothing.**
+Run `mayara-server -vv` and watch for `Garmin xHD command:` lines. They log the
+command received, the control it was translated into, and any reason the radar
+refused it.
+
+## Under the hood
+
+For the protocol details and how the translation works, see
+[Garmin xHD Output Bridge](internals/garmin-xhd-output.md).

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -173,3 +173,4 @@ Integration tests in `tests/replay_*.rs` replay brand-specific pcap fixtures and
 - [ARPA Target Tracking](arpa.md) — IMM filtering and blob detection
 - [Radar Status Model](radar-status.md) — design intent for lifecycle/health status vs. idle, and the ARPA/idle interaction
 - [Mayara Server for radar_pi Developers](radar_pi_comparison.md) — concept map for developers coming from the radar_pi OpenCPN plugin
+- [Garmin xHD Output Bridge](garmin-xhd-output.md) — emulating a Garmin radar so a Garmin plotter can show any brand

--- a/docs/internals/garmin-xhd-output.md
+++ b/docs/internals/garmin-xhd-output.md
@@ -117,11 +117,25 @@ becomes 50%.
 ## What is not emulated
 
 The `0x09B1` capability bitmap is what a display reads to decide which controls
-to offer, so `EMULATED_CAPABILITIES` in `status.rs` lists exactly the features
-the bridge translates — transmit, range, and the gain, sea and rain controls of
-range A — and `GarminCapabilities::to_body()` serializes them. A bit claimed
-there but ignored in `command.rs` would be a knob on the plotter that does
-nothing, so the list is the honest one rather than a capture replayed verbatim.
+to offer, so `emulated_capabilities()` in `status.rs` builds it from the
+controls the source radar actually has, rather than from a fixed list or a
+capture replayed verbatim. A radar with no rain control does not get a rain
+menu on the plotter; a gain that cannot be switched to automatic does not get a
+gain mode. Three kinds of bit go into it (see
+`research/garmin/feature-detection.md`):
+
+- **Command gates**, one per control the bridge translates — transmit, range,
+  and the gain, sea and rain controls of range A. A bit claimed here but
+  ignored in `command.rs` would be a knob on the plotter that does nothing.
+- **Group bits**, one per block of controls. The MFD checks a control bit and
+  its group bit together, so `RANGE_A_GAIN` without `GAIN_GROUP` is a gain the
+  plotter never sends.
+- **Class bits**, `CLASS_CAPABILITIES`, which say what protocol is being
+  spoken rather than what can be adjusted. The MFD reduces them to a radar
+  class and draws anything below class 2 with the legacy two-colour ramp
+  however many bits per sample the spokes carry, so the bridge always claims
+  them — a real GMR xHD does too.
+
 For comparison, `capabilities::LEGACY_HD_BITS` is what a Garmin MFD hardcodes
 for a legacy HD radar, which is likewise single-range and Doppler-less.
 
@@ -138,3 +152,6 @@ Left out, and why:
 - **Bearing alignment.** Deliberate: the source radar has already applied its
   own before it hands over a spoke, so the emulated radar reports itself as
   aligned and offers no control to change that.
+- **The quick-adjust panel.** `QUICK_ADJUST_PANEL` gates the on-screen
+  sliders, but which control each of its three slots adjusts is not known, and
+  a slot guessed wrong is a slider that moves the wrong setting.

--- a/docs/internals/garmin-xhd-output.md
+++ b/docs/internals/garmin-xhd-output.md
@@ -1,0 +1,140 @@
+# Garmin xHD Output Bridge
+
+`src/lib/output/garmin_xhd/` is the mirror image of a brand in
+`src/lib/brand/`. A brand receives a proprietary protocol and feeds it into
+`RadarInfo`; this bridge subscribes to `RadarInfo` and emits a proprietary
+protocol — the Garmin enhanced radar protocol, as a GMR xHD speaks it. See
+[the setup guide](../garmin-xhd-output.md) for what it does for a user, and
+`research/garmin/enhanced-radar-protocol.md` for the wire format.
+
+## Where it hangs off the radar
+
+`RadarInfo::start_outputs()` starts every output that republishes a radar's
+spokes outside the Signal K API — the `--output` stdout forwarder and this
+bridge. Every brand calls it once the radar is registered with `SharedRadars`,
+which is what makes the bridge brand-agnostic: nothing in
+`src/lib/output/` knows which brand produced the spokes it is converting.
+
+`spawn()` refuses in three cases: the radar is a Garmin (the plotter can talk
+to it directly), the host has no address on the Garmin Marine Network, or
+another radar is already being emulated. The last is tracked in a `OnceLock`,
+because the xHD multicast groups and ports are fixed and two emulated radars
+would interleave their spokes.
+
+## Tasks
+
+Four subsystems run per bridge. Each owns its socket; none of them shares one.
+
+| Module       | Direction | Endpoint             | Contents                     |
+| ------------ | --------- | -------------------- | ---------------------------- |
+| `cdm.rs`     | out       | `239.254.2.2:50050`  | discovery heartbeat `0x038e` |
+| `status.rs`  | out       | `239.254.2.0:50100`  | settings and state reports   |
+| `spokes.rs`  | out       | `239.254.2.0:50102`  | sweep data `0x0998`          |
+| `command.rs` | in        | `<local addr>:50101` | control changes from plotter |
+
+Each outgoing socket binds the well-known port it sends to. The plotter
+identifies a stream by its source port and ignores traffic from an ephemeral
+one, which is why `network::create_multicast_send()` is used rather than a
+plain bind. The outgoing interface is pinned with `IP_MULTICAST_IF` rather than
+left to the routing table, which on a host whose Garmin network is not its
+default route would send the traffic out of the wrong interface.
+
+Multicast loopback is left on, so a display on the same host sees the emulated
+radar too — a second mayara, or an OpenCPN with radar_pi. That leaves mayara
+free to discover the radar it is emulating itself, which `spawn()` prevents by
+recording the address it announces from in `EMULATED_SOURCE`;
+`locator::is_own_emulated_radar()` drops beacons from it. The filter is that
+narrow on purpose: every local address would also cover a second mayara on the
+same host, which shares them and is a display, not an echo of ourselves.
+
+## Spoke conversion
+
+`convert.rs` holds everything that differs between a source radar and an xHD.
+
+**Angular resolution.** An xHD turns 1440 spokes per revolution; sources range
+from 250 (Raymarine Quantum) to 8192 (Furuno). `SpokeStream` maps each source
+spoke onto an xHD spoke index. Several source spokes landing on one index are
+merged by taking the strongest sample of each pair, so downsampling a Furuno
+does not throw away five spokes out of six. A source coarser than 1440 leaves
+gaps, which are filled by repeating the spoke across the sector it covers —
+capped at `MAX_REPEAT`, beyond which a gap means spokes went missing rather
+than that the source is coarse.
+
+Because the sector a spoke covers is only known once the next one arrives, the
+stream always emits one spoke behind.
+
+**Sample values.** mayara spokes carry legend indices, not echo strength: index
+`n` means "the n-th colour of this radar's legend", and how many there are
+depends on the radar. `intensity_table()` builds a 256-entry lookup from the
+`Legend`, scaling the normal colours linearly onto the xHD's `0..=255`. The
+Doppler bands above them have no equivalent on an xHD and become plain echoes:
+approaching and receding at full strength, Furuno's rain class at the legend's
+own notion of a medium return.
+
+A radar's legend and spoke count are not final when it is discovered — a
+Raymarine reports how many intensity levels it has only once it says which
+model it is — so `spokes.rs` re-reads both from `SharedRadars` every few
+seconds and calls `SpokeStream::reconfigure()`.
+
+**The two range fields.** `range_meters` is the range the plotter displays and
+is always an entry of the xHD range table. `display_meters` is the distance the
+samples actually cover, which is what the plotter scales the image by. They are
+not the same number on every radar: a Furuno keeps sweeping past the range it
+was set to and delivers the overshoot, so its `spoke.range` is roughly 1.78× the
+range in use. Passing `spoke.range` through as `display_meters` is what makes
+the chart overlay line up, on any brand, without knowing which brand it is.
+
+**Pacing.** Radars deliver spokes in bursts — a Furuno hands over some 1500
+every 450 ms — while an xHD trickles them out one at a time. `spokes.rs`
+buffers a burst and drains it over the time the burst took to arrive, so the
+plotter sees a sweep that turns steadily. The pace is remeasured on every
+burst; nothing has to know the antenna's rotation speed.
+
+## Controls
+
+`command.rs` translates a plotter command into a `ControlValue` and hands it to
+`SharedControls::process_client_request()` — the same entry point the REST and
+WebSocket API use, so the value is validated and unit-converted exactly as a
+request from mayara's own GUI would be. The reply channel is drained and any
+rejection logged.
+
+The plotter waits for the radar to confirm a command before it shows the new
+setting, so each accepted command is echoed back on the report stream. The echo
+has to leave from port 50100, which the status task owns, so `command.rs` sends
+it through a channel and `status.rs` forwards it immediately.
+
+Range needs one thing more. Between the plotter's command and the radar acting
+on it, the Range control still holds the old value, and a report stream that
+told the truth would make the plotter's range ring snap back. `Shared` therefore
+remembers the range the plotter asked for and reports it until the radar
+confirms it or `RANGE_CONFIRM_TIMEOUT` passes — after which a command the radar
+ignored stops being reported as though it had worked.
+
+Rain clutter has no automatic mode on an xHD: it is off, or it is set to a
+level. "Off" becomes a rain value of 0, and switching it on without a level
+becomes 50%.
+
+## What is not emulated
+
+The `0x09B1` capability bitmap is what a display reads to decide which controls
+to offer, so `EMULATED_CAPABILITIES` in `status.rs` lists exactly the features
+the bridge translates — transmit, range, and the gain, sea and rain controls of
+range A — and `GarminCapabilities::to_body()` serializes them. A bit claimed
+there but ignored in `command.rs` would be a knob on the plotter that does
+nothing, so the list is the honest one rather than a capture replayed verbatim.
+For comparison, `capabilities::LEGACY_HD_BITS` is what a Garmin MFD hardcodes
+for a legacy HD radar, which is likewise single-range and Doppler-less.
+
+Left out, and why:
+
+- **Dual range.** The bridge presents a single range whatever the source radar
+  supports. The GMR xHD in the capture claims dual range despite having none —
+  the MFD appears to set that whole capability word unconditionally — and a
+  display that believes it offers a second range that stays black. mayara's own
+  Garmin receiver registers a phantom Range B radar when told this.
+- **Doppler.** An xHD has none; see the intensity mapping above.
+- **Timed transmit, no-transmit zones, rotation speed, park position.** The
+  source radar may well support these, but the bridge does not forward them.
+- **Bearing alignment.** Deliberate: the source radar has already applied its
+  own before it hands over a spoke, so the emulated radar reports itself as
+  aligned and offers no control to change that.

--- a/src/lib/brand/emulator/mod.rs
+++ b/src/lib/brand/emulator/mod.rs
@@ -178,6 +178,8 @@ pub(crate) fn create_emulator_radar(args: &Cli, radars: &SharedRadars, subsys: &
 
         radars.update(&mut info);
 
+        info.start_outputs(radars, subsys);
+
         // Start the report receiver (spoke generator)
         let report_name = info.key() + " reports";
         let report_receiver = report::EmulatorReportReceiver::new(args, info, radars.clone());

--- a/src/lib/brand/furuno/mod.rs
+++ b/src/lib/brand/furuno/mod.rs
@@ -115,7 +115,7 @@ impl FurunoLocator {
 
             let report_name = info.key();
 
-            info.start_forwarding_radar_messages_to_stdout(subsys);
+            info.start_outputs(radars, subsys);
 
             // In replay mode, detect model from the original beacon string
             // (not from controls which persistence may have overwritten).
@@ -141,7 +141,7 @@ impl FurunoLocator {
             if let Some(ref mut ib) = info_b {
                 ib.send_command_addr.set_port(port);
                 ib.report_addr.set_port(port);
-                ib.start_forwarding_radar_messages_to_stdout(subsys);
+                ib.start_outputs(radars, subsys);
                 if let Some(model) = replay_model.filter(|m| *m != RadarModel::Unknown) {
                     settings::update_when_model_known(ib, model, REPLAY_FIRMWARE_VERSION);
                     radars.update(ib);

--- a/src/lib/brand/garmin/capabilities.rs
+++ b/src/lib/brand/garmin/capabilities.rs
@@ -27,6 +27,21 @@ const CAP_BODY_FIRST_WORD_OFFSET: usize = 8;
 /// header offset prefix.
 const CAP_BODY_TOTAL_LEN: usize = CAP_BODY_FIRST_WORD_OFFSET + CAP_WORDS * 8;
 
+/// The eight bytes before the first capability word, as a GMR xHD sends them.
+///
+/// Captured at offset +00 of the `0x09B1` body in
+/// `radar-recordings/garmin/garmin_xhd.pcap`, the same fixture as
+/// `SAMPLE_0X09B1_BODY` below; documented in
+/// `research/garmin/feature-detection.md`, which reads the first four fields
+/// as a length/version pair followed by two unidentified ones.
+///
+/// Their meaning is unknown and does not matter: the MFD's
+/// `radar_parse_xhd_capability_packet()` (`FUN_0490ef30`) reads the five words
+/// at their fixed offsets `+0x08`..`+0x28` and never looks at the prefix. It is
+/// reproduced so a body mayara generates has the same shape as one off the wire.
+const CAP_BODY_PREFIX: [u8; CAP_BODY_FIRST_WORD_OFFSET] =
+    [0x01, 0x00, 0x30, 0x00, 0x9d, 0x00, 0x0a, 0x00];
+
 /// Capability bit identifiers. Numeric values match the per-bit indices
 /// used by the Garmin MFD; the multi-byte u64 layout is hidden inside
 /// [`GarminCapabilities::has`].
@@ -139,11 +154,29 @@ impl GarminCapabilities {
     /// (single range, manual/auto gain, sea/rain clutter, no-TX zone 1,
     /// sentry mode, RPM mode toggle).
     pub(crate) fn for_legacy_hd() -> Self {
+        Self::from_bits(LEGACY_HD_BITS)
+    }
+
+    /// Build a capability vector claiming exactly `bits`.
+    pub(crate) fn from_bits(bits: &[u32]) -> Self {
         let mut caps = Self::empty();
-        for &bit in LEGACY_HD_BITS {
+        for &bit in bits {
             caps.set(bit);
         }
         caps
+    }
+
+    /// Serialize into a `0x09B1` message body, the inverse of [`Self::parse`].
+    /// Used by the Garmin xHD output bridge to tell a display what the radar
+    /// it emulates can do.
+    pub(crate) fn to_body(self) -> [u8; CAP_BODY_TOTAL_LEN] {
+        let mut body = [0u8; CAP_BODY_TOTAL_LEN];
+        body[..CAP_BODY_FIRST_WORD_OFFSET].copy_from_slice(&CAP_BODY_PREFIX);
+        for (word, value) in self.bits.iter().enumerate() {
+            let start = CAP_BODY_FIRST_WORD_OFFSET + word * 8;
+            body[start..start + 8].copy_from_slice(&value.to_le_bytes());
+        }
+        body
     }
 
     /// Parse a `0x09B1` payload (the message body **as received from the

--- a/src/lib/brand/garmin/capabilities.rs
+++ b/src/lib/brand/garmin/capabilities.rs
@@ -45,11 +45,32 @@ const CAP_BODY_PREFIX: [u8; CAP_BODY_FIRST_WORD_OFFSET] =
 /// Capability bit identifiers. Numeric values match the per-bit indices
 /// used by the Garmin MFD; the multi-byte u64 layout is hidden inside
 /// [`GarminCapabilities::has`].
+///
+/// Not every bit gates a control of its own. Three kinds occur:
+///
+/// * **Command gates** — one bit per control, checked by the MFD's
+///   `Radar_Manager_Command_*` wrapper before it sends that command.
+/// * **Group bits** — one bit per block of related controls. The MFD tests
+///   `group && control`, so a control bit on its own is never acted on.
+/// * **Class bits** — `RANGE_MODE`, `QUICK_ADJUST_GAIN`, `QUICK_ADJUST_SEA`,
+///   `CLASS_6`, `CLASS_7`, `ENHANCED_PROTOCOL` and `HIGH_CLASS`, which the MFD
+///   reduces to a radar class that decides, with `COLOR_PALETTE`, which
+///   palette the picture is drawn in.
 #[allow(non_camel_case_types)]
 pub(crate) mod cap {
     // ---- Operational ----
     pub(crate) const RANGE_MODE: u32 = 0x02;
+    /// Slots of the on-screen quick-adjust panel, which `QUICK_ADJUST_PANEL`
+    /// gates. Both are also inputs to the radar class.
+    pub(crate) const QUICK_ADJUST_GAIN: u32 = 0x03;
+    pub(crate) const QUICK_ADJUST_SEA: u32 = 0x04;
+    /// Never checked on their own: these two exist only as class inputs.
+    pub(crate) const CLASS_6: u32 = 0x06;
+    pub(crate) const CLASS_7: u32 = 0x07;
     pub(crate) const RANGE_MODE_TOGGLE: u32 = 0x09;
+    /// Master flag of the enhanced (xHD and newer) protocol, and a class
+    /// input. Gates the dual-range and range-channel menus.
+    pub(crate) const ENHANCED_PROTOCOL: u32 = 0x0b;
     pub(crate) const RPM_MODE: u32 = 0x0c;
     pub(crate) const TRANSMIT_MODE: u32 = 0x13;
     pub(crate) const FRONT_OF_BOAT: u32 = 0x1c;
@@ -61,8 +82,23 @@ pub(crate) mod cap {
     pub(crate) const SENTRY_MODE: u32 = 0x24;
     pub(crate) const SENTRY_TRANSMIT_TIME: u32 = 0x28;
     pub(crate) const SENTRY_STANDBY_TIME: u32 = 0x29;
+    pub(crate) const QUICK_ADJUST_PANEL: u32 = 0x2d;
     pub(crate) const DITHER_MODE: u32 = 0x37;
     pub(crate) const NOISE_BLANKER_MODE: u32 = 0x38;
+
+    // ---- Group bits, each gating a block of the controls below ----
+    pub(crate) const GAIN_GROUP: u32 = 0x2a;
+    pub(crate) const RAIN_GROUP: u32 = 0x3e;
+    pub(crate) const SEA_GROUP: u32 = 0x42;
+    pub(crate) const FTC_GROUP: u32 = 0x9b;
+    /// Both bits are needed: the MFD tests them as `(a & b) == 1`.
+    pub(crate) const DOPPLER_GROUP_A: u32 = 0xa0;
+    pub(crate) const DOPPLER_GROUP_B: u32 = 0xa2;
+    pub(crate) const ECHO_TRAIL_GROUP: u32 = 0xa5;
+    pub(crate) const PULSE_EXPANSION_GROUP: u32 = 0xaa;
+    pub(crate) const TARGET_SIZE_GROUP: u32 = 0xb7;
+    pub(crate) const DOPPLER_SENSITIVITY_GROUP: u32 = 0xc2;
+    pub(crate) const SCAN_AVERAGE_GROUP: u32 = 0xc9;
 
     // ---- Range A ----
     pub(crate) const RANGE_A: u32 = 0x4a;
@@ -92,7 +128,11 @@ pub(crate) mod cap {
     pub(crate) const AFC_COARSE: u32 = 0x65;
 
     // ---- Hardware ----
+    /// Raises the radar class from 2 to 3. A GMR xHD sets it.
+    pub(crate) const HIGH_CLASS: u32 = 0x9a;
     pub(crate) const ANTENNA_SIZE: u32 = 0x9c;
+    /// Picks the second of the two non-legacy palettes the MFD renders with.
+    pub(crate) const COLOR_PALETTE: u32 = 0x9f;
 
     // ---- Doppler / MotionScope (Fantom) ----
     pub(crate) const DOPPLER_RANGE_A: u32 = 0xa3;

--- a/src/lib/brand/garmin/mod.rs
+++ b/src/lib/brand/garmin/mod.rs
@@ -12,12 +12,16 @@ use crate::radar::range::Ranges;
 use crate::radar::{RadarInfo, SharedRadars};
 use crate::{Brand, Cli};
 
-mod capabilities;
+// `capabilities::cap` is shared with the Garmin xHD output bridge, which
+// builds the bitmap it reports from the same bit numbers.
+pub(crate) mod capabilities;
 mod cdm_heartbeat;
 mod command;
-mod discovery;
-mod protocol;
-mod range_table;
+// Shared with the Garmin xHD output bridge, which speaks the same wire
+// protocol from the other side.
+pub(crate) mod discovery;
+pub(crate) mod protocol;
+pub(crate) mod range_table;
 mod report;
 mod settings;
 
@@ -189,7 +193,7 @@ impl GarminLocator {
         subsys: &SubsystemHandle,
     ) {
         if let Some(mut info) = radars.add(info) {
-            info.start_forwarding_radar_messages_to_stdout(subsys);
+            info.start_outputs(radars, subsys);
 
             let report_name = info.key();
             radars.update(&mut info);
@@ -201,7 +205,7 @@ impl GarminLocator {
             if let Some(ib) = info_b
                 && let Some(mut ib) = radars.add(ib)
             {
-                ib.start_forwarding_radar_messages_to_stdout(subsys);
+                ib.start_outputs(radars, subsys);
                 radars.update(&mut ib);
                 report_receiver.set_range_b(&self.args, ib, radars.clone());
             }

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -264,7 +264,7 @@ impl KodenLocator {
 
         if let Some(info) = radars.add(radar_info) {
             let report_name = info.key();
-            info.start_forwarding_radar_messages_to_stdout(subsys);
+            info.start_outputs(radars, subsys);
 
             let report_receiver =
                 report::KodenReportReceiver::new(&self.args, radars.clone(), info);

--- a/src/lib/brand/navico/mod.rs
+++ b/src/lib/brand/navico/mod.rs
@@ -387,7 +387,7 @@ impl NavicoLocator {
 
             let report_name = info.key() + " reports";
 
-            info.start_forwarding_radar_messages_to_stdout(subsys);
+            info.start_outputs(radars, subsys);
 
             let report_receiver =
                 report::NavicoReportReceiver::new(&self.args, info, radars.clone());

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -576,7 +576,7 @@ impl RaymarineLocator {
 
         if let Some(mut info) = radars.add(info) {
             // It's new, start the RadarProcessor thread
-            info.start_forwarding_radar_messages_to_stdout(subsys);
+            info.start_outputs(radars, subsys);
 
             let report_name = info.key();
             radars.update(&mut info);

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -228,13 +228,20 @@ impl Locator {
                                     buf
                                 );
 
-                                let _ = locator_socket.state.process(
-                                    &buf,
-                                    &addr,
-                                    &locator_socket.nic_addr,
-                                    radars,
-                                    subsys,
-                                );
+                                if is_own_emulated_radar(&addr) {
+                                    log::trace!(
+                                        "{}: ignoring the radar we are emulating ourselves",
+                                        addr
+                                    );
+                                } else {
+                                    let _ = locator_socket.state.process(
+                                        &buf,
+                                        &addr,
+                                        &locator_socket.nic_addr,
+                                        radars,
+                                        subsys,
+                                    );
+                                }
                                 if self.args.multiple_radar || !radars.have_discovered() {
                                     // Respawn this task
                                     spawn_receive(&mut set, locator_socket);
@@ -606,6 +613,25 @@ fn spawn_interface_request_handler(
             _ => Err(RadarError::Shutdown),
         }
     });
+}
+
+/// Whether a beacon came from the radar this mayara is emulating itself.
+///
+/// The Garmin xHD output announces a radar that looks exactly like a real one,
+/// on multicast groups this mayara is also listening to, so without this it
+/// would discover its own emulation. Only the address the emulation sends from
+/// is ignored, not every local address: a second mayara on the same host
+/// shares those addresses and is a display that ought to see the radar.
+fn is_own_emulated_radar(addr: &SocketAddrV4) -> bool {
+    #[cfg(feature = "garmin-xhd-output")]
+    {
+        crate::output::garmin_xhd::is_emulated_source(addr.ip())
+    }
+    #[cfg(not(feature = "garmin-xhd-output"))]
+    {
+        let _ = addr;
+        false
+    }
 }
 
 fn spawn_receive(set: &mut JoinSet<Result<ResultType, RadarError>>, mut socket: LocatorSocket) {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -22,6 +22,8 @@ pub mod navdata;
 pub mod network;
 #[cfg(feature = "pcap-replay")]
 pub(crate) mod nnd;
+#[cfg(feature = "garmin-xhd-output")]
+pub(crate) mod output;
 #[cfg(feature = "pcap-replay")]
 pub mod pcap;
 pub mod process;

--- a/src/lib/output/garmin_xhd/cdm.rs
+++ b/src/lib/output/garmin_xhd/cdm.rs
@@ -1,0 +1,139 @@
+//! Discovery heartbeat of the emulated xHD radar (`239.254.2.2:50050`).
+//!
+//! Every Garmin marine device announces itself with a CDM "V2 heartbeat", and
+//! a plotter only offers a radar it has heard one from. The emulated radar
+//! announces itself as a GMR xHD, quickly at first so it shows up on a plotter
+//! that was already switched on, then at the leisurely rate a real one uses.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use tokio_graceful_shutdown::SubsystemHandle;
+
+use crate::brand::garmin::protocol::{CDM_HEARTBEAT_ADDRESS, MSG_CDM_HEARTBEAT};
+use crate::radar::RadarError;
+
+use super::multicast_send;
+
+/// Product id of the GMR xHD, which is what makes a plotter treat the
+/// announcement as coming from a radar it knows how to drive.
+const PRODUCT_ID_XHD: u16 = 0x06d0;
+
+/// Remaining identity fields, as a real GMR xHD sends them.
+const PRODUCT_SUBTYPE: u8 = 5;
+const SYC_GROUP_ID: u8 = 6;
+const SERVICE_CLASS: u8 = 1;
+const SERVICE_INSTANCE: u8 = 0;
+const SERVICE_VERSION: u16 = 2;
+const SERVICE_ID: u32 = 0x08d4_0aa0;
+
+/// `version_marker`: this is a V2 heartbeat, the only version mayara's own
+/// discovery accepts and the only one seen in captures.
+const VERSION_MARKER: u8 = 2;
+
+/// `simulator_mode`: zero for a real radar rather than a simulated one. The
+/// emulated radar claims to be real, because to the plotter it is.
+const SIMULATOR_MODE: u8 = 0;
+
+/// Byte at +07, constant in every capture and of unknown meaning.
+const CONSTANT_07: u8 = 1;
+
+/// The announcement lists the services the device offers; a radar offers one.
+const SERVICE_COUNT: u8 = 1;
+
+/// Tag and length of the sequence counter in the serialized tail.
+const TAIL_TAG_SEQUENCE: u8 = 1;
+const TAIL_LEN_SEQUENCE: u8 = 4;
+
+/// Padding runs: one byte after the version marker, three before the service
+/// entries.
+const PAD_AFTER_VERSION: [u8; 1] = [0];
+const PAD_BEFORE_SERVICES: [u8; 3] = [0; 3];
+
+/// Heartbeats sent at the fast rate before settling into the slow one.
+const FAST_HEARTBEATS: u32 = 30;
+const FAST_INTERVAL: Duration = Duration::from_secs(1);
+const SLOW_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Build the `0x038e` announcement. The layout is documented in
+/// `research/garmin/discovery-handshake.md` and in
+/// `brand::garmin::discovery`, which parses it.
+fn heartbeat(sequence: u32) -> Vec<u8> {
+    let mut body = Vec::with_capacity(26);
+    body.push(VERSION_MARKER);
+    body.extend_from_slice(&PAD_AFTER_VERSION);
+    body.extend_from_slice(&PRODUCT_ID_XHD.to_le_bytes());
+    body.push(SIMULATOR_MODE);
+    body.push(PRODUCT_SUBTYPE);
+    body.push(SYC_GROUP_ID);
+    body.push(CONSTANT_07);
+    body.push(SERVICE_COUNT);
+    body.extend_from_slice(&PAD_BEFORE_SERVICES);
+
+    body.push(SERVICE_CLASS);
+    body.push(SERVICE_INSTANCE);
+    body.extend_from_slice(&SERVICE_VERSION.to_le_bytes());
+    body.extend_from_slice(&SERVICE_ID.to_le_bytes());
+
+    // Serialized tail: one tagged field holding the sequence counter.
+    body.push(TAIL_TAG_SEQUENCE);
+    body.push(TAIL_LEN_SEQUENCE);
+    body.extend_from_slice(&sequence.to_le_bytes());
+
+    super::packet(MSG_CDM_HEARTBEAT, &body)
+}
+
+pub(super) async fn run(
+    local_addr: Ipv4Addr,
+    subsys: &mut SubsystemHandle,
+) -> Result<(), RadarError> {
+    let socket = match multicast_send(&CDM_HEARTBEAT_ADDRESS, local_addr) {
+        Ok(socket) => socket,
+        Err(e) => {
+            log::error!("Garmin xHD heartbeat: cannot open socket: {e}");
+            return Ok(());
+        }
+    };
+
+    let mut sequence: u32 = 0;
+    loop {
+        if let Err(e) = socket.send(&heartbeat(sequence)).await {
+            log::warn!("Garmin xHD heartbeat: send failed: {e}");
+        }
+        sequence = sequence.wrapping_add(1);
+
+        let interval = if sequence < FAST_HEARTBEATS {
+            FAST_INTERVAL
+        } else {
+            SLOW_INTERVAL
+        };
+
+        tokio::select! {
+            biased;
+            _ = subsys.on_shutdown_requested() => return Ok(()),
+            _ = tokio::time::sleep(interval) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::brand::garmin::discovery;
+
+    #[test]
+    fn heartbeat_identifies_the_radar_as_a_gmr_xhd() {
+        let packet = heartbeat(7);
+        assert_eq!(
+            u32::from_le_bytes(packet[0..4].try_into().unwrap()),
+            MSG_CDM_HEARTBEAT
+        );
+
+        let parsed = discovery::parse(&packet[8..]).expect("valid heartbeat");
+        assert_eq!(parsed.product_id, PRODUCT_ID_XHD);
+        assert_eq!(parsed.version, 2);
+        assert_eq!(parsed.simulator_mode, 0);
+        assert_eq!(parsed.product_subtype, PRODUCT_SUBTYPE);
+        assert_eq!(discovery::product_name(parsed.product_id), Some("GMR xHD"));
+    }
+}

--- a/src/lib/output/garmin_xhd/command.rs
+++ b/src/lib/output/garmin_xhd/command.rs
@@ -1,0 +1,333 @@
+//! Control commands from the plotter (`<local addr>:50101`).
+//!
+//! The plotter sends one packet per control it changes, in the same TLV form
+//! the radar reports its state in. Each is translated into a mayara control
+//! change on the source radar and echoed back on the report stream, which is
+//! how a real radar acknowledges a command.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use serde_json::json;
+use socket2::SockAddr;
+use tokio::net::UdpSocket;
+use tokio_graceful_shutdown::SubsystemHandle;
+
+use crate::brand::garmin::protocol::*;
+use crate::radar::settings::{ControlId, ControlValue};
+use crate::radar::{Power, RadarError};
+
+use super::convert::nearest_xhd_range;
+use super::{GAIN_MODE_AUTO, SEA_MODE_AUTO, SEA_MODE_MANUAL, SEA_MODE_OFF, Shared, packet_u8};
+
+/// Rain clutter gain used when the plotter switches rain filtering on without
+/// saying how much. The xHD protocol has a separate on/off and gain command,
+/// and the plotter sends the gain only once the user moves the slider.
+const RAIN_DEFAULT_PERCENT: f64 = 50.0;
+
+/// Depth of the reply channel the control system answers on. Replies only
+/// carry errors worth logging, so a command whose reply is dropped because
+/// the channel is full has still been sent to the radar.
+const REPLY_CHANNEL_DEPTH: usize = 16;
+
+/// Largest command the plotter sends is a few dozen bytes; this is room to
+/// spare for anything else that lands on the port.
+const RECEIVE_BUFFER: usize = 2048;
+
+pub(super) async fn run(
+    local_addr: Ipv4Addr,
+    shared: Arc<Shared>,
+    subsys: &mut SubsystemHandle,
+) -> Result<(), RadarError> {
+    let socket = match listen(local_addr) {
+        Ok(socket) => socket,
+        Err(e) => {
+            log::error!("Garmin xHD command: cannot listen on {local_addr}:{COMMAND_PORT}: {e}");
+            return Ok(());
+        }
+    };
+    log::debug!("Garmin xHD command: listening on {local_addr}:{COMMAND_PORT}");
+
+    let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel::<ControlValue>(REPLY_CHANNEL_DEPTH);
+    let mut buffer = [0u8; RECEIVE_BUFFER];
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = subsys.on_shutdown_requested() => return Ok(()),
+            Some(reply) = reply_rx.recv() => {
+                if let Some(error) = reply.error {
+                    log::warn!("Garmin xHD command: {:?} rejected: {error}", reply.id);
+                }
+            }
+            received = socket.recv_from(&mut buffer) => {
+                let length = match received {
+                    Ok((length, _)) => length,
+                    Err(e) => {
+                        log::warn!("Garmin xHD command: receive failed: {e}");
+                        continue;
+                    }
+                };
+                handle(&buffer[..length], &shared, &reply_tx);
+            }
+        }
+    }
+}
+
+fn listen(local_addr: Ipv4Addr) -> std::io::Result<UdpSocket> {
+    let socket = crate::network::new_socket()?;
+    socket.bind(&SockAddr::from(SocketAddr::new(
+        IpAddr::V4(local_addr),
+        COMMAND_PORT,
+    )))?;
+    UdpSocket::from_std(socket.into())
+}
+
+/// Decode one command packet and act on it.
+fn handle(datagram: &[u8], shared: &Shared, reply_tx: &tokio::sync::mpsc::Sender<ControlValue>) {
+    if datagram.len() < GMN_HEADER_LEN {
+        return;
+    }
+    let message_id = u32::from_le_bytes(datagram[0..4].try_into().unwrap());
+    let payload_len = u32::from_le_bytes(datagram[4..8].try_into().unwrap()) as usize;
+    let Some(payload) = GMN_HEADER_LEN
+        .checked_add(payload_len)
+        .and_then(|end| datagram.get(GMN_HEADER_LEN..end))
+    else {
+        log::warn!("Garmin xHD command: 0x{message_id:04x} truncated");
+        return;
+    };
+
+    let byte = payload.first().copied();
+    let word = payload
+        .get(0..2)
+        .map(|p| u16::from_le_bytes(p.try_into().unwrap()));
+    let long = payload
+        .get(0..4)
+        .map(|p| u32::from_le_bytes(p.try_into().unwrap()));
+
+    // Percent as the enhanced protocol carries it: percent × 100.
+    let percent = || word.map(|w| w as f64 / GAIN_SCALE as f64);
+
+    let control = match message_id {
+        MSG_TRANSMIT_MODE => byte.map(|on| {
+            let power = if on != 0 {
+                Power::Transmit
+            } else {
+                Power::Standby
+            };
+            ControlValue::new(ControlId::Power, json!(power as u32))
+        }),
+
+        MSG_RANGE_A => long.map(|meters| {
+            // The plotter can only pick a range mayara offered it, but a
+            // radar with a range table of its own will land on whatever it
+            // has that is closest.
+            shared.set_pending_range(nearest_xhd_range(meters));
+            ControlValue::new(ControlId::Range, json!(meters))
+        }),
+
+        MSG_RANGE_A_GAIN_MODE => byte.map(|mode| auto(ControlId::Gain, mode == GAIN_MODE_AUTO)),
+        MSG_RANGE_A_GAIN => percent().map(|p| manual(ControlId::Gain, p)),
+
+        MSG_RANGE_A_SEA_MODE => byte.and_then(|mode| match mode {
+            SEA_MODE_AUTO => Some(auto(ControlId::Sea, true)),
+            SEA_MODE_MANUAL => Some(auto(ControlId::Sea, false)),
+            SEA_MODE_OFF => Some(manual(ControlId::Sea, 0.0)),
+            // Switching sea clutter off is not the safe reading of a mode we
+            // do not know: it is the one that quietly changes the picture.
+            _ => {
+                log::warn!("Garmin xHD command: unknown sea clutter mode {mode}");
+                None
+            }
+        }),
+        MSG_RANGE_A_SEA_GAIN => percent().map(|p| manual(ControlId::Sea, p)),
+
+        // Rain filtering has no automatic mode on an xHD: it is off, or it is
+        // set to a level. Switching it on before the user has picked a level
+        // has to mean something, so it means half.
+        MSG_RANGE_A_RAIN_MODE => byte.map(|mode| {
+            let percent = if mode != 0 {
+                shared
+                    .control(ControlId::Rain)
+                    .filter(|&v| v > 0.0)
+                    .unwrap_or(RAIN_DEFAULT_PERCENT)
+            } else {
+                0.0
+            };
+            manual(ControlId::Rain, percent)
+        }),
+        MSG_RANGE_A_RAIN_GAIN => percent().map(|p| manual(ControlId::Rain, p)),
+
+        _ => {
+            log::debug!("Garmin xHD command: ignoring 0x{message_id:04x}");
+            return;
+        }
+    };
+
+    // Either the payload was too short for the value this message carries, or
+    // it held a value we do not understand — which is logged where it is seen.
+    let Some(control) = control else {
+        log::warn!("Garmin xHD command: 0x{message_id:04x} carries nothing we can act on");
+        return;
+    };
+
+    log::debug!("Garmin xHD command: 0x{message_id:04x} -> {control:?}");
+    if let Err(e) = shared
+        .controls
+        .process_client_request(control, reply_tx.clone())
+    {
+        log::warn!("Garmin xHD command: 0x{message_id:04x} cannot be forwarded: {e}");
+        return;
+    }
+
+    // Acknowledge by echoing the command, exactly as a real radar reports
+    // back the value it was told to take. The plotter waits for this before
+    // it shows the new setting.
+    shared.echo(datagram.to_vec());
+    if message_id == MSG_TRANSMIT_MODE {
+        let state = if byte.is_some_and(|on| on != 0) {
+            STATE_TRANSMIT
+        } else {
+            STATE_STANDBY
+        };
+        shared.echo(packet_u8(MSG_SCANNER_STATE, state as u8));
+    }
+}
+
+/// A control set to a value, in whatever units mayara models it in.
+fn manual(id: ControlId, value: f64) -> ControlValue {
+    ControlValue {
+        auto: Some(false),
+        ..ControlValue::new(id, json!(value))
+    }
+}
+
+/// A control switched between automatic and manual, leaving its value alone.
+fn auto(id: ControlId, automatic: bool) -> ControlValue {
+    ControlValue {
+        auto: Some(automatic),
+        value: None,
+        ..ControlValue::new(id, serde_json::Value::Null)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::garmin_xhd::tests::controls;
+    use crate::output::garmin_xhd::{packet_u16, packet_u32};
+
+    /// Feed one command packet to the bridge and return the control change it
+    /// asked the radar for, if any.
+    fn command(shared: &Shared, packet: &[u8]) -> Option<ControlValue> {
+        let mut updates = shared.controls.control_update_subscribe();
+        let (reply_tx, _reply_rx) = tokio::sync::mpsc::channel(1);
+        handle(packet, shared, &reply_tx);
+        updates.try_recv().ok().map(|update| update.control_value)
+    }
+
+    #[test]
+    fn transmit_button_powers_the_radar() {
+        let (shared, mut echo_rx) = Shared::new(controls());
+
+        let control = command(&shared, &packet_u8(MSG_TRANSMIT_MODE, 1)).expect("control change");
+        assert_eq!(control.id, ControlId::Power);
+        assert_eq!(control.as_f64().unwrap(), Power::Transmit as u32 as f64);
+
+        // The plotter is told the radar took the command, twice over: the
+        // command itself and the scanner state that follows from it.
+        assert_eq!(echo_rx.try_recv().unwrap(), packet_u8(MSG_TRANSMIT_MODE, 1));
+        assert_eq!(
+            echo_rx.try_recv().unwrap(),
+            packet_u8(MSG_SCANNER_STATE, STATE_TRANSMIT as u8)
+        );
+
+        let control = command(&shared, &packet_u8(MSG_TRANSMIT_MODE, 0)).expect("control change");
+        assert_eq!(control.as_f64().unwrap(), Power::Standby as u32 as f64);
+    }
+
+    #[test]
+    fn range_is_forwarded_and_reported_back_before_the_radar_confirms() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        let control = command(&shared, &packet_u32(MSG_RANGE_A, 5556)).expect("control change");
+        assert_eq!(control.id, ControlId::Range);
+        assert_eq!(control.as_f64().unwrap(), 5556.0);
+        assert_eq!(shared.range_m(), 5556);
+    }
+
+    #[test]
+    fn gain_arrives_as_a_percentage() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        let control =
+            command(&shared, &packet_u16(MSG_RANGE_A_GAIN, 7500)).expect("control change");
+        assert_eq!(control.id, ControlId::Gain);
+        assert_eq!(control.as_f64().unwrap(), 75.0);
+        assert_eq!(control.auto, Some(false));
+
+        let control = command(
+            &shared,
+            &packet_u8(MSG_RANGE_A_GAIN_MODE, super::GAIN_MODE_AUTO),
+        )
+        .expect("control change");
+        assert_eq!(control.auto, Some(true));
+        assert!(control.value.is_none(), "auto must not change the value");
+    }
+
+    #[test]
+    fn sea_clutter_modes_reach_the_radar() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        let off = command(&shared, &packet_u8(MSG_RANGE_A_SEA_MODE, 0)).expect("control change");
+        assert_eq!(off.as_f64().unwrap(), 0.0);
+        assert_eq!(off.auto, Some(false));
+
+        let auto = command(
+            &shared,
+            &packet_u8(MSG_RANGE_A_SEA_MODE, super::SEA_MODE_AUTO),
+        )
+        .expect("control change");
+        assert_eq!(auto.auto, Some(true));
+
+        let manual = command(
+            &shared,
+            &packet_u8(MSG_RANGE_A_SEA_MODE, super::SEA_MODE_MANUAL),
+        )
+        .expect("control change");
+        assert_eq!(manual.auto, Some(false));
+        assert!(manual.value.is_none(), "manual must not change the value");
+
+        // A mode we do not know must not be read as "switch sea clutter off",
+        // which would quietly change the picture.
+        assert!(command(&shared, &packet_u8(MSG_RANGE_A_SEA_MODE, 9)).is_none());
+    }
+
+    #[test]
+    fn rain_filtering_switched_on_without_a_level_picks_one() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        let on = command(&shared, &packet_u8(MSG_RANGE_A_RAIN_MODE, 1)).expect("control change");
+        assert_eq!(on.id, ControlId::Rain);
+        assert_eq!(on.as_f64().unwrap(), RAIN_DEFAULT_PERCENT);
+
+        shared.controls.set(&ControlId::Rain, 20., None).unwrap();
+        let on = command(&shared, &packet_u8(MSG_RANGE_A_RAIN_MODE, 1)).expect("control change");
+        assert_eq!(on.as_f64().unwrap(), 20.0, "a level already set is kept");
+
+        let off = command(&shared, &packet_u8(MSG_RANGE_A_RAIN_MODE, 0)).expect("control change");
+        assert_eq!(off.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn unhandled_and_malformed_commands_are_ignored() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        assert!(command(&shared, &packet_u8(MSG_RPM_MODE, 1)).is_none());
+        assert!(command(&shared, &[]).is_none());
+        assert!(command(&shared, &[0x19, 0x09, 0, 0]).is_none());
+        // Says it carries four bytes but carries none.
+        assert!(command(&shared, &[0x1e, 0x09, 0, 0, 4, 0, 0, 0]).is_none());
+    }
+}

--- a/src/lib/output/garmin_xhd/convert.rs
+++ b/src/lib/output/garmin_xhd/convert.rs
@@ -1,0 +1,466 @@
+//! Conversion of mayara spokes into Garmin xHD `0x0998` sweep packets.
+//!
+//! Three things differ between any given source radar and an xHD, and all
+//! three are handled here:
+//!
+//! * **Angular resolution.** An xHD turns 1440 spokes per revolution. Source
+//!   radars deliver anything from 250 (Raymarine Quantum) to 8192 (Furuno), so
+//!   spokes are merged or repeated to land on exactly 1440.
+//! * **Sample count.** An xHD spoke carries a fixed number of samples whatever
+//!   the range; source spokes do not.
+//! * **Sample values.** mayara spokes carry legend indices, whose meaning
+//!   depends on the radar's legend, while an xHD carries 8-bit echo strength.
+
+use std::collections::VecDeque;
+
+use crate::brand::garmin::protocol::{
+    ANGLE_UNITS_PER_SPOKE, MSG_SPOKE, SPOKE_HEADER_SIZE, SPOKES_PER_REVOLUTION,
+};
+use crate::radar::Legend;
+
+/// The ranges an xHD offers, in meters: 1/8 NM to 48 NM. The plotter picks
+/// what it shows from this list, so the emulated radar has to speak it too.
+pub(super) const XHD_RANGES_M: &[u32] = &[
+    232, 463, 926, 1389, 1852, 2778, 3704, 5556, 7408, 11112, 14816, 22224, 29632, 44448, 66672,
+    88896,
+];
+
+/// Samples per emitted spoke, at every range. Real xHD captures use this
+/// count; the field is variable on the wire but there is no reason to differ.
+const SAMPLES_PER_SPOKE: usize = 695;
+
+/// `scan_length` header field, constant in every real xHD capture.
+const SCAN_LENGTH: u16 = 0x02d3;
+
+/// `fill_1` header field. Documented as padding, but a plotter fed zeroes here
+/// locks up, so send what a real radar sends.
+const FILL_1: u16 = 1;
+
+/// `fills_4` header field, same story as [`FILL_1`].
+const FILLS_4: u16 = 0x0108;
+
+/// Upper bound on how many xHD spokes one source spoke may be repeated into.
+/// A radar with few spokes per revolution needs the repeat to paint a solid
+/// picture, but a gap wider than this means spokes went missing rather than
+/// that the source is coarse, and smearing one spoke across the hole would
+/// invent echoes that were never received.
+const MAX_REPEAT: u16 = 16;
+
+/// Return the xHD range-table entry closest to `meters`.
+pub(super) fn nearest_xhd_range(meters: u32) -> u32 {
+    XHD_RANGES_M
+        .iter()
+        .copied()
+        .min_by_key(|&r| r.abs_diff(meters))
+        .expect("xHD range table is not empty")
+}
+
+/// Maps mayara legend indices to xHD echo strength.
+///
+/// Legend indices below `pixel_colors` are echo strengths on a scale the radar
+/// chose, and scale linearly onto the xHD's 0..=255. Above that sit the
+/// Doppler classes and the rendering-only entries (target history, static
+/// background) that a spoke straight off a radar never contains.
+fn intensity_table(legend: &Legend) -> [u8; 256] {
+    let mut table = [0u8; 256];
+
+    let top = legend.pixel_colors.saturating_sub(1);
+    if top > 0 {
+        for (index, entry) in table
+            .iter_mut()
+            .enumerate()
+            .take(legend.pixel_colors as usize)
+        {
+            *entry = (index * u8::MAX as usize / top as usize) as u8;
+        }
+    }
+
+    // An xHD has no Doppler, so a moving target has to be shown as an echo.
+    // Approaching and receding targets are solid returns; the rain class that
+    // Furuno's NXT reports is a soft one, and painting it at full strength
+    // would turn a rain shower into a coastline.
+    let bands = [
+        (legend.doppler_approaching, u8::MAX),
+        (legend.doppler_receding, u8::MAX),
+        (
+            legend.doppler_rain,
+            table[legend.medium_return.min(top) as usize],
+        ),
+    ];
+    for (band, intensity) in bands {
+        if let Some((first, count)) = band {
+            for index in first..first.saturating_add(count) {
+                table[index as usize] = intensity;
+            }
+        }
+    }
+
+    table
+}
+
+/// Resample `samples` to [`SAMPLES_PER_SPOKE`], mapping legend indices to
+/// echo strength on the way.
+///
+/// Downsampling takes the strongest sample of each group rather than one
+/// arbitrary member of it: a buoy is one or two samples wide, and picking a
+/// neighbour instead drops it from the picture.
+fn resample(samples: &[u8], intensity: &[u8; 256], out: &mut [u8; SAMPLES_PER_SPOKE]) {
+    if samples.is_empty() {
+        out.fill(0);
+        return;
+    }
+
+    for (i, slot) in out.iter_mut().enumerate() {
+        let start = i * samples.len() / SAMPLES_PER_SPOKE;
+        let end = (((i + 1) * samples.len() / SAMPLES_PER_SPOKE).max(start + 1)).min(samples.len());
+        *slot = samples[start..end]
+            .iter()
+            .map(|&v| intensity[v as usize])
+            .max()
+            .unwrap_or(0);
+    }
+}
+
+/// One xHD spoke under construction.
+struct Pending {
+    /// Spoke index in `0..SPOKES_PER_REVOLUTION`.
+    index: u16,
+    samples: [u8; SAMPLES_PER_SPOKE],
+    /// Range shown by the plotter, an entry of [`XHD_RANGES_M`].
+    range_m: u32,
+    /// Distance covered by the samples, which is what the plotter scales the
+    /// image by. Not the same as `range_m` on every radar: a Furuno keeps
+    /// sweeping past the selected range and delivers the overshoot.
+    display_m: u32,
+}
+
+/// Turns a stream of mayara spokes into a stream of xHD spoke packets.
+pub(super) struct SpokeStream {
+    spokes_per_revolution: u32,
+    intensity: [u8; 256],
+    pending: Option<Pending>,
+}
+
+impl SpokeStream {
+    pub(super) fn new(spokes_per_revolution: u16, legend: &Legend) -> Self {
+        Self {
+            spokes_per_revolution: spokes_per_revolution.max(1) as u32,
+            intensity: intensity_table(legend),
+            pending: None,
+        }
+    }
+
+    /// Adopt a radar's spoke geometry and legend, which both settle only once
+    /// the radar has reported its model.
+    pub(super) fn reconfigure(&mut self, spokes_per_revolution: u16, legend: &Legend) {
+        let spokes_per_revolution = spokes_per_revolution.max(1) as u32;
+        if self.spokes_per_revolution != spokes_per_revolution {
+            self.spokes_per_revolution = spokes_per_revolution;
+            self.pending = None;
+        }
+        self.intensity = intensity_table(legend);
+    }
+
+    /// Feed one source spoke, appending finished xHD packets to `out`.
+    ///
+    /// A spoke is only complete once the following one shows where its sector
+    /// ends, so this emits the *previous* spoke.
+    pub(super) fn push(
+        &mut self,
+        angle: u32,
+        samples: &[u8],
+        range_m: u32,
+        display_m: u32,
+        out: &mut VecDeque<Vec<u8>>,
+    ) {
+        // Wrap before narrowing: an angle beyond a revolution — a radar that
+        // reports more than it claims, or one whose spoke count changed under
+        // us — would otherwise be truncated into an unrelated index.
+        let index = ((angle as u64 * SPOKES_PER_REVOLUTION as u64)
+            / self.spokes_per_revolution as u64
+            % SPOKES_PER_REVOLUTION as u64) as u16;
+
+        match &mut self.pending {
+            // Several source spokes fall in the same xHD spoke: keep the
+            // strongest echo of each sample rather than the last one.
+            Some(pending) if pending.index == index => {
+                let mut merged = [0u8; SAMPLES_PER_SPOKE];
+                resample(samples, &self.intensity, &mut merged);
+                for (slot, value) in pending.samples.iter_mut().zip(merged) {
+                    *slot = (*slot).max(value);
+                }
+                pending.range_m = range_m;
+                pending.display_m = display_m;
+            }
+            _ => {
+                let mut new = Pending {
+                    index,
+                    samples: [0u8; SAMPLES_PER_SPOKE],
+                    range_m,
+                    display_m,
+                };
+                resample(samples, &self.intensity, &mut new.samples);
+                if let Some(previous) = self.pending.replace(new) {
+                    emit(&previous, index, out);
+                }
+            }
+        }
+    }
+}
+
+/// Write the finished spoke to `out`, repeated across the sector it covers —
+/// every xHD spoke from its own index up to (but not including) `next_index`.
+fn emit(pending: &Pending, next_index: u16, out: &mut VecDeque<Vec<u8>>) {
+    let spokes = SPOKES_PER_REVOLUTION as u16;
+    let span = (next_index + spokes - pending.index) % spokes;
+    let repeat = span.clamp(1, MAX_REPEAT);
+
+    for offset in 0..repeat {
+        out.push_back(spoke_packet(pending, (pending.index + offset) % spokes));
+    }
+}
+
+/// Build one `0x0998` spoke packet.
+///
+/// ```text
+///   [0]  u32 packet_type         0x0998
+///   [4]  u32 payload_len
+///   [8]  u16 fill_1              1
+///   [10] u16 scan_length         0x02d3
+///   [12] u16 angle               1/8 degree units, 0..11519
+///   [14] u16 fill_2              0
+///   [16] u32 range_meters        range the plotter displays
+///   [20] u32 display_meters      distance the samples cover
+///   [24] u8  range_indicator     0 = range A
+///   [25] u8  dual_range          0
+///   [26] u16 scan_length_bytes_s sample count
+///   [28] u16 fills_4             0x0108
+///   [30] u32 scan_length_bytes_i sample count again
+///   [34] u16 fills_5             0
+///   [36] u8  line_data[]
+/// ```
+fn spoke_packet(pending: &Pending, index: u16) -> Vec<u8> {
+    let payload_len = (SPOKE_HEADER_SIZE - 8 + SAMPLES_PER_SPOKE) as u32;
+    let mut packet = Vec::with_capacity(SPOKE_HEADER_SIZE + SAMPLES_PER_SPOKE);
+
+    packet.extend_from_slice(&MSG_SPOKE.to_le_bytes());
+    packet.extend_from_slice(&payload_len.to_le_bytes());
+    packet.extend_from_slice(&FILL_1.to_le_bytes());
+    packet.extend_from_slice(&SCAN_LENGTH.to_le_bytes());
+    packet.extend_from_slice(&(index * ANGLE_UNITS_PER_SPOKE).to_le_bytes());
+    packet.extend_from_slice(&0u16.to_le_bytes()); // fill_2
+    packet.extend_from_slice(&pending.range_m.to_le_bytes());
+    packet.extend_from_slice(&pending.display_m.to_le_bytes());
+    packet.push(0); // range_indicator: range A
+    packet.push(0); // dual_range
+    packet.extend_from_slice(&(SAMPLES_PER_SPOKE as u16).to_le_bytes());
+    packet.extend_from_slice(&FILLS_4.to_le_bytes());
+    packet.extend_from_slice(&(SAMPLES_PER_SPOKE as u32).to_le_bytes());
+    packet.extend_from_slice(&0u16.to_le_bytes()); // fills_5
+    packet.extend_from_slice(&pending.samples);
+    packet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TargetMode;
+    use crate::radar::default_legend;
+
+    fn legend(pixel_values: u8, doppler_levels: u8) -> Legend {
+        default_legend(&TargetMode::None, doppler_levels, false, pixel_values)
+    }
+
+    /// Feed a whole revolution of source spokes and return the emitted packets.
+    fn revolution(spokes_per_revolution: u16, legend: &Legend, samples: &[u8]) -> Vec<Vec<u8>> {
+        let mut stream = SpokeStream::new(spokes_per_revolution, legend);
+        let mut out = VecDeque::new();
+        for angle in 0..spokes_per_revolution as u32 {
+            stream.push(angle, samples, 3704, 3704, &mut out);
+        }
+        // The last spoke stays pending until the next revolution starts.
+        stream.push(0, samples, 3704, 3704, &mut out);
+        out.into()
+    }
+
+    fn angle_of(packet: &[u8]) -> u16 {
+        u16::from_le_bytes([packet[12], packet[13]])
+    }
+
+    #[test]
+    fn nearest_range_snaps_to_the_table() {
+        assert_eq!(nearest_xhd_range(3704), 3704);
+        assert_eq!(nearest_xhd_range(6000), 5556);
+        assert_eq!(nearest_xhd_range(7000), 7408);
+        assert_eq!(nearest_xhd_range(0), 232);
+        assert_eq!(nearest_xhd_range(u32::MAX), 88896);
+    }
+
+    #[test]
+    fn a_revolution_yields_one_full_xhd_revolution_whatever_the_source() {
+        let legend = legend(16, 0);
+        for spokes in [250u16, 720, 1440, 2048, 4096, 8192] {
+            let packets = revolution(spokes, &legend, &[1u8; 512]);
+            assert_eq!(
+                packets.len(),
+                SPOKES_PER_REVOLUTION,
+                "{spokes} spokes/revolution"
+            );
+            let angles: Vec<u16> = packets.iter().map(|p| angle_of(p)).collect();
+            let expected: Vec<u16> = (0..SPOKES_PER_REVOLUTION as u16)
+                .map(|i| i * ANGLE_UNITS_PER_SPOKE)
+                .collect();
+            assert_eq!(angles, expected, "{spokes} spokes/revolution");
+        }
+    }
+
+    #[test]
+    fn an_angle_beyond_a_revolution_wraps_instead_of_truncating() {
+        let legend = legend(16, 0);
+        let mut stream = SpokeStream::new(2048, &legend);
+        let mut out = VecDeque::new();
+        // Far enough past a revolution that the quotient does not fit a u16:
+        // 100000 × 1440 / 2048 = 70312, which wraps to spoke 1192. Narrowing
+        // before the wrap would truncate to 4776 and land on spoke 456.
+        stream.push(100_000, &[1u8; 512], 3704, 3704, &mut out);
+        stream.push(100_001, &[1u8; 512], 3704, 3704, &mut out);
+
+        assert_eq!(angle_of(&out[0]), 1192 * ANGLE_UNITS_PER_SPOKE);
+    }
+
+    #[test]
+    fn angle_stays_within_the_wire_range() {
+        let legend = legend(16, 0);
+        for packet in revolution(8192, &legend, &[1u8; 512]) {
+            assert!(angle_of(&packet) < 11520);
+        }
+    }
+
+    #[test]
+    fn packet_carries_the_constants_a_plotter_insists_on() {
+        let legend = legend(16, 0);
+        let packet = revolution(1440, &legend, &[0u8; 512]).remove(0);
+
+        assert_eq!(packet.len(), SPOKE_HEADER_SIZE + SAMPLES_PER_SPOKE);
+        assert_eq!(
+            u32::from_le_bytes(packet[0..4].try_into().unwrap()),
+            MSG_SPOKE
+        );
+        assert_eq!(
+            u32::from_le_bytes(packet[4..8].try_into().unwrap()) as usize,
+            SPOKE_HEADER_SIZE - 8 + SAMPLES_PER_SPOKE
+        );
+        assert_eq!(
+            u16::from_le_bytes(packet[8..10].try_into().unwrap()),
+            FILL_1
+        );
+        assert_eq!(
+            u16::from_le_bytes(packet[28..30].try_into().unwrap()),
+            FILLS_4
+        );
+        assert_eq!(
+            u16::from_le_bytes(packet[26..28].try_into().unwrap()) as usize,
+            SAMPLES_PER_SPOKE
+        );
+    }
+
+    #[test]
+    fn range_fields_keep_display_range_apart_from_selected_range() {
+        let legend = legend(16, 0);
+        let mut stream = SpokeStream::new(1440, &legend);
+        let mut out = VecDeque::new();
+        // A Furuno at 3 NM sweeps well past the range it displays.
+        stream.push(0, &[1u8; 512], 5556, 9902, &mut out);
+        stream.push(1, &[1u8; 512], 5556, 9902, &mut out);
+
+        let packet = out.pop_front().unwrap();
+        assert_eq!(u32::from_le_bytes(packet[16..20].try_into().unwrap()), 5556);
+        assert_eq!(u32::from_le_bytes(packet[20..24].try_into().unwrap()), 9902);
+    }
+
+    #[test]
+    fn legend_indices_scale_onto_the_full_intensity_range() {
+        let legend = legend(16, 0);
+        let mut stream = SpokeStream::new(1440, &legend);
+        let mut out = VecDeque::new();
+        let samples: Vec<u8> = (0..16).collect();
+        stream.push(0, &samples, 3704, 3704, &mut out);
+        stream.push(1, &samples, 3704, 3704, &mut out);
+
+        let packet = out.pop_front().unwrap();
+        let data = &packet[SPOKE_HEADER_SIZE..];
+        assert_eq!(data[0], 0, "no return stays black");
+        assert_eq!(
+            data[SAMPLES_PER_SPOKE - 1],
+            u8::MAX,
+            "strongest legend index becomes the strongest echo"
+        );
+    }
+
+    #[test]
+    fn doppler_targets_become_strong_echoes() {
+        let legend = legend(16, 4);
+        let (first, count) = legend.doppler_approaching.expect("doppler legend");
+        let mut stream = SpokeStream::new(1440, &legend);
+        let mut out = VecDeque::new();
+        let samples = vec![first + count - 1; 8];
+        stream.push(0, &samples, 3704, 3704, &mut out);
+        stream.push(1, &samples, 3704, 3704, &mut out);
+
+        let packet = out.pop_front().unwrap();
+        assert_eq!(packet[SPOKE_HEADER_SIZE], u8::MAX);
+    }
+
+    #[test]
+    fn downsampling_keeps_the_strongest_sample() {
+        let legend = legend(16, 0);
+        let mut stream = SpokeStream::new(1440, &legend);
+        let mut out = VecDeque::new();
+        // One strong sample among 2048, far more than fit in a spoke: it has
+        // to survive the resampling.
+        let mut samples = vec![0u8; 2048];
+        samples[1000] = 15;
+        stream.push(0, &samples, 3704, 3704, &mut out);
+        stream.push(1, &samples, 3704, 3704, &mut out);
+
+        let packet = out.pop_front().unwrap();
+        assert!(packet[SPOKE_HEADER_SIZE..].contains(&u8::MAX));
+    }
+
+    #[test]
+    fn merged_spokes_keep_the_strongest_echo() {
+        let legend = legend(16, 0);
+        // 2880 source spokes: two land on every xHD spoke.
+        let mut stream = SpokeStream::new(2880, &legend);
+        let mut out = VecDeque::new();
+        stream.push(0, &[15u8; 695], 3704, 3704, &mut out);
+        stream.push(1, &[0u8; 695], 3704, 3704, &mut out);
+        stream.push(2, &[0u8; 695], 3704, 3704, &mut out);
+
+        let packet = out.pop_front().unwrap();
+        assert_eq!(packet[SPOKE_HEADER_SIZE], u8::MAX);
+    }
+
+    #[test]
+    fn a_gap_wider_than_the_repeat_limit_is_not_smeared() {
+        let legend = legend(16, 0);
+        let mut stream = SpokeStream::new(1440, &legend);
+        let mut out = VecDeque::new();
+        stream.push(0, &[1u8; 512], 3704, 3704, &mut out);
+        stream.push(1000, &[1u8; 512], 3704, 3704, &mut out);
+
+        assert_eq!(out.len(), MAX_REPEAT as usize);
+    }
+
+    #[test]
+    fn empty_spoke_data_yields_an_empty_spoke() {
+        let legend = legend(16, 0);
+        let mut stream = SpokeStream::new(1440, &legend);
+        let mut out = VecDeque::new();
+        stream.push(0, &[], 3704, 3704, &mut out);
+        stream.push(1, &[], 3704, 3704, &mut out);
+
+        let packet = out.pop_front().unwrap();
+        assert!(packet[SPOKE_HEADER_SIZE..].iter().all(|&v| v == 0));
+    }
+}

--- a/src/lib/output/garmin_xhd/mod.rs
+++ b/src/lib/output/garmin_xhd/mod.rs
@@ -316,11 +316,23 @@ pub(super) mod tests {
 
     /// Controls of a radar that offers everything the bridge can translate.
     pub(super) fn controls() -> SharedControls {
+        controls_with(
+            &[ControlId::Range],
+            &[ControlId::Gain, ControlId::Sea, ControlId::Rain],
+        )
+    }
+
+    /// Controls as a brand registers them: those in `manual` have no automatic
+    /// mode, those in `automatic` do. `Power` comes with every radar, added by
+    /// [`SharedControls::new`].
+    pub(super) fn controls_with(manual: &[ControlId], automatic: &[ControlId]) -> SharedControls {
         use crate::radar::settings::{HAS_AUTO_NOT_ADJUSTABLE, new_auto, new_numeric};
 
         let mut controls = HashMap::new();
-        new_numeric(ControlId::Range, 0., 100_000.).build(&mut controls);
-        for id in [ControlId::Gain, ControlId::Sea, ControlId::Rain] {
+        for &id in manual {
+            new_numeric(id, 0., 100_000.).build(&mut controls);
+        }
+        for &id in automatic {
             new_auto(id, 0., 100., HAS_AUTO_NOT_ADJUSTABLE).build(&mut controls);
         }
         SharedControls::new(

--- a/src/lib/output/garmin_xhd/mod.rs
+++ b/src/lib/output/garmin_xhd/mod.rs
@@ -1,0 +1,395 @@
+//! Garmin xHD output bridge.
+//!
+//! Emulates a Garmin GMR xHD radar on the Garmin Marine Network so a Garmin
+//! chartplotter can display the picture of any radar mayara supports. The
+//! plotter discovers the emulated radar exactly as it would a real xHD, and
+//! the controls it offers (range, gain, sea, rain, transmit) are translated
+//! into mayara control changes on the source radar.
+//!
+//! Four tasks run concurrently:
+//!
+//! | Task      | Direction | Endpoint             | Contents                     |
+//! |-----------|-----------|----------------------|------------------------------|
+//! | `cdm`     | out       | `239.254.2.2:50050`  | discovery heartbeat `0x038e` |
+//! | `status`  | out       | `239.254.2.0:50100`  | settings/state reports       |
+//! | `spokes`  | out       | `239.254.2.0:50102`  | sweep data `0x0998`          |
+//! | `command` | in        | `<local addr>:50101` | control changes from plotter |
+//!
+//! Only one radar can be bridged per mayara instance: the emulated radar owns
+//! the fixed xHD multicast groups and ports, so a second one would interleave
+//! its spokes with the first. The first radar discovered wins; use `--brand`
+//! to steer that choice on a boat with several radars.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use network_interface::{NetworkInterface, NetworkInterfaceConfig};
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
+
+use crate::Brand;
+use crate::brand::garmin::protocol::GARMIN_NETMASK;
+use crate::network;
+use crate::radar::settings::{ControlId, SharedControls};
+use crate::radar::{RadarInfo, SharedRadars};
+
+mod cdm;
+mod command;
+mod convert;
+mod spokes;
+mod status;
+
+use convert::nearest_xhd_range;
+
+/// Base address of the Garmin Marine Network, `172.16.0.0/12` together with
+/// [`GARMIN_NETMASK`].
+const GARMIN_SUBNET: Ipv4Addr = Ipv4Addr::new(172, 16, 0, 0);
+
+/// Range reported until the source radar tells us what it is really doing
+/// (2 NM, an entry of the xHD range table).
+const DEFAULT_RANGE_M: u32 = 3704;
+
+/// How long the range the plotter asked for overrides the range the radar
+/// reports. Long enough for a radar to act on the command and report back,
+/// short enough that a command the radar ignored does not stick.
+const RANGE_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Key of the radar being bridged. The xHD multicast groups and ports are
+/// fixed, so exactly one radar can be emulated per process.
+static BRIDGED_RADAR: OnceLock<String> = OnceLock::new();
+
+/// Address the emulated radar announces itself from, so the locator can tell
+/// mayara's own emulation apart from a real Garmin radar.
+static EMULATED_SOURCE: OnceLock<Ipv4Addr> = OnceLock::new();
+
+/// Whether `addr` is the emulated radar of this mayara. See
+/// [`crate::locator::is_own_emulated_radar`], the only caller.
+pub(crate) fn is_emulated_source(addr: &Ipv4Addr) -> bool {
+    EMULATED_SOURCE.get() == Some(addr)
+}
+
+/// Gain mode as the enhanced protocol expresses it.
+pub(super) const GAIN_MODE_MANUAL: u8 = 0;
+pub(super) const GAIN_MODE_AUTO: u8 = 2;
+
+/// Sea clutter mode as the enhanced protocol expresses it.
+pub(super) const SEA_MODE_OFF: u8 = 0;
+pub(super) const SEA_MODE_MANUAL: u8 = 1;
+pub(super) const SEA_MODE_AUTO: u8 = 2;
+
+/// Command acknowledgements that may queue up before the report stream gets
+/// round to them. The plotter cannot change more settings at once than this.
+const ECHO_DEPTH: usize = 32;
+
+/// State the outgoing tasks share with the command listener.
+pub(super) struct Shared {
+    controls: SharedControls,
+    /// Range the plotter last asked for, and when we stop insisting on it.
+    /// Without this the report stream would keep announcing the old range for
+    /// as long as the radar needs to act on the command, and the plotter would
+    /// snap its range ring back to where it was.
+    pending_range: Mutex<Option<(u32, Instant)>>,
+    /// Command acknowledgements waiting to go out on the report stream, which
+    /// owns the socket they have to be sent from.
+    echo_tx: mpsc::Sender<Vec<u8>>,
+}
+
+impl Shared {
+    fn new(controls: SharedControls) -> (Self, mpsc::Receiver<Vec<u8>>) {
+        let (echo_tx, echo_rx) = mpsc::channel(ECHO_DEPTH);
+        (
+            Self {
+                controls,
+                pending_range: Mutex::new(None),
+                echo_tx,
+            },
+            echo_rx,
+        )
+    }
+
+    /// Acknowledge a command by having the report stream send `packet`.
+    fn echo(&self, packet: Vec<u8>) {
+        if self.echo_tx.try_send(packet).is_err() {
+            log::warn!("Garmin xHD: dropped a command acknowledgement");
+        }
+    }
+
+    /// Value of a numeric control on the source radar.
+    fn control(&self, id: ControlId) -> Option<f64> {
+        self.controls.get(&id).and_then(|c| c.value)
+    }
+
+    /// Whether a control is in automatic mode.
+    fn control_auto(&self, id: ControlId) -> bool {
+        self.controls
+            .get(&id)
+            .and_then(|c| c.auto)
+            .unwrap_or_default()
+    }
+
+    /// Range to report to the plotter, always an entry of the xHD range table.
+    fn range_m(&self) -> u32 {
+        // A radar that has not reported a range yet leaves the control at
+        // zero, which is not a range the plotter can be told about.
+        let radar_range = self
+            .control(ControlId::Range)
+            .filter(|&meters| meters > 0.0)
+            .map(|meters| nearest_xhd_range(meters as u32));
+
+        let mut pending = self.pending_range.lock().unwrap();
+        if let Some((wanted, until)) = *pending {
+            if radar_range == Some(wanted) || Instant::now() >= until {
+                *pending = None;
+            } else {
+                return wanted;
+            }
+        }
+        radar_range.unwrap_or(DEFAULT_RANGE_M)
+    }
+
+    fn set_pending_range(&self, range_m: u32) {
+        *self.pending_range.lock().unwrap() =
+            Some((range_m, Instant::now() + RANGE_CONFIRM_TIMEOUT));
+    }
+}
+
+/// TLV packet: 4-byte message id, 4-byte payload length, payload.
+fn packet(msg_id: u32, payload: &[u8]) -> Vec<u8> {
+    let mut p = Vec::with_capacity(8 + payload.len());
+    p.extend_from_slice(&msg_id.to_le_bytes());
+    p.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    p.extend_from_slice(payload);
+    p
+}
+
+fn packet_u8(msg_id: u32, value: u8) -> Vec<u8> {
+    packet(msg_id, &[value])
+}
+
+fn packet_u16(msg_id: u32, value: u16) -> Vec<u8> {
+    packet(msg_id, &value.to_le_bytes())
+}
+
+fn packet_u32(msg_id: u32, value: u32) -> Vec<u8> {
+    packet(msg_id, &value.to_le_bytes())
+}
+
+/// Create one of the outgoing multicast sockets.
+///
+/// The socket binds the well-known port it also sends to: the plotter
+/// identifies the stream by its source port, and an ephemeral one makes it
+/// ignore the traffic. The outgoing interface is pinned rather than left to
+/// the routing table, which would send the traffic out of the default route
+/// on a host whose Garmin network is not the one it reaches the world by. The
+/// TTL keeps the traffic on this segment.
+///
+/// Multicast loopback is left on, so a display on the same host — a second
+/// mayara, or an OpenCPN with radar_pi — sees the emulated radar just as one
+/// across the network does. mayara's own locator ignores what mayara sends,
+/// which is what keeps it from discovering the radar it is emulating.
+fn multicast_send(dest: &SocketAddr, local_addr: Ipv4Addr) -> io::Result<UdpSocket> {
+    let SocketAddr::V4(dest) = dest else {
+        unreachable!("Garmin multicast addresses are IPv4");
+    };
+    let socket = network::create_connected_send(dest, &local_addr)?;
+    let options = socket2::SockRef::from(&socket);
+    options.set_multicast_if_v4(&local_addr)?;
+    options.set_multicast_ttl_v4(1)?;
+    Ok(socket)
+}
+
+/// Whether `ip` is part of the Garmin Marine Network.
+fn in_garmin_network(ip: Ipv4Addr) -> bool {
+    network::match_ipv4(&ip, &GARMIN_SUBNET, &GARMIN_NETMASK)
+}
+
+/// Local address to emulate the radar from.
+///
+/// Preferred is an address on the same NIC as the source radar: that is how a
+/// single-NIC installation is set up, and it cannot pick up a container bridge
+/// address by accident. Failing that, any address in `172.16.0.0/16` qualifies
+/// — the range Garmin devices actually use, whereas the `172.17`–`172.31` half
+/// of the `/12` is where Docker and friends live.
+fn local_addr(radar_nic: Ipv4Addr) -> Option<Ipv4Addr> {
+    fn addresses(iface: &NetworkInterface) -> impl Iterator<Item = Ipv4Addr> + '_ {
+        iface.addr.iter().filter_map(|a| match a.ip() {
+            IpAddr::V4(ip) => Some(ip),
+            IpAddr::V6(_) => None,
+        })
+    }
+
+    let interfaces = NetworkInterface::show().ok()?;
+
+    let radar_interface = interfaces
+        .iter()
+        .find(|iface| addresses(iface).any(|ip| ip == radar_nic));
+    if let Some(iface) = radar_interface
+        && let Some(ip) = addresses(iface).find(|ip| in_garmin_network(*ip))
+    {
+        return Some(ip);
+    }
+
+    let garmin_prefix = &GARMIN_SUBNET.octets()[..2];
+    interfaces
+        .iter()
+        .flat_map(addresses)
+        .find(|ip| ip.octets()[..2] == *garmin_prefix)
+}
+
+/// Start the bridge for `info`, unless another radar is already being bridged
+/// or the host has no address on the Garmin Marine Network.
+pub(crate) fn spawn(info: &RadarInfo, radars: &SharedRadars, subsys: &SubsystemHandle) {
+    let key = info.key();
+
+    if info.brand == Brand::Garmin {
+        log::info!("{key}: Garmin xHD output not started: radar is a Garmin already");
+        return;
+    }
+
+    let Some(local_addr) = local_addr(info.nic_addr) else {
+        log::error!(
+            "{key}: Garmin xHD output not started: no address on the Garmin Marine Network \
+             ({GARMIN_SUBNET}/12) found; give the radar NIC a second address in 172.16.x.x"
+        );
+        return;
+    };
+
+    let bridged = BRIDGED_RADAR.get_or_init(|| key.clone());
+    if bridged != &key {
+        log::info!("{key}: Garmin xHD output not started: already emulating {bridged}");
+        return;
+    }
+
+    log::info!("{key}: Garmin xHD output emulating a GMR xHD on {local_addr}");
+    let _ = EMULATED_SOURCE.set(local_addr);
+
+    let (shared, echo_rx) = Shared::new(info.controls.clone());
+    let shared = Arc::new(shared);
+
+    subsys.start(SubsystemBuilder::new(
+        format!("{key}/GarminXhd/CDM"),
+        async move |s: &mut SubsystemHandle| cdm::run(local_addr, s).await,
+    ));
+
+    let status_shared = shared.clone();
+    subsys.start(SubsystemBuilder::new(
+        format!("{key}/GarminXhd/Status"),
+        async move |s: &mut SubsystemHandle| {
+            status::run(local_addr, status_shared, echo_rx, s).await
+        },
+    ));
+
+    let spokes_shared = shared.clone();
+    let spokes_radars = radars.clone();
+    let spokes_key = key.clone();
+    let message_rx = info.message_tx.subscribe();
+    subsys.start(SubsystemBuilder::new(
+        format!("{key}/GarminXhd/Spokes"),
+        async move |s: &mut SubsystemHandle| {
+            spokes::run(
+                local_addr,
+                spokes_key,
+                spokes_radars,
+                message_rx,
+                spokes_shared,
+                s,
+            )
+            .await
+        },
+    ));
+
+    subsys.start(SubsystemBuilder::new(
+        format!("{key}/GarminXhd/Command"),
+        async move |s: &mut SubsystemHandle| command::run(local_addr, shared, s).await,
+    ));
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+    use crate::Cli;
+    use clap::Parser as _;
+    use std::collections::HashMap;
+
+    /// Controls of a radar that offers everything the bridge can translate.
+    pub(super) fn controls() -> SharedControls {
+        use crate::radar::settings::{HAS_AUTO_NOT_ADJUSTABLE, new_auto, new_numeric};
+
+        let mut controls = HashMap::new();
+        new_numeric(ControlId::Range, 0., 100_000.).build(&mut controls);
+        for id in [ControlId::Gain, ControlId::Sea, ControlId::Rain] {
+            new_auto(id, 0., 100., HAS_AUTO_NOT_ADJUSTABLE).build(&mut controls);
+        }
+        SharedControls::new(
+            "test".to_string(),
+            tokio::sync::broadcast::Sender::new(1),
+            &Cli::parse_from(["mayara"]),
+            controls,
+        )
+    }
+
+    #[test]
+    fn range_falls_back_until_the_radar_reports_one() {
+        let (shared, _echo_rx) = Shared::new(controls());
+        assert_eq!(shared.range_m(), DEFAULT_RANGE_M);
+    }
+
+    #[test]
+    fn reported_range_is_snapped_to_the_xhd_table() {
+        let (shared, _echo_rx) = Shared::new(controls());
+        shared.controls.set(&ControlId::Range, 5000., None).unwrap();
+        assert_eq!(shared.range_m(), 5556);
+    }
+
+    #[test]
+    fn the_range_the_plotter_asked_for_holds_until_the_radar_confirms() {
+        let (shared, _echo_rx) = Shared::new(controls());
+        shared.controls.set(&ControlId::Range, 3704., None).unwrap();
+
+        shared.set_pending_range(11112);
+        assert_eq!(shared.range_m(), 11112, "the radar has not acted yet");
+
+        shared
+            .controls
+            .set(&ControlId::Range, 11112., None)
+            .unwrap();
+        assert_eq!(shared.range_m(), 11112);
+
+        // Once confirmed, the radar is back in charge of what is reported.
+        shared.controls.set(&ControlId::Range, 3704., None).unwrap();
+        assert_eq!(shared.range_m(), 3704);
+    }
+
+    #[test]
+    fn a_range_the_radar_never_takes_stops_being_reported() {
+        let (shared, _echo_rx) = Shared::new(controls());
+        shared.controls.set(&ControlId::Range, 3704., None).unwrap();
+
+        *shared.pending_range.lock().unwrap() = Some((11112, Instant::now()));
+        assert_eq!(shared.range_m(), 3704);
+    }
+
+    #[test]
+    fn packets_carry_message_id_length_and_value() {
+        assert_eq!(packet_u8(0x0919, 1), vec![0x19, 0x09, 0, 0, 1, 0, 0, 0, 1]);
+        assert_eq!(
+            packet_u16(0x0925, 0x1234),
+            vec![0x25, 0x09, 0, 0, 2, 0, 0, 0, 0x34, 0x12]
+        );
+        assert_eq!(
+            packet_u32(0x091e, 3704),
+            vec![0x1e, 0x09, 0, 0, 4, 0, 0, 0, 0x78, 0x0e, 0, 0]
+        );
+    }
+
+    #[test]
+    fn garmin_network_covers_the_whole_slash_12() {
+        assert!(in_garmin_network(Ipv4Addr::new(172, 16, 2, 0)));
+        assert!(in_garmin_network(Ipv4Addr::new(172, 31, 1, 1)));
+        assert!(!in_garmin_network(Ipv4Addr::new(172, 15, 255, 255)));
+        assert!(!in_garmin_network(Ipv4Addr::new(192, 168, 1, 1)));
+    }
+}

--- a/src/lib/output/garmin_xhd/spokes.rs
+++ b/src/lib/output/garmin_xhd/spokes.rs
@@ -1,0 +1,238 @@
+//! Sweep data stream of the emulated xHD radar (`239.254.2.0:50102`).
+//!
+//! Source radars deliver spokes in bursts — a Furuno hands over some 1500 of
+//! them every 450 ms — while a real xHD trickles them out one at a time. A
+//! plotter fed the bursts draws a sweep that jumps and then stalls, so spokes
+//! are buffered and paced out at the rate they come in.
+
+use std::collections::VecDeque;
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use protobuf::Message as _;
+use tokio::sync::broadcast;
+use tokio_graceful_shutdown::SubsystemHandle;
+
+use crate::brand::garmin::protocol::{DATA_ADDRESS, SPOKES_PER_REVOLUTION};
+use crate::protos::RadarMessage::RadarMessage;
+use crate::radar::{RadarError, SharedRadars};
+
+use super::convert::SpokeStream;
+use super::{Shared, multicast_send};
+
+/// Buffer depth, in xHD spokes. Two revolutions is more delay than any radar's
+/// burst needs; beyond it the network is not keeping up and the oldest spokes
+/// are worth less than the newest.
+const QUEUE_MAX: usize = SPOKES_PER_REVOLUTION * 2;
+
+/// Longest gap between bursts that still says something about how fast spokes
+/// arrive. A radar in standby sends nothing for minutes; pacing the first
+/// burst after that by how long the silence lasted would trickle it out.
+const MAX_BURST_SPACING: Duration = Duration::from_secs(1);
+
+/// Pacing bounds, from an antenna turning implausibly fast to one turning
+/// implausibly slow — 1440 spokes at 4 ms each is a revolution in under 6
+/// seconds, slower than any radar mayara supports.
+const MIN_INTERVAL: Duration = Duration::from_micros(100);
+const MAX_INTERVAL: Duration = Duration::from_millis(4);
+
+/// How often the radar's legend and spoke geometry are picked up again. Both
+/// only settle once the radar has reported which model it is.
+const RECONFIGURE_INTERVAL: Duration = Duration::from_secs(5);
+
+pub(super) async fn run(
+    local_addr: Ipv4Addr,
+    key: String,
+    radars: SharedRadars,
+    mut message_rx: broadcast::Receiver<Bytes>,
+    shared: Arc<Shared>,
+    subsys: &mut SubsystemHandle,
+) -> Result<(), RadarError> {
+    let socket = match multicast_send(&DATA_ADDRESS, local_addr) {
+        Ok(socket) => socket,
+        Err(e) => {
+            log::error!("{key}: Garmin xHD spokes: cannot open socket: {e}");
+            return Ok(());
+        }
+    };
+
+    let Some(info) = radars.get_by_key(&key) else {
+        log::error!("{key}: Garmin xHD spokes: radar is gone");
+        return Ok(());
+    };
+    let mut stream = SpokeStream::new(info.spokes_per_revolution, &info.get_legend());
+    let mut reconfigured = Instant::now();
+
+    let mut queue: VecDeque<Vec<u8>> = VecDeque::new();
+    let mut interval = MAX_INTERVAL;
+    let mut next_send = Instant::now();
+    let mut last_batch = Instant::now();
+
+    loop {
+        while let Some(packet) = queue.front() {
+            if Instant::now() < next_send {
+                break;
+            }
+            if let Err(e) = socket.send(packet).await {
+                log::warn!("{key}: Garmin xHD spokes: send failed: {e}");
+            }
+            queue.pop_front();
+            next_send += interval;
+        }
+
+        // With an empty queue there is nothing to pace, so wait for the next
+        // batch and start the clock when it arrives.
+        let wait = if queue.is_empty() {
+            None
+        } else {
+            Some(next_send.saturating_duration_since(Instant::now()))
+        };
+
+        tokio::select! {
+            biased;
+            _ = subsys.on_shutdown_requested() => return Ok(()),
+            _ = tokio::time::sleep(wait.unwrap_or_default()), if wait.is_some() => {}
+            message = message_rx.recv() => {
+                let bytes = match message {
+                    Ok(bytes) => bytes,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        log::warn!("{key}: Garmin xHD spokes: dropped {n} messages");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                };
+
+                if reconfigured.elapsed() >= RECONFIGURE_INTERVAL {
+                    reconfigured = Instant::now();
+                    if let Some(info) = radars.get_by_key(&key) {
+                        stream.reconfigure(info.spokes_per_revolution, &info.get_legend());
+                    }
+                }
+
+                let was_empty = queue.is_empty();
+                enqueue(&bytes, &shared, &mut stream, &mut queue, &key);
+
+                // Drain what is buffered over the time the next burst is
+                // expected to take, which is how long this one took to arrive.
+                let elapsed = last_batch.elapsed().min(MAX_BURST_SPACING);
+                last_batch = Instant::now();
+                if !queue.is_empty() {
+                    interval = (elapsed / queue.len() as u32).clamp(MIN_INTERVAL, MAX_INTERVAL);
+                }
+                if was_empty {
+                    next_send = Instant::now();
+                }
+            }
+        }
+    }
+}
+
+/// Convert one broadcast message into xHD spokes.
+fn enqueue(
+    bytes: &[u8],
+    shared: &Shared,
+    stream: &mut SpokeStream,
+    queue: &mut VecDeque<Vec<u8>>,
+    key: &str,
+) {
+    let message = match RadarMessage::parse_from_bytes(bytes) {
+        Ok(message) => message,
+        Err(e) => {
+            log::warn!("{key}: Garmin xHD spokes: cannot parse message: {e}");
+            return;
+        }
+    };
+
+    let range_m = shared.range_m();
+    for spoke in &message.spokes {
+        // The plotter scales the image by the distance the samples cover, so
+        // a spoke that does not say what that is cannot be drawn.
+        if spoke.range == 0 {
+            continue;
+        }
+        stream.push(spoke.angle, &spoke.data, range_m, spoke.range, queue);
+    }
+
+    if queue.len() > QUEUE_MAX {
+        let dropped = queue.len() - QUEUE_MAX;
+        queue.drain(..dropped);
+        log::warn!("{key}: Garmin xHD spokes: behind by {dropped} spokes, dropping oldest");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TargetMode;
+    use crate::output::garmin_xhd::tests::controls;
+    use crate::protos::RadarMessage::radar_message::Spoke;
+    use crate::radar::default_legend;
+
+    /// A batch of spokes as a brand would broadcast it, serialized.
+    fn message(spokes: impl IntoIterator<Item = (u32, u32)>) -> Vec<u8> {
+        let mut message = RadarMessage::new();
+        for (angle, range) in spokes {
+            let mut spoke = Spoke::new();
+            spoke.angle = angle;
+            spoke.range = range;
+            spoke.data = vec![1u8; 512];
+            message.spokes.push(spoke);
+        }
+        message.write_to_bytes().expect("serializable")
+    }
+
+    fn fixture() -> (Arc<Shared>, SpokeStream, VecDeque<Vec<u8>>) {
+        let (shared, _echo_rx) = Shared::new(controls());
+        let legend = default_legend(&TargetMode::None, 0, false, 16);
+        (
+            Arc::new(shared),
+            SpokeStream::new(1440, &legend),
+            VecDeque::new(),
+        )
+    }
+
+    #[test]
+    fn a_message_that_is_not_a_radar_message_is_dropped() {
+        let (shared, mut stream, mut queue) = fixture();
+        enqueue(
+            b"\xff\xff not protobuf",
+            &shared,
+            &mut stream,
+            &mut queue,
+            "t",
+        );
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn spokes_without_a_range_are_skipped() {
+        let (shared, mut stream, mut queue) = fixture();
+        // Only the third spoke says how far its samples reach, and a spoke is
+        // emitted once the following one bounds it — so nothing comes out.
+        enqueue(
+            &message([(0, 0), (1, 0), (2, 3704)]),
+            &shared,
+            &mut stream,
+            &mut queue,
+            "t",
+        );
+        assert!(queue.is_empty());
+
+        enqueue(&message([(3, 3704)]), &shared, &mut stream, &mut queue, "t");
+        assert_eq!(queue.len(), 1, "the two ranged spokes bound one xHD spoke");
+    }
+
+    #[test]
+    fn a_queue_that_runs_away_is_trimmed_to_the_newest_spokes() {
+        let (shared, mut stream, mut queue) = fixture();
+        let batch = message((0..1440).map(|angle| (angle, 3704)));
+
+        for _ in 0..3 {
+            enqueue(&batch, &shared, &mut stream, &mut queue, "t");
+        }
+
+        assert_eq!(queue.len(), QUEUE_MAX);
+    }
+}

--- a/src/lib/output/garmin_xhd/status.rs
+++ b/src/lib/output/garmin_xhd/status.rs
@@ -1,0 +1,462 @@
+//! Report stream of the emulated xHD radar (`239.254.2.0:50100`).
+//!
+//! A real xHD broadcasts its entire state as a stream of single-value reports,
+//! and the plotter mirrors what it hears there: a setting the radar never
+//! reports back is a setting the plotter shows as unavailable. The same set is
+//! sent once a second, and again immediately after the plotter changes
+//! something so its own commands are confirmed without a wait.
+
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio_graceful_shutdown::SubsystemHandle;
+
+use crate::brand::garmin::capabilities::{GarminCapabilities, cap};
+use crate::brand::garmin::protocol::*;
+use crate::radar::settings::ControlId;
+use crate::radar::{Power, RadarError};
+
+use super::convert::XHD_RANGES_M;
+use super::{
+    GAIN_MODE_AUTO, GAIN_MODE_MANUAL, SEA_MODE_AUTO, SEA_MODE_MANUAL, SEA_MODE_OFF, Shared,
+    multicast_send, packet, packet_u8, packet_u16, packet_u32,
+};
+
+/// Interval between full state broadcasts.
+const REPORT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// What the emulated radar claims it can do — which is exactly what the bridge
+/// translates into a control change on the source radar, no more.
+///
+/// A display decides from this which controls to offer, so a bit claimed here
+/// and ignored in `command.rs` becomes a knob on the plotter that does
+/// nothing. Notably absent is the Range B block: the bridge presents a single
+/// range whatever the source radar can do. The GMR xHD in
+/// `radar-recordings/garmin/garmin_xhd.pcap` claims dual range even though it
+/// has none — the MFD appears to set that whole word unconditionally — and a
+/// display that believes it offers a second range no spoke ever arrives on.
+///
+/// The list a Garmin MFD hardcodes for a legacy HD radar, which is likewise
+/// single-range and has no Doppler, is `capabilities::LEGACY_HD_BITS`; this is
+/// that set less the features the bridge does not forward.
+const EMULATED_CAPABILITIES: &[u32] = &[
+    cap::TRANSMIT_MODE,
+    cap::RANGE_A,
+    cap::RANGE_A_GAIN_MODE,
+    cap::RANGE_A_GAIN,
+    cap::RANGE_A_RAIN_MODE,
+    cap::RANGE_A_RAIN_GAIN,
+    cap::RANGE_A_SEA_MODE,
+    cap::RANGE_A_SEA_GAIN,
+];
+
+// Reports a real xHD sends whose meaning is not documented anywhere, and for
+// which mayara has no equivalent state. They are replayed with the values seen
+// in the capture: leaving them out makes the plotter wait for a radar that
+// never finishes starting up.
+const MSG_SCAN_TYPE_B: u32 = 0x0912;
+const MSG_SCAN_TYPE_C: u32 = 0x0913;
+const MSG_ANTENNA_HEIGHT: u32 = 0x0928;
+const MSG_ANTENNA_FORWARD: u32 = 0x0929;
+const MSG_ANTENNA_STARBOARD: u32 = 0x092a;
+const MSG_ANTENNA_POWER: u32 = 0x092b;
+const MSG_TUNE_FINE: u32 = 0x0951;
+const MSG_TUNE_COARSE: u32 = 0x0952;
+const MSG_TUNE_MODE: u32 = 0x0953;
+const MSG_TRIGGER_PERIOD: u32 = 0x0994;
+const MSG_TRIGGER_DELAY: u32 = 0x0995;
+const MSG_TRIGGER_PERIOD_B: u32 = 0x0996;
+const MSG_STATUS_A: u32 = 0x099c;
+const MSG_STATUS_B: u32 = 0x099d;
+const MSG_STATUS_C: u32 = 0x099e;
+
+/// Antenna position, in centimetres. An xHD reports where it is mounted; the
+/// Signal K API models that as vessel configuration rather than radar state,
+/// so plausible values are sent instead of nothing.
+const ANTENNA_HEIGHT_CM: u16 = 350;
+const ANTENNA_FORWARD_CM: u16 = 150;
+const ANTENNA_STARBOARD_CM: u16 = 0;
+
+// Values of the reports above, as the captured GMR xHD sends them. mayara has
+// no equivalent state to derive any of these from, and they describe the
+// transmitter rather than anything the source radar could contribute.
+const ANTENNA_POWER: u16 = 0x2134;
+const TRIGGER_PERIOD: u32 = 0x0000_09b4;
+const TRIGGER_DELAY: u32 = 0x0000_1710;
+const TRIGGER_PERIOD_B: u32 = 0x0000_16f8;
+const TUNE_FINE: u8 = 2;
+const TUNE_COARSE: u8 = 0;
+const TUNE_MODE: u8 = 0;
+const STATUS_A: u8 = 1;
+const STATUS_B: u8 = 1;
+const STATUS_C: u8 = 0;
+
+/// Scan type: one range, as opposed to the dual-range modes.
+const SCAN_TYPE_SINGLE: u8 = 1;
+const SCAN_TYPE_B: u8 = 0;
+const SCAN_TYPE_C: u8 = 0;
+
+/// Range mode: single range.
+const RANGE_MODE_SINGLE: u8 = 0;
+
+/// Automatic frequency control, which the emulated radar leaves on and offers
+/// no way to change.
+const AFC_MODE_AUTO: u8 = 1;
+
+/// Interference rejection and crosstalk suppression happen on the source
+/// radar, if at all, so the emulated one reports both switched off.
+const DITHER_OFF: u8 = 0;
+const NOISE_BLANKER_OFF: u8 = 0;
+
+/// Spokes per revolution as an xHD counts them for this report, which is not
+/// the 1440 it sends (`0x0960` in the capture; see
+/// `research/garmin/discovery-handshake.md`).
+const SPOKE_TOTAL: u32 = 2400;
+
+/// Supply voltage in decivolts: 12.0 V.
+const INPUT_VOLTAGE_DV: u16 = 120;
+
+/// Everything the bridge does not emulate reports as off or centred.
+const OFF: u8 = 0;
+const NO_BEARING_OFFSET: u32 = 0;
+const NO_TIME: u16 = 0;
+
+/// Milliseconds until the scanner state changes again. The emulated radar
+/// never warms up or spins down on a timer, so its state is always settled.
+const NO_STATE_CHANGE_PENDING: u32 = 0;
+
+/// The range B fields still have to carry something in single-range mode;
+/// 1/2 NM is what the captured radar reports.
+const RANGE_B_M: u32 = 926;
+
+pub(super) async fn run(
+    local_addr: Ipv4Addr,
+    shared: Arc<Shared>,
+    mut echo_rx: mpsc::Receiver<Vec<u8>>,
+    subsys: &mut SubsystemHandle,
+) -> Result<(), RadarError> {
+    let socket = match multicast_send(&REPORT_ADDRESS, local_addr) {
+        Ok(socket) => socket,
+        Err(e) => {
+            log::error!("Garmin xHD status: cannot open socket: {e}");
+            return Ok(());
+        }
+    };
+
+    let send = async |report: &[u8]| {
+        if let Err(e) = socket.send(report).await {
+            log::warn!("Garmin xHD status: send failed: {e}");
+        }
+    };
+
+    loop {
+        for report in reports(&shared) {
+            send(&report).await;
+        }
+
+        let next_report = tokio::time::Instant::now() + REPORT_INTERVAL;
+        loop {
+            tokio::select! {
+                biased;
+                _ = subsys.on_shutdown_requested() => return Ok(()),
+                // A command acknowledgement has to go out on this socket, and
+                // it has to go out now: the plotter shows nothing until the
+                // radar confirms what it was told.
+                Some(echo) = echo_rx.recv() => send(&echo).await,
+                _ = tokio::time::sleep_until(next_report) => break,
+            }
+        }
+    }
+}
+
+/// The full state of the emulated radar, one value per packet.
+fn reports(shared: &Shared) -> Vec<Vec<u8>> {
+    let power = shared
+        .control(ControlId::Power)
+        .and_then(|v| Power::from_value(&serde_json::json!(v as i64)).ok())
+        .unwrap_or(Power::Standby);
+    let transmitting = power == Power::Transmit;
+    let scanner_state = match power {
+        Power::Transmit => STATE_TRANSMIT,
+        Power::Preparing => STATE_WARMING_UP,
+        // A radar that is off or faulted cannot be told apart from one in
+        // standby over this protocol; the picture stopping says the rest.
+        _ => STATE_STANDBY,
+    } as u8;
+
+    let gain_auto = shared.control_auto(ControlId::Gain);
+    let gain = percent_to_wire(shared.control(ControlId::Gain));
+
+    let sea_auto = shared.control_auto(ControlId::Sea);
+    let sea = percent_to_wire(shared.control(ControlId::Sea));
+    let sea_mode = if sea_auto {
+        SEA_MODE_AUTO
+    } else if sea > 0 {
+        SEA_MODE_MANUAL
+    } else {
+        SEA_MODE_OFF
+    };
+
+    // Rain filtering is on or off on an xHD, with no automatic mode; a radar
+    // set to filter nothing is one with rain filtering switched off.
+    let rain = percent_to_wire(shared.control(ControlId::Rain));
+    let rain_mode = u8::from(rain > 0);
+
+    vec![
+        packet_u8(MSG_SCANNER_STATE, scanner_state),
+        packet_u32(MSG_STATE_CHANGE, NO_STATE_CHANGE_PENDING),
+        packet_u8(MSG_TRANSMIT_MODE, u8::from(transmitting)),
+        packet_u8(MSG_TRANSMIT_MODE_CURRENT, u8::from(transmitting)),
+        packet_u8(MSG_SCAN_TYPE, SCAN_TYPE_SINGLE),
+        packet_u8(MSG_SCAN_TYPE_B, SCAN_TYPE_B),
+        packet_u8(MSG_SCAN_TYPE_C, SCAN_TYPE_C),
+        packet_u8(MSG_RANGE_MODE, RANGE_MODE_SINGLE),
+        packet_u32(MSG_RANGE_A, shared.range_m()),
+        packet_u32(MSG_RANGE_B, RANGE_B_M),
+        packet_u8(
+            MSG_RANGE_A_GAIN_MODE,
+            if gain_auto {
+                GAIN_MODE_AUTO
+            } else {
+                GAIN_MODE_MANUAL
+            },
+        ),
+        packet_u16(MSG_RANGE_A_GAIN, gain),
+        packet_u8(MSG_RANGE_A_SEA_MODE, sea_mode),
+        packet_u16(MSG_RANGE_A_SEA_GAIN, sea),
+        packet_u8(MSG_RANGE_A_SEA_STATE, OFF),
+        packet_u8(MSG_RANGE_A_RAIN_MODE, rain_mode),
+        packet_u16(MSG_RANGE_A_RAIN_GAIN, rain),
+        packet_u8(MSG_DITHER_MODE, DITHER_OFF),
+        packet_u8(MSG_NOISE_BLANKER, NOISE_BLANKER_OFF),
+        // The source radar applies its own bearing alignment before it hands
+        // over a spoke, so the emulated radar is aligned by definition.
+        packet_u32(MSG_BEARING_ALIGNMENT, NO_BEARING_OFFSET),
+        packet_u8(MSG_NO_TX_ZONE_1_MODE, OFF),
+        packet_u8(MSG_SENTRY_MODE, OFF),
+        packet_u16(MSG_SENTRY_STANDBY_TIME, NO_TIME),
+        packet_u16(MSG_SENTRY_TRANSMIT_TIME, NO_TIME),
+        packet_u8(MSG_AFC_MODE, AFC_MODE_AUTO),
+        packet_u8(MSG_RPM_MODE, OFF),
+        packet_u16(MSG_ANTENNA_HEIGHT, ANTENNA_HEIGHT_CM),
+        packet_u16(MSG_ANTENNA_FORWARD, ANTENNA_FORWARD_CM),
+        packet_u16(MSG_ANTENNA_STARBOARD, ANTENNA_STARBOARD_CM),
+        packet_u16(MSG_ANTENNA_POWER, ANTENNA_POWER),
+        packet_u32(MSG_TRIGGER_PERIOD, TRIGGER_PERIOD),
+        packet_u32(MSG_TRIGGER_DELAY, TRIGGER_DELAY),
+        packet_u32(MSG_TRIGGER_PERIOD_B, TRIGGER_PERIOD_B),
+        packet_u8(MSG_TUNE_FINE, TUNE_FINE),
+        packet_u8(MSG_TUNE_COARSE, TUNE_COARSE),
+        packet_u8(MSG_TUNE_MODE, TUNE_MODE),
+        packet_u8(MSG_STATUS_A, STATUS_A),
+        packet_u8(MSG_STATUS_B, STATUS_B),
+        packet_u8(MSG_STATUS_C, STATUS_C),
+        packet_u32(MSG_MAX_RANGE, *XHD_RANGES_M.last().unwrap()),
+        packet_u32(MSG_SPOKE_TOTAL, SPOKE_TOTAL),
+        packet_u16(MSG_INPUT_VOLTAGE, INPUT_VOLTAGE_DV),
+        capability_report(),
+        range_table(),
+    ]
+}
+
+/// A control value in percent as the enhanced protocol carries it.
+fn percent_to_wire(percent: Option<f64>) -> u16 {
+    (percent.unwrap_or(0.0).clamp(0.0, 100.0) * GAIN_SCALE as f64) as u16
+}
+
+/// The `0x09B1` capability bitmap: the features listed in
+/// [`EMULATED_CAPABILITIES`], as five 64-bit words.
+fn capability_report() -> Vec<u8> {
+    let capabilities = GarminCapabilities::from_bits(EMULATED_CAPABILITIES);
+    packet(MSG_CAPABILITY, &capabilities.to_body())
+}
+
+/// The `0x09B2` range table: a version/length header, an entry count, and the
+/// ranges the plotter may pick from.
+fn range_table() -> Vec<u8> {
+    let count = XHD_RANGES_M.len() as u32;
+    let body_len = 8 + count * 4;
+
+    let mut body = Vec::with_capacity(body_len as usize);
+    body.extend_from_slice(&1u16.to_le_bytes());
+    body.extend_from_slice(&(body_len as u16).to_le_bytes());
+    body.extend_from_slice(&count.to_le_bytes());
+    for &meters in XHD_RANGES_M {
+        body.extend_from_slice(&meters.to_le_bytes());
+    }
+    packet(MSG_RANGE_TABLE, &body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::brand::garmin::range_table;
+    use crate::output::garmin_xhd::tests::controls;
+
+    /// The payload of one report, by message id.
+    fn report_of(reports: &[Vec<u8>], message_id: u32) -> Vec<u8> {
+        reports
+            .iter()
+            .find(|r| u32::from_le_bytes(r[0..4].try_into().unwrap()) == message_id)
+            .unwrap_or_else(|| panic!("no report 0x{message_id:04x}"))[GMN_HEADER_LEN..]
+            .to_vec()
+    }
+
+    #[test]
+    fn standby_and_transmit_are_reported_as_the_plotter_expects() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        shared
+            .controls
+            .set(&ControlId::Power, Power::Standby as u32 as f64, None)
+            .unwrap();
+        let reports = super::reports(&shared);
+        assert_eq!(
+            report_of(&reports, MSG_SCANNER_STATE),
+            [STATE_STANDBY as u8]
+        );
+        assert_eq!(report_of(&reports, MSG_TRANSMIT_MODE), [0]);
+
+        shared
+            .controls
+            .set(&ControlId::Power, Power::Transmit as u32 as f64, None)
+            .unwrap();
+        let reports = super::reports(&shared);
+        assert_eq!(
+            report_of(&reports, MSG_SCANNER_STATE),
+            [STATE_TRANSMIT as u8]
+        );
+        assert_eq!(report_of(&reports, MSG_TRANSMIT_MODE), [1]);
+        assert_eq!(report_of(&reports, MSG_TRANSMIT_MODE_CURRENT), [1]);
+    }
+
+    #[test]
+    fn sea_clutter_off_manual_and_auto_map_onto_the_three_modes() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        shared
+            .controls
+            .set(&ControlId::Sea, 0., Some(false))
+            .unwrap();
+        assert_eq!(
+            report_of(&super::reports(&shared), MSG_RANGE_A_SEA_MODE),
+            [SEA_MODE_OFF]
+        );
+
+        shared
+            .controls
+            .set(&ControlId::Sea, 30., Some(false))
+            .unwrap();
+        let reports = super::reports(&shared);
+        assert_eq!(report_of(&reports, MSG_RANGE_A_SEA_MODE), [SEA_MODE_MANUAL]);
+        assert_eq!(
+            report_of(&reports, MSG_RANGE_A_SEA_GAIN),
+            3000u16.to_le_bytes()
+        );
+
+        shared
+            .controls
+            .set(&ControlId::Sea, 30., Some(true))
+            .unwrap();
+        assert_eq!(
+            report_of(&super::reports(&shared), MSG_RANGE_A_SEA_MODE),
+            [SEA_MODE_AUTO]
+        );
+    }
+
+    #[test]
+    fn rain_filtering_is_off_when_the_radar_filters_nothing() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        shared.controls.set(&ControlId::Rain, 0., None).unwrap();
+        assert_eq!(
+            report_of(&super::reports(&shared), MSG_RANGE_A_RAIN_MODE),
+            [0]
+        );
+
+        shared.controls.set(&ControlId::Rain, 40., None).unwrap();
+        let reports = super::reports(&shared);
+        assert_eq!(report_of(&reports, MSG_RANGE_A_RAIN_MODE), [1]);
+        assert_eq!(
+            report_of(&reports, MSG_RANGE_A_RAIN_GAIN),
+            4000u16.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn gain_mode_follows_the_control() {
+        let (shared, _echo_rx) = Shared::new(controls());
+
+        shared
+            .controls
+            .set(&ControlId::Gain, 75., Some(false))
+            .unwrap();
+        let reports = super::reports(&shared);
+        assert_eq!(
+            report_of(&reports, MSG_RANGE_A_GAIN_MODE),
+            [GAIN_MODE_MANUAL]
+        );
+        assert_eq!(report_of(&reports, MSG_RANGE_A_GAIN), 7500u16.to_le_bytes());
+
+        shared
+            .controls
+            .set(&ControlId::Gain, 75., Some(true))
+            .unwrap();
+        assert_eq!(
+            report_of(&super::reports(&shared), MSG_RANGE_A_GAIN_MODE),
+            [GAIN_MODE_AUTO]
+        );
+    }
+
+    #[test]
+    fn capabilities_claimed_are_the_ones_the_bridge_honours() {
+        // Parsed from the packet as broadcast, so this covers what a display
+        // actually receives rather than the constant behind it.
+        let (shared, _echo_rx) = Shared::new(controls());
+        let broadcast = report_of(&super::reports(&shared), MSG_CAPABILITY);
+        let reported = GarminCapabilities::parse(&broadcast).expect("valid capabilities");
+
+        for bit in EMULATED_CAPABILITIES {
+            assert!(reported.has(*bit), "capability 0x{bit:02x} was lost");
+        }
+
+        // A single-range radar, whatever the source radar can do. Claiming
+        // otherwise makes a display offer a range no spoke ever arrives on.
+        assert!(!reported.has_dual_range());
+        for bit in cap::RANGE_B..=cap::RANGE_B_SEA_GAIN {
+            assert!(!reported.has(bit), "Range B bit 0x{bit:02x} claimed");
+        }
+
+        // Nor anything else the bridge cannot act on.
+        for bit in [
+            cap::SENTRY_MODE,
+            cap::NO_TX_ZONE_1_MODE,
+            cap::RPM_MODE,
+            cap::FRONT_OF_BOAT,
+            cap::PARK_POSITION,
+            cap::DOPPLER_RANGE_A,
+        ] {
+            assert!(!reported.has(bit), "capability 0x{bit:02x} claimed");
+        }
+    }
+
+    #[test]
+    fn range_table_parses_back_to_the_ranges_offered() {
+        let packet = super::range_table();
+        let parsed = range_table::parse(&packet[GMN_HEADER_LEN..]).expect("valid range table");
+        let distances: Vec<u32> = parsed.all.iter().map(|r| r.distance() as u32).collect();
+        assert_eq!(distances, XHD_RANGES_M);
+    }
+
+    #[test]
+    fn percent_maps_onto_the_wire_scale() {
+        assert_eq!(percent_to_wire(None), 0);
+        assert_eq!(percent_to_wire(Some(0.0)), 0);
+        assert_eq!(percent_to_wire(Some(50.0)), 5000);
+        assert_eq!(percent_to_wire(Some(100.0)), 10000);
+        assert_eq!(percent_to_wire(Some(150.0)), 10000);
+        assert_eq!(percent_to_wire(Some(-10.0)), 0);
+    }
+}

--- a/src/lib/output/garmin_xhd/status.rs
+++ b/src/lib/output/garmin_xhd/status.rs
@@ -15,7 +15,7 @@ use tokio_graceful_shutdown::SubsystemHandle;
 
 use crate::brand::garmin::capabilities::{GarminCapabilities, cap};
 use crate::brand::garmin::protocol::*;
-use crate::radar::settings::ControlId;
+use crate::radar::settings::{ControlId, SharedControls};
 use crate::radar::{Power, RadarError};
 
 use super::convert::XHD_RANGES_M;
@@ -27,29 +27,23 @@ use super::{
 /// Interval between full state broadcasts.
 const REPORT_INTERVAL: Duration = Duration::from_secs(1);
 
-/// What the emulated radar claims it can do — which is exactly what the bridge
-/// translates into a control change on the source radar, no more.
+/// What the emulated radar is, as opposed to what the source radar can do.
 ///
-/// A display decides from this which controls to offer, so a bit claimed here
-/// and ignored in `command.rs` becomes a knob on the plotter that does
-/// nothing. Notably absent is the Range B block: the bridge presents a single
-/// range whatever the source radar can do. The GMR xHD in
-/// `radar-recordings/garmin/garmin_xhd.pcap` claims dual range even though it
-/// has none — the MFD appears to set that whole word unconditionally — and a
-/// display that believes it offers a second range no spoke ever arrives on.
-///
-/// The list a Garmin MFD hardcodes for a legacy HD radar, which is likewise
-/// single-range and has no Doppler, is `capabilities::LEGACY_HD_BITS`; this is
-/// that set less the features the bridge does not forward.
-const EMULATED_CAPABILITIES: &[u32] = &[
-    cap::TRANSMIT_MODE,
-    cap::RANGE_A,
-    cap::RANGE_A_GAIN_MODE,
-    cap::RANGE_A_GAIN,
-    cap::RANGE_A_RAIN_MODE,
-    cap::RANGE_A_RAIN_GAIN,
-    cap::RANGE_A_SEA_MODE,
-    cap::RANGE_A_SEA_GAIN,
+/// The MFD reduces these bits to a radar class, and draws anything below
+/// class 2 with the legacy two-colour ramp however many bits per sample the
+/// spokes carry. `COLOR_PALETTE` then picks which of the two remaining
+/// palettes it uses. A GMR xHD sets all of them, so the bridge does too:
+/// they describe the protocol being spoken, not a control anyone can reach.
+/// See `research/garmin/feature-detection.md`.
+const CLASS_CAPABILITIES: &[u32] = &[
+    cap::RANGE_MODE,
+    cap::QUICK_ADJUST_GAIN,
+    cap::QUICK_ADJUST_SEA,
+    cap::CLASS_6,
+    cap::CLASS_7,
+    cap::ENHANCED_PROTOCOL,
+    cap::HIGH_CLASS,
+    cap::COLOR_PALETTE,
 ];
 
 // Reports a real xHD sends whose meaning is not documented anywhere, and for
@@ -256,7 +250,7 @@ fn reports(shared: &Shared) -> Vec<Vec<u8>> {
         packet_u32(MSG_MAX_RANGE, *XHD_RANGES_M.last().unwrap()),
         packet_u32(MSG_SPOKE_TOTAL, SPOKE_TOTAL),
         packet_u16(MSG_INPUT_VOLTAGE, INPUT_VOLTAGE_DV),
-        capability_report(),
+        capability_report(&shared.controls),
         range_table(),
     ]
 }
@@ -266,11 +260,61 @@ fn percent_to_wire(percent: Option<f64>) -> u16 {
     (percent.unwrap_or(0.0).clamp(0.0, 100.0) * GAIN_SCALE as f64) as u16
 }
 
-/// The `0x09B1` capability bitmap: the features listed in
-/// [`EMULATED_CAPABILITIES`], as five 64-bit words.
-fn capability_report() -> Vec<u8> {
-    let capabilities = GarminCapabilities::from_bits(EMULATED_CAPABILITIES);
-    packet(MSG_CAPABILITY, &capabilities.to_body())
+/// The `0x09B1` capability bitmap of the emulated radar, as five 64-bit words.
+fn capability_report(controls: &SharedControls) -> Vec<u8> {
+    packet(MSG_CAPABILITY, &emulated_capabilities(controls).to_body())
+}
+
+/// What the emulated radar claims it can do: the class bits, plus one bit per
+/// control the bridge really translates onto the source radar.
+///
+/// A display decides from this which controls to offer, so a bit claimed for a
+/// control the source radar does not have is a knob on the plotter that does
+/// nothing. The other way round is just as wrong: the MFD tests a control bit
+/// together with the group bit of the block it belongs to, so a gain the
+/// bridge forwards but never claims `GAIN_GROUP` for is a knob the plotter
+/// will not send.
+///
+/// Notably absent is the Range B block: the bridge presents a single range
+/// whatever the source radar can do. The GMR xHD in
+/// `radar-recordings/garmin/garmin_xhd.pcap` claims dual range even though it
+/// has none — the MFD appears to set that whole word unconditionally — and a
+/// display that believes it offers a second range no spoke ever arrives on.
+///
+/// `QUICK_ADJUST_PANEL` is left clear for a different reason: which control
+/// each of its three slots adjusts is not known, and a slot guessed wrong is a
+/// slider that moves the wrong setting.
+fn emulated_capabilities(controls: &SharedControls) -> GarminCapabilities {
+    let mut bits = CLASS_CAPABILITIES.to_vec();
+
+    if controls.contains_key(&ControlId::Power) {
+        bits.push(cap::TRANSMIT_MODE);
+    }
+    if controls.contains_key(&ControlId::Range) {
+        bits.push(cap::RANGE_A);
+    }
+    if let Some(gain) = controls.get(&ControlId::Gain) {
+        bits.extend([cap::GAIN_GROUP, cap::RANGE_A_GAIN]);
+        // The gain mode command is the one that switches to automatic; a
+        // radar that only knows one mode has no use for it.
+        if gain.has_auto() {
+            bits.push(cap::RANGE_A_GAIN_MODE);
+        }
+    }
+    // Sea clutter mode carries off and manual as well as automatic, so it is
+    // claimed whether or not the source radar has an automatic mode.
+    if controls.contains_key(&ControlId::Sea) {
+        bits.extend([cap::SEA_GROUP, cap::RANGE_A_SEA_MODE, cap::RANGE_A_SEA_GAIN]);
+    }
+    if controls.contains_key(&ControlId::Rain) {
+        bits.extend([
+            cap::RAIN_GROUP,
+            cap::RANGE_A_RAIN_MODE,
+            cap::RANGE_A_RAIN_GAIN,
+        ]);
+    }
+
+    GarminCapabilities::from_bits(&bits)
 }
 
 /// The `0x09B2` range table: a version/length header, an entry count, and the
@@ -293,7 +337,7 @@ fn range_table() -> Vec<u8> {
 mod tests {
     use super::*;
     use crate::brand::garmin::range_table;
-    use crate::output::garmin_xhd::tests::controls;
+    use crate::output::garmin_xhd::tests::{controls, controls_with};
 
     /// The payload of one report, by message id.
     fn report_of(reports: &[Vec<u8>], message_id: u32) -> Vec<u8> {
@@ -410,16 +454,32 @@ mod tests {
         );
     }
 
+    /// The capability bitmap a display receives, parsed back out of the
+    /// broadcast rather than read off the value that went into it.
+    fn claimed(controls: SharedControls) -> GarminCapabilities {
+        let (shared, _echo_rx) = Shared::new(controls);
+        let broadcast = report_of(&super::reports(&shared), MSG_CAPABILITY);
+        GarminCapabilities::parse(&broadcast).expect("valid capabilities")
+    }
+
     #[test]
     fn capabilities_claimed_are_the_ones_the_bridge_honours() {
-        // Parsed from the packet as broadcast, so this covers what a display
-        // actually receives rather than the constant behind it.
-        let (shared, _echo_rx) = Shared::new(controls());
-        let broadcast = report_of(&super::reports(&shared), MSG_CAPABILITY);
-        let reported = GarminCapabilities::parse(&broadcast).expect("valid capabilities");
+        let reported = claimed(controls());
 
-        for bit in EMULATED_CAPABILITIES {
-            assert!(reported.has(*bit), "capability 0x{bit:02x} was lost");
+        for bit in [
+            cap::TRANSMIT_MODE,
+            cap::RANGE_A,
+            cap::GAIN_GROUP,
+            cap::RANGE_A_GAIN,
+            cap::RANGE_A_GAIN_MODE,
+            cap::SEA_GROUP,
+            cap::RANGE_A_SEA_MODE,
+            cap::RANGE_A_SEA_GAIN,
+            cap::RAIN_GROUP,
+            cap::RANGE_A_RAIN_MODE,
+            cap::RANGE_A_RAIN_GAIN,
+        ] {
+            assert!(reported.has(bit), "capability 0x{bit:02x} was lost");
         }
 
         // A single-range radar, whatever the source radar can do. Claiming
@@ -437,8 +497,45 @@ mod tests {
             cap::FRONT_OF_BOAT,
             cap::PARK_POSITION,
             cap::DOPPLER_RANGE_A,
+            cap::QUICK_ADJUST_PANEL,
         ] {
             assert!(!reported.has(bit), "capability 0x{bit:02x} claimed");
+        }
+    }
+
+    #[test]
+    fn controls_the_source_radar_lacks_are_not_claimed() {
+        // A radar with a range and a gain, and nothing else to adjust.
+        let reported = claimed(controls_with(&[ControlId::Range, ControlId::Gain], &[]));
+
+        assert!(reported.has(cap::RANGE_A));
+        assert!(reported.has(cap::GAIN_GROUP));
+        assert!(reported.has(cap::RANGE_A_GAIN));
+
+        // A gain that cannot be switched to automatic has no gain mode.
+        assert!(!reported.has(cap::RANGE_A_GAIN_MODE));
+
+        // Sea and rain go entirely, group bit and all: a group bit on its own
+        // would leave the plotter a menu with nothing behind it.
+        for bit in [
+            cap::SEA_GROUP,
+            cap::RANGE_A_SEA_MODE,
+            cap::RANGE_A_SEA_GAIN,
+            cap::RAIN_GROUP,
+            cap::RANGE_A_RAIN_MODE,
+            cap::RANGE_A_RAIN_GAIN,
+        ] {
+            assert!(!reported.has(bit), "capability 0x{bit:02x} claimed");
+        }
+    }
+
+    #[test]
+    fn the_radar_class_is_claimed_whatever_the_source_radar_offers() {
+        // Below class 2 the plotter draws the picture with the legacy
+        // two-colour ramp, however many controls the source radar has.
+        let reported = claimed(controls_with(&[], &[]));
+        for bit in CLASS_CAPABILITIES {
+            assert!(reported.has(*bit), "class bit 0x{bit:02x} was lost");
         }
     }
 

--- a/src/lib/output/mod.rs
+++ b/src/lib/output/mod.rs
@@ -1,0 +1,4 @@
+//! Outputs that re-publish a radar's spoke stream in a foreign protocol, so
+//! displays that only speak that protocol can show a mayara radar.
+
+pub(crate) mod garmin_xhd;

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -776,7 +776,12 @@ impl RadarInfo {
         }
     }
 
-    pub fn start_forwarding_radar_messages_to_stdout(&self, subsys: &SubsystemHandle) {
+    /// Start every output that re-publishes this radar's spoke stream to a
+    /// consumer outside the Signal K API: the `--output` stdout forwarder and,
+    /// when compiled in, the Garmin xHD bridge. Called by each brand once the
+    /// radar has been registered with [`SharedRadars`].
+    #[cfg_attr(not(feature = "garmin-xhd-output"), allow(unused_variables))]
+    pub(crate) fn start_outputs(&self, radars: &SharedRadars, subsys: &SubsystemHandle) {
         if self.output {
             let info_clone2 = self.clone();
 
@@ -785,6 +790,9 @@ impl RadarInfo {
                 async move |s: &mut SubsystemHandle| info_clone2.forward_output(s).await,
             ));
         }
+
+        #[cfg(feature = "garmin-xhd-output")]
+        crate::output::garmin_xhd::spawn(self, radars, subsys);
     }
 
     async fn forward_output(self, subsys: &mut SubsystemHandle) -> Result<(), RadarError> {
@@ -1361,7 +1369,7 @@ const OPAQUE: u8 = 255;
 /// - `0` — no Doppler (HD, plain xHD)
 /// - `1` — single flat Doppler color per direction (Navico HALO)
 /// - `4` — 4-level brightness gradient per direction (Garmin Fantom)
-fn default_legend(
+pub(crate) fn default_legend(
     targets: &TargetMode,
     doppler_levels: u8,
     has_rain_class: bool,

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -2996,6 +2996,12 @@ impl Control {
         &self.item
     }
 
+    /// Whether this control has an automatic mode at all, as opposed to
+    /// whether it is currently in one.
+    pub fn has_auto(&self) -> bool {
+        self.item.automatic.is_some()
+    }
+
     /// The `auto` flag as reported to clients. Auto-capable controls (those with
     /// an automatic mode — gain, sea, rain, ...) always report a flag,
     /// defaulting to `false` when the radar has not set one, so a client never


### PR DESCRIPTION
A Garmin GPSMAP only draws radar from a Garmin radar. Built with the optional
`garmin-xhd-output` feature, Mayara now emulates a GMR xHD on the Garmin Marine
Network and feeds it the picture of whichever radar it found — Furuno, Navico,
Raymarine, Koden, or the built-in emulator. The plotter discovers it by itself
and lists it as a GMR xHD.

Controls work both ways: range, gain, sea clutter, rain clutter and the
transmit button on the plotter change the setting on the real radar, and a
change made from Mayara's GUI shows up on the plotter.

The feature is off by default; it needs `cargo build --features garmin-xhd-output`
and a `172.16.x.x` address on the interface the plotter is reached through.
See [docs/garmin-xhd-output.md](docs/garmin-xhd-output.md).

Supersedes #478 by @matztam, whose work this builds on — closes #478.

## What changed against #478

The bridge was Furuno-only. It now hangs off `RadarInfo::start_outputs()`,
which replaces `start_forwarding_radar_messages_to_stdout()` and is called by
every brand, so nothing in `src/lib/output/` knows which brand produced the
spokes it converts. Three things turned out to be brand-specific rather than
one:

- **Sample values** are legend indices, not echo strength. They are mapped
  through a table built from the radar's own `Legend`; previously a 16-level
  Navico or a 2-level HD radome would have drawn a nearly black picture.
  Doppler classes, which an xHD has no room for, become plain strong echoes.
- **Spoke counts** differ by a factor of thirty across brands. Spokes are
  merged or repeated onto the xHD's 1440 per revolution, which fills the
  picture of a 250-spoke Quantum and stops an 8192-spoke Furuno from sending
  five times the traffic a real xHD does.
- **Range**: the spoke header's `range_meters` is the Range control and
  `display_meters` is `spoke.range`, which is what those two fields mean. The
  hardcoded 1.7822 Furuno correction factor is gone.

Also: bursts are drained at the rate they arrive rather than a fixed 200 µs;
commands go through `SharedControls::process_client_request()` so they are
validated and unit-converted like any other client request, with rejections
logged; acknowledgements leave from the report socket the plotter expects them
on; and the capability bitmap is constructed from named bits listing exactly
what the bridge honours, instead of replaying a capture that claims dual range
the bridge does not have.

One radar is bridged per instance, since the emulated radar owns fixed
multicast groups and ports. Multicast loopback stays on so a display on the
same host sees it too; Mayara avoids discovering its own emulation by ignoring
beacons from the single address it announces from.

## Testing

31 unit tests cover the spoke conversion (angle mapping across six source spoke
counts, peak-preserving resampling, legend and Doppler mapping, the two range
fields), the command translation, the report stream, and the capability set.
CI now runs clippy and the test suite with the feature enabled.

Verified end to end on loopback, with a second Mayara standing in for the
plotter (recipe in the docs): the emulated radar is discovered, reports
`dual_range=false`, registers as a single radar, offers exactly the five
controls the bridge translates, and streams spokes at 577/s — 1440 per
revolution at 24 RPM.

Not verified on a real Garmin chartplotter — I have no hardware. The two
behaviours most worth watching there are the reduced capability set and the
range acknowledgement, which now holds the plotter's requested range until the
radar confirms it instead of locking for a fixed 5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds the optional `garmin-xhd-output` feature.
- Emulates a Garmin GMR xHD radar for Garmin chartplotters.
- Converts and streams data from supported radar brands over the Garmin Marine Network.
- Forwards range, gain, sea clutter, rain clutter, and transmit controls.
- Adds discovery, status, spoke, command, acknowledgement, and range handling.
- Integrates output startup through `RadarInfo::start_outputs()`.
- Adds network validation, documentation, 35 bridge tests, and feature-enabled CI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->