### PR TITLE
refactor(ais): drop vestigial AisVessel::status field

### DIFF
--- a/src/lib/ais.rs
+++ b/src/lib/ais.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast;
 
 use crate::stream::SignalKDelta;
 
-/// Timeout after which a vessel is marked as "Lost" (3 minutes)
+/// Silence after which a vessel is dropped from the store (3 minutes)
 const AIS_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// GPS position
@@ -385,7 +385,7 @@ impl AisVesselStore {
     /// Returns the number of vessels dropped.
     pub fn check_timeouts(&self) -> usize {
         let now = Instant::now();
-        let mut lost_vessels = Vec::new();
+        let mut timed_out_vessels = Vec::new();
 
         {
             let vessels = match self.vessels.read() {
@@ -394,22 +394,22 @@ impl AisVesselStore {
             };
             for (mmsi, vessel) in vessels.iter() {
                 if now.duration_since(vessel.last_update) > AIS_TIMEOUT {
-                    lost_vessels.push(mmsi.clone());
+                    timed_out_vessels.push(mmsi.clone());
                 }
             }
         }
 
-        if !lost_vessels.is_empty() {
+        if !timed_out_vessels.is_empty() {
             let mut vessels = match self.vessels.write() {
                 Ok(v) => v,
                 Err(_) => return 0,
             };
-            for mmsi in &lost_vessels {
+            for mmsi in &timed_out_vessels {
                 vessels.remove(mmsi);
             }
         }
 
-        lost_vessels.len()
+        timed_out_vessels.len()
     }
 
     /// Broadcast a vessel update to all connected clients
@@ -425,6 +425,10 @@ impl AisVesselStore {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// How far past [`AIS_TIMEOUT`] a test backdates a vessel to put it
+    /// unambiguously beyond the timeout.
+    const TIMEOUT_MARGIN: Duration = Duration::from_secs(1);
 
     #[test]
     fn test_extract_mmsi() {
@@ -787,7 +791,7 @@ mod tests {
             let mut vessels = store.vessels.write().unwrap();
             let vessel = vessels.get_mut("111111111").unwrap();
             vessel.last_update = Instant::now()
-                .checked_sub(AIS_TIMEOUT + Duration::from_secs(1))
+                .checked_sub(AIS_TIMEOUT + TIMEOUT_MARGIN)
                 .expect("backdate");
         }
         assert_eq!(store.check_timeouts(), 1);
@@ -820,7 +824,7 @@ mod tests {
             let mut vessels = store.vessels.write().unwrap();
             let vessel = vessels.get_mut("111111111").unwrap();
             vessel.last_update = Instant::now()
-                .checked_sub(AIS_TIMEOUT + Duration::from_secs(1))
+                .checked_sub(AIS_TIMEOUT + TIMEOUT_MARGIN)
                 .expect("backdate");
         }
         store.flush_pending_broadcasts();

--- a/src/lib/ais.rs
+++ b/src/lib/ais.rs
@@ -56,16 +56,15 @@ pub struct AisVessel {
     pub heading: Option<f64>,
     pub cog: Option<f64>,
     pub sog: Option<f64>,
-    pub status: String,
     last_update: Instant,
 }
 
 /// Serializable view of AisVessel (only includes dimensions when known).
 ///
 /// This is the input to [`SignalKDelta::for_ais_vessel`], which fans it out
-/// into Signal K's own delta paths. `status` is deliberately absent: Signal K
-/// has no liveness field — a consumer ages a vessel out when its updates stop —
-/// so mayara's internal `Active`/`Lost` state never reaches the wire.
+/// into Signal K's own delta paths. There is no liveness field: Signal K has
+/// none, and a consumer ages a vessel out when its updates stop. A vessel is
+/// live for exactly as long as it is in the store.
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AisVesselApi {
@@ -112,7 +111,6 @@ impl AisVessel {
             heading: None,
             cog: None,
             sog: None,
-            status: "Active".to_string(),
             last_update: Instant::now(),
         }
     }
@@ -365,26 +363,24 @@ impl AisVesselStore {
         to_broadcast.len()
     }
 
-    /// Get all active vessels (for initial connection)
+    /// Get all live vessels (for initial connection). Timed-out vessels are
+    /// dropped by [`Self::check_timeouts`], so everything still in the store
+    /// counts as live.
     pub fn get_all_active(&self) -> Vec<AisVesselApi> {
         let vessels = match self.vessels.read() {
             Ok(v) => v,
             Err(_) => return Vec::new(),
         };
-        vessels
-            .values()
-            .filter(|v| v.status == "Active")
-            .map(AisVesselApi::from)
-            .collect()
+        vessels.values().map(AisVesselApi::from).collect()
     }
 
     /// Drop vessels whose updates have stopped for longer than [`AIS_TIMEOUT`].
     ///
     /// Nothing is broadcast: Signal K has no "lost" delta, so a client ages a
     /// vessel out when its updates stop. Emitting one here would be worse than
-    /// silence — with no `status` on the wire it is indistinguishable from a
-    /// live refresh, and it would re-assert the vessel's last known position
-    /// exactly when that position has become untrustworthy.
+    /// silence — with no liveness field on the wire it is indistinguishable
+    /// from a live refresh, and it would re-assert the vessel's last known
+    /// position exactly when that position has become untrustworthy.
     ///
     /// Returns the number of vessels dropped.
     pub fn check_timeouts(&self) -> usize {
@@ -397,8 +393,7 @@ impl AisVesselStore {
                 Err(_) => return 0,
             };
             for (mmsi, vessel) in vessels.iter() {
-                if vessel.status == "Active" && now.duration_since(vessel.last_update) > AIS_TIMEOUT
-                {
+                if now.duration_since(vessel.last_update) > AIS_TIMEOUT {
                     lost_vessels.push(mmsi.clone());
                 }
             }
@@ -506,7 +501,6 @@ mod tests {
         assert!(vessel.position.is_none());
         assert!(vessel.cog.is_none());
         assert!(vessel.sog.is_none());
-        assert_eq!(vessel.status, "Active");
         assert!(!vessel.dimensions.has_any());
     }
 
@@ -731,8 +725,6 @@ mod tests {
         assert!(json.get("sog").is_none());
         // These should always be present
         assert!(json.get("mmsi").is_some());
-        // `status` is internal-only — Signal K has no liveness field.
-        assert!(json.get("status").is_none());
     }
 
     #[test]
@@ -776,7 +768,7 @@ mod tests {
     }
 
     #[test]
-    fn test_store_get_all_active_filters_lost() {
+    fn test_store_get_all_active_excludes_timed_out() {
         let (tx, _rx) = broadcast::channel(16);
         let store = AisVesselStore::new(tx);
 
@@ -790,13 +782,15 @@ mod tests {
         store.update("vessels.urn:mrn:imo:mmsi:111111111", &updates);
         store.update("vessels.urn:mrn:imo:mmsi:222222222", &updates);
 
-        // Mark one as lost manually
+        // Age one past the timeout so the next sweep drops it
         {
             let mut vessels = store.vessels.write().unwrap();
-            if let Some(v) = vessels.get_mut("111111111") {
-                v.status = "Lost".to_string();
-            }
+            let vessel = vessels.get_mut("111111111").unwrap();
+            vessel.last_update = Instant::now()
+                .checked_sub(AIS_TIMEOUT + Duration::from_secs(1))
+                .expect("backdate");
         }
+        assert_eq!(store.check_timeouts(), 1);
 
         let active = store.get_all_active();
         assert_eq!(active.len(), 1);
@@ -804,9 +798,9 @@ mod tests {
     }
 
     /// A vessel that stops reporting is dropped silently. Signal K has no
-    /// "lost" delta — a client ages the vessel out — and with no `status` on
-    /// the wire a farewell broadcast would be indistinguishable from a live
-    /// refresh re-asserting a position that has just gone stale.
+    /// "lost" delta — a client ages the vessel out — and with no liveness
+    /// field on the wire a farewell broadcast would be indistinguishable
+    /// from a live refresh re-asserting a position that has just gone stale.
     #[test]
     fn test_check_timeouts_drops_silently() {
         let (tx, mut rx) = broadcast::channel(16);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -616,9 +616,9 @@ pub async fn start_session(
                     },
                     _ = interval.tick() => {
                         if let Some(store) = navdata::get_ais_store() {
-                            let lost_count = store.check_timeouts();
-                            if lost_count > 0 {
-                                log::debug!("Marked {} AIS vessels as Lost", lost_count);
+                            let removed_count = store.check_timeouts();
+                            if removed_count > 0 {
+                                log::debug!("Dropped {} timed-out AIS vessels", removed_count);
                             }
                         }
                     }


### PR DESCRIPTION
No user-visible change: AIS vessels appear, update, and age off the display exactly as before. This is internal cleanup of state that no longer did anything.

Follow-up to review feedback on #467.

## Background

#467 changed AIS age-out to drop timed-out vessels from the store outright, rather than marking them `Lost` and broadcasting a farewell delta. That removed the only writer of `AisVessel::status`, leaving a field that was always `"Active"` and two readers that were therefore always true — the filter in `get_all_active` and the guard in `check_timeouts`. It read like live liveness tracking while tracking nothing.

The field never reached the wire (`AisVesselApi` has no liveness field, by design — Signal K has none), so removing it is not an API change and needs no version bump.

`test_store_get_all_active_filters_lost` existed only to exercise the filter, and faked its input by writing `"Lost"` directly — a state production code can no longer produce. It becomes `test_store_get_all_active_excludes_timed_out`, asserting the same property through the real timeout path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Removes the vestigial `AisVessel::status` field and related status handling. `get_all_active` returns all vessels in storage. `check_timeouts` removes vessels based on `last_update` age. Tests verify timeout removal through the actual timeout path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->