### PR TITLE
fix(raymarine): draw RD/HD echoes at their true distance

### DIFF
--- a/src/lib/brand/raymarine/report/rd.rs
+++ b/src/lib/brand/raymarine/report/rd.rs
@@ -54,6 +54,13 @@ struct SpokeHeader3 {
     data_len: u32,
 }
 
+/// A spoke reaches twice as far as the range the radar reports: the last
+/// sample of a 512-sample D or 1024-sample HD spoke sits at twice the
+/// selected range, and a Raymarine MFD draws only the inner half. The
+/// Quantum states the same ratio explicitly in its frame header
+/// (`scan_len` / `returns_per_range`).
+const RD_SPOKE_RANGE_FACTOR: u32 = 2;
+
 const FRAME_HEADER_LENGTH: usize = size_of::<FrameHeader>();
 const SPOKE_HEADER_2_LENGTH: usize = size_of::<SpokeHeader2>();
 const SPOKE_HEADER_1_LENGTH: usize = size_of::<SpokeHeader1>();
@@ -235,7 +242,7 @@ pub(crate) fn process_frame(receiver: &mut RaymarineReportReceiver, data: &[u8])
             % receiver.common.info.spokes_per_revolution;
 
         receiver.common.add_spoke(
-            receiver.range_meters * 4,
+            receiver.range_meters * RD_SPOKE_RANGE_FACTOR,
             angle,
             None,
             process_spoke(hd_type, returns_per_line, spoke, data_len),


### PR DESCRIPTION
Raymarine RD and HD radomes painted every echo at twice its real distance. A buoy at 0.5 nm showed up on the 1 nm ring, and the outer part of each sweep fell off the edge of the PPI, so only the innermost quarter of what the radar sent was ever visible.

## Cause

A Raymarine spoke reaches twice as far as the range the radar reports — a Raymarine MFD draws only the inner half. The RD receiver declared four times that range when handing the spoke to the renderer, which then stretched every spoke by a factor of two.

Three things agree on the correct ratio:

- `radar_pi` sets `m_range_meters = m_radar_ranges[range_id] * 2` and passes exactly that as the spoke extent for both the D and HD dialects.
- mayara's own Quantum path already uses the same ratio: `range_meters * returns_per_line / returns_per_range`, which is `radar_pi`'s Quantum call with `m_range_meters = 2 x table` substituted in.
- The Quantum states the ratio explicitly in its frame header (`scan_len` / `returns_per_range`).

Only the RD path carried the unexplained `* 4`, present since the original Raymarine commit.

## Test plan

- [x] `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D warnings` clean
- [x] `cargo test --features pcap-replay` passes, including the RD418D and RD418HD replay fixtures
- [ ] On-water confirmation that echoes now line up with the range rings (needs an RD/HD owner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Sets the Raymarine RD spoke range factor to `2`, matching `radar_pi` and Quantum implementations.
- Renders RD and HD radar echoes at their true distance without truncating the outer sweep.
- Passes formatting, Clippy, and replay-based tests for RD418D and RD418HD fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->