### PR TITLE
fix(ais): stop the timeout sweep dropping vessels that just reported

### DIFF
--- a/src/lib/ais.rs
+++ b/src/lib/ais.rs
@@ -382,34 +382,21 @@ impl AisVesselStore {
     /// from a live refresh, and it would re-assert the vessel's last known
     /// position exactly when that position has become untrustworthy.
     ///
+    /// Selection and removal happen under one write lock, so a vessel that
+    /// reports in mid-sweep cannot be dropped on the strength of an age
+    /// measured before it arrived.
+    ///
     /// Returns the number of vessels dropped.
     pub fn check_timeouts(&self) -> usize {
         let now = Instant::now();
-        let mut timed_out_vessels = Vec::new();
+        let mut vessels = match self.vessels.write() {
+            Ok(v) => v,
+            Err(_) => return 0,
+        };
 
-        {
-            let vessels = match self.vessels.read() {
-                Ok(v) => v,
-                Err(_) => return 0,
-            };
-            for (mmsi, vessel) in vessels.iter() {
-                if now.duration_since(vessel.last_update) > AIS_TIMEOUT {
-                    timed_out_vessels.push(mmsi.clone());
-                }
-            }
-        }
-
-        if !timed_out_vessels.is_empty() {
-            let mut vessels = match self.vessels.write() {
-                Ok(v) => v,
-                Err(_) => return 0,
-            };
-            for mmsi in &timed_out_vessels {
-                vessels.remove(mmsi);
-            }
-        }
-
-        timed_out_vessels.len()
+        let before = vessels.len();
+        vessels.retain(|_, vessel| now.duration_since(vessel.last_update) <= AIS_TIMEOUT);
+        before - vessels.len()
     }
 
     /// Broadcast a vessel update to all connected clients


### PR DESCRIPTION
An AIS vessel could briefly vanish from the display even though it was still transmitting, reappearing on its next report. Most likely on a busy plot, where the three-minute sweep is more often running while some vessel happens to be reporting.

Raised by CodeRabbit on #498. The bug predates that PR — it is not something #498 introduced.

## Cause

`AisVesselStore::check_timeouts` chose its victims under a read lock, released it, then removed them under a write lock. `update()` could refresh a vessel's `last_update` in the gap, so the sweep deleted it on the strength of an age measured before its report arrived. `update()` re-creates vessels on demand, which is why the vessel came back rather than staying gone.

Selection and removal now happen in a single write-locked `retain` pass, so no report can slip between the two.

## Testing

No new test: the failure needs a specific interleaving of two threads, and any test that tried to force it would be timing-dependent and flaky. The existing `test_check_timeouts_drops_silently` and `test_store_get_all_active_excludes_timed_out` cover the observable behaviour — timed-out vessels dropped, fresh ones kept, correct count returned — and both still pass.

## Merge order

Stacked on `chore/ais-drop-vestigial-status` (#498), which rewrites the same function; based on `main` it would conflict. GitHub retargets this to `main` automatically once #498 merges.