### PR TITLE
feat(radar): identify radars from their own protocol, not their address

### DIFF
--- a/src/lib/brand/garmin/discovery.rs
+++ b/src/lib/brand/garmin/discovery.rs
@@ -28,15 +28,17 @@
 //! +07     1     constant             0x01
 //! +08     1     service_count        0x01
 //! +09     3     padding              0x00 0x00 0x00
-//! +0c     8*N   service_id_array     [class:1][inst:0][ver:2][rsv:0]+u32 id
+//! +0c     4*N   service_id_array     one u32 per published service
+//!         4     unique_id            per-device, stable across power cycles
 //!         var   serialized tail      uptime/sequence counter
 //! ```
 
 #![allow(dead_code)]
 
 use super::protocol::{
-    CDM_OFFSET_PRODUCT_ID, CDM_OFFSET_PRODUCT_SUBTYPE, CDM_OFFSET_SIMULATOR_MODE,
-    CDM_OFFSET_SYC_GROUP_ID, CDM_OFFSET_VERSION_MARKER,
+    CDM_OFFSET_PRODUCT_ID, CDM_OFFSET_PRODUCT_SUBTYPE, CDM_OFFSET_SERVICE_COUNT,
+    CDM_OFFSET_SIMULATOR_MODE, CDM_OFFSET_SYC_GROUP_ID, CDM_OFFSET_VERSION_MARKER,
+    CDM_SERVICE_ARRAY_OFFSET, CDM_SERVICE_ID_LEN,
 };
 
 /// Minimum number of bytes the CDM heartbeat body must contain (i.e.
@@ -60,6 +62,11 @@ pub(crate) struct CdmHeartbeat {
     /// network group. Devices on the same boat share the same value.
     /// Read from gmcfg `"syc.group_id"` in the firmware; default 6.
     pub syc_group_id: u8,
+    /// Per-device identifier, the word following the service id array.
+    /// Stable across power cycles and independent of the address, so it
+    /// is what distinguishes one Garmin radar from another. `None` if
+    /// the body is truncated before it.
+    pub unique_id: Option<u32>,
 }
 
 /// Parse the body of a `0x038e` heartbeat. `payload` must be the slice
@@ -81,9 +88,19 @@ pub(crate) fn parse(payload: &[u8]) -> Option<CdmHeartbeat> {
             .try_into()
             .ok()?,
     );
+    // The identifier sits after a variable-length service array, so its
+    // offset depends on how many services this device publishes.
+    let unique_id = payload
+        .get(CDM_OFFSET_SERVICE_COUNT)
+        .map(|count| CDM_SERVICE_ARRAY_OFFSET + *count as usize * CDM_SERVICE_ID_LEN)
+        .and_then(|at| payload.get(at..at + 4))
+        .and_then(|b| b.try_into().ok())
+        .map(u32::from_le_bytes);
+
     Some(CdmHeartbeat {
         version,
         product_id,
+        unique_id,
         simulator_mode: payload[CDM_OFFSET_SIMULATOR_MODE],
         product_subtype: payload[CDM_OFFSET_PRODUCT_SUBTYPE],
         syc_group_id: payload[CDM_OFFSET_SYC_GROUP_ID],
@@ -175,6 +192,36 @@ pub(crate) fn product_name(product_id: u16) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// CDM heartbeat body from the Fantom Pro radar in
+    /// `radar-recordings/garmin/fantom_pro/`. Two published services, so
+    /// the unique id sits four bytes further along than on the xHD — the
+    /// reason the offset has to be computed rather than fixed.
+    const FANTOM_BODY: [u8; 30] = [
+        0x02, 0x8c, 0x2c, 0x0f, 0x00, 0x00, 0x02, 0x01, 0x02, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00,
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x30, 0xce, 0xc2, 0x04, 0x01, 0x04, 0xb3, 0x00, 0x00, 0x00,
+    ];
+
+    /// The identity is what tells two Garmin radars apart: Garmin assigns
+    /// addresses by role, so both of these radars answer on 172.16.2.0.
+    #[test]
+    fn unique_id_is_read_past_the_service_array() {
+        let xhd = parse(&SAMPLE_BODY).expect("xHD heartbeat");
+        assert_eq!(xhd.unique_id, Some(0x08d4_0aa0));
+
+        let fantom = parse(&FANTOM_BODY).expect("Fantom heartbeat");
+        assert_eq!(fantom.product_id, 0x0f2c);
+        assert_eq!(fantom.unique_id, Some(0x04c2_ce30));
+        assert_ne!(xhd.unique_id, fantom.unique_id);
+    }
+
+    /// A body truncated before the identifier must not be misread as one:
+    /// better no identity than a wrong one shared between radars.
+    #[test]
+    fn unique_id_is_absent_when_the_body_is_truncated() {
+        let short = &SAMPLE_BODY[..18];
+        assert_eq!(parse(short).and_then(|hb| hb.unique_id), None);
+    }
 
     /// CDM heartbeat body captured from a GMR xHD radar in
     /// `radar-recordings/garmin/garmin_xhd.pcap`. Sourced from

--- a/src/lib/brand/garmin/mod.rs
+++ b/src/lib/brand/garmin/mod.rs
@@ -259,7 +259,11 @@ impl GarminLocator {
 
         // CDM messages (broadcast on a separate multicast group).
         if packet_type == MSG_CDM_HEARTBEAT {
-            self.handle_cdm_heartbeat(report, from);
+            // The heartbeat is what identifies a radar, so it is also what
+            // lets one that was waiting on its identity be registered.
+            if self.handle_cdm_heartbeat(report, from) {
+                self.try_register_pending(from, nic_addr, radars, subsys);
+            }
             return Ok(());
         }
         if packet_type == discovery::MSG_CDM_PRODUCT_DATA {
@@ -343,14 +347,18 @@ impl GarminLocator {
         Ok(())
     }
 
-    /// Parse a CDM `0x038E` heartbeat and stash the radar's product_id.
-    /// On first receipt, also send a `0x0391` product data request to
-    /// learn the radar's factory name and user alias.
-    fn handle_cdm_heartbeat(&self, report: &[u8], from: &SocketAddrV4) {
+    /// Parse a CDM `0x038E` heartbeat and stash the radar's identity and
+    /// product_id. On first receipt, also send a `0x0391` product data
+    /// request to learn the radar's factory name and user alias.
+    ///
+    /// Returns whether this heartbeat was the first to identify the radar,
+    /// which is the moment a radar waiting on its identity can be
+    /// registered.
+    fn handle_cdm_heartbeat(&self, report: &[u8], from: &SocketAddrV4) -> bool {
         let payload = &report[GMN_HEADER_LEN..];
         let hb = match discovery::parse(payload) {
             Some(h) => h,
-            None => return,
+            None => return false,
         };
 
         // Mirror the boat's SYC group so mayara's outbound heartbeat
@@ -372,9 +380,9 @@ impl GarminLocator {
         // product_id changes: registration may happen on the very first
         // one, and a radar keyed before its identity is known could never
         // be re-keyed.
-        if let Some(unique_id) = hb.unique_id {
-            state.unique_ids.insert(*from.ip(), unique_id);
-        }
+        let identity_is_new = hb
+            .unique_id
+            .is_some_and(|id| state.unique_ids.insert(*from.ip(), id).is_none());
 
         if already != Some(hb.product_id) {
             log::info!(
@@ -398,6 +406,8 @@ impl GarminLocator {
                 }
             });
         }
+
+        identity_is_new
     }
 
     /// Parse a CDM `0x0392` product data response and stash the radar's
@@ -566,12 +576,19 @@ impl GarminLocator {
         // across power cycles and independent of its address. Garmin
         // assigns addresses by device role — every radar answers on
         // 172.16.2.0 — so the address distinguishes almost nothing.
+        // Capability and range packets can arrive before the first
+        // heartbeat, and a radar registered then could never be re-keyed.
+        // Wait for the identity instead: heartbeats come every five
+        // seconds, and each one retries registration.
         let hardware_id = {
             let state = self.state.lock().unwrap();
-            state
-                .unique_ids
-                .get(from.ip())
-                .map(|id| format!("{:08x}", id))
+            match state.unique_ids.get(from.ip()) {
+                Some(id) => format!("{:08x}", id),
+                None => {
+                    log::debug!("{}: waiting for a heartbeat to identify the radar", from);
+                    return;
+                }
+            }
         };
         let state = self.state.lock().unwrap();
         let product_id = state.product_ids.get(from.ip()).copied();
@@ -609,7 +626,7 @@ impl GarminLocator {
             &self.args,
             Brand::Garmin,
             None,
-            hardware_id.as_deref(),
+            Some(hardware_id.as_str()),
             dual_a,
             detected_type.pixel_values(),
             detected_type.spokes_per_revolution(),
@@ -637,7 +654,7 @@ impl GarminLocator {
                 &self.args,
                 Brand::Garmin,
                 None,
-                hardware_id.as_deref(),
+                Some(hardware_id.as_str()),
                 Some("B"),
                 detected_type.pixel_values(),
                 detected_type.spokes_per_revolution(),

--- a/src/lib/brand/garmin/mod.rs
+++ b/src/lib/brand/garmin/mod.rs
@@ -148,10 +148,18 @@ struct LocatorShared {
     radars: HashMap<SocketAddrV4, RadarState>,
     /// Garmin CDM `product_id` per radar IP, learned from the `0x038e`
     /// heartbeat. Used to look up the model name.
-    product_ids: HashMap<SocketAddrV4, u16>,
+    ///
+    /// Keyed by address only. The heartbeat arrives on the CDM port and
+    /// the radar's own traffic on another, so anything keyed by the full
+    /// socket address is stored under one key and looked up under a
+    /// different one — it would never be found.
+    product_ids: HashMap<Ipv4Addr, u16>,
     /// Factory name + user alias per radar IP, learned from the `0x0392`
     /// product data response.
-    device_names: HashMap<SocketAddrV4, discovery::CdmProductData>,
+    device_names: HashMap<Ipv4Addr, discovery::CdmProductData>,
+    /// Per-device identifier from the `0x038e` heartbeat. Stable across
+    /// power cycles, so it is what a radar is keyed on.
+    unique_ids: HashMap<Ipv4Addr, u32>,
 }
 
 #[derive(Clone)]
@@ -359,7 +367,15 @@ impl GarminLocator {
         }
 
         let mut state = self.state.lock().unwrap();
-        let already = state.product_ids.get(from).copied();
+        let already = state.product_ids.get(from.ip()).copied();
+        // Record the identity on every heartbeat, not just when the
+        // product_id changes: registration may happen on the very first
+        // one, and a radar keyed before its identity is known could never
+        // be re-keyed.
+        if let Some(unique_id) = hb.unique_id {
+            state.unique_ids.insert(*from.ip(), unique_id);
+        }
+
         if already != Some(hb.product_id) {
             log::info!(
                 "{}: Garmin CDM heartbeat: product_id=0x{:04x} ({})",
@@ -367,7 +383,7 @@ impl GarminLocator {
                 hb.product_id,
                 discovery::product_name(hb.product_id).unwrap_or("unknown"),
             );
-            state.product_ids.insert(*from, hb.product_id);
+            state.product_ids.insert(*from.ip(), hb.product_id);
 
             // Send a product data request to learn the device name/alias.
             // This is fire-and-forget; the response arrives as 0x0392 on
@@ -399,7 +415,7 @@ impl GarminLocator {
             pd.device_alias,
         );
         let mut state = self.state.lock().unwrap();
-        state.device_names.insert(*from, pd);
+        state.device_names.insert(*from.ip(), pd);
     }
 
     /// Handle a `MSG_CAPABILITY` packet that arrived for a pending
@@ -546,13 +562,20 @@ impl GarminLocator {
             _ => return,
         };
 
-        // Garmin radars don't expose a per-unit serial number on the
-        // wire. Passing None for serial_no makes RadarInfo::new fall
-        // back to the last two octets of the radar's IP (172.16.x.y)
-        // as the key suffix, which is unique per physical radar.
+        // The heartbeat's unique id is the radar's own identity: stable
+        // across power cycles and independent of its address. Garmin
+        // assigns addresses by device role — every radar answers on
+        // 172.16.2.0 — so the address distinguishes almost nothing.
+        let hardware_id = {
+            let state = self.state.lock().unwrap();
+            state
+                .unique_ids
+                .get(from.ip())
+                .map(|id| format!("{:08x}", id))
+        };
         let state = self.state.lock().unwrap();
-        let product_id = state.product_ids.get(from).copied();
-        let device_info = state.device_names.get(from).cloned();
+        let product_id = state.product_ids.get(from.ip()).copied();
+        let device_info = state.device_names.get(from.ip()).cloned();
         drop(state);
 
         // Model name: prefer the factory name from 0x0392, fall back
@@ -586,7 +609,7 @@ impl GarminLocator {
             &self.args,
             Brand::Garmin,
             None,
-            None,
+            hardware_id.as_deref(),
             dual_a,
             detected_type.pixel_values(),
             detected_type.spokes_per_revolution(),
@@ -614,7 +637,7 @@ impl GarminLocator {
                 &self.args,
                 Brand::Garmin,
                 None,
-                None,
+                hardware_id.as_deref(),
                 Some("B"),
                 detected_type.pixel_values(),
                 detected_type.spokes_per_revolution(),

--- a/src/lib/brand/garmin/protocol.rs
+++ b/src/lib/brand/garmin/protocol.rs
@@ -171,6 +171,11 @@ pub(crate) const CDM_OFFSET_PRODUCT_SUBTYPE: usize = 5;
 /// MFD configured, and the MFD reads it from gmcfg `"syc.group_id"`.
 pub(crate) const CDM_OFFSET_SYC_GROUP_ID: usize = 6;
 
+// CDM heartbeat body layout. Derived from `cdm_build_and_send_v2_heartbeat`
+// in the MFD firmware and checked against the GMR xHD capture in
+// `testdata/pcap/garmin-xhd.pcap.gz` and the Fantom Pro recordings; see
+// `research/garmin/discovery-handshake.md`.
+
 /// Number of services this device publishes, at +08. The service id
 /// array follows the padding at [`CDM_SERVICE_ARRAY_OFFSET`].
 pub(crate) const CDM_OFFSET_SERVICE_COUNT: usize = 8;
@@ -180,6 +185,11 @@ pub(crate) const CDM_SERVICE_ARRAY_OFFSET: usize = 0x0c;
 
 /// Size of one entry in the service id array. The device's unique
 /// identifier is the word immediately after the array.
+///
+/// Four, not eight: a single-service device cannot distinguish the two
+/// readings, and the xHD publishes one. The Fantom Pro's radar and MFD
+/// publish 2 and 17, and under the 8-byte reading the MFD's array
+/// overruns its own packet.
 pub(crate) const CDM_SERVICE_ID_LEN: usize = 4;
 
 // =============================================================================

--- a/src/lib/brand/garmin/protocol.rs
+++ b/src/lib/brand/garmin/protocol.rs
@@ -171,6 +171,17 @@ pub(crate) const CDM_OFFSET_PRODUCT_SUBTYPE: usize = 5;
 /// MFD configured, and the MFD reads it from gmcfg `"syc.group_id"`.
 pub(crate) const CDM_OFFSET_SYC_GROUP_ID: usize = 6;
 
+/// Number of services this device publishes, at +08. The service id
+/// array follows the padding at [`CDM_SERVICE_ARRAY_OFFSET`].
+pub(crate) const CDM_OFFSET_SERVICE_COUNT: usize = 8;
+
+/// Start of the service id array.
+pub(crate) const CDM_SERVICE_ARRAY_OFFSET: usize = 0x0c;
+
+/// Size of one entry in the service id array. The device's unique
+/// identifier is the word immediately after the array.
+pub(crate) const CDM_SERVICE_ID_LEN: usize = 4;
+
 // =============================================================================
 // Legacy HD message IDs (0x02xx)
 // =============================================================================

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
+use std::time::{Duration, Instant};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
 
 use crate::locator::LocatorAddress;
@@ -17,13 +18,26 @@ mod settings;
 
 use protocol::{
     BEACON_ADDRESS, CMD_MAC_ADDRESS, CONTROL_PREFIX, IMAGE_MARKER, IMG_MIN_SIZE, KEEPALIVE_PACKET,
-    MAC_ADDRESS_REQUEST, PIXEL_VALUES, RADAR_PORT, RESP_POWER, RESP_WARMUP, SPOKE_LEN, SPOKES,
-    STATUS_PREFIX,
+    MAC_ADDRESS_REQUEST, PACKET_END, PIXEL_VALUES, RADAR_PORT, RESP_POWER, RESP_WARMUP, SPOKE_LEN,
+    SPOKES, STATUS_PREFIX,
 };
 
 /// Length of a `0xA7` MAC address response: prefix, command, six bytes
 /// of MAC, terminator.
 const MAC_RESPONSE_LEN: usize = 9;
+
+/// How long to keep asking a radar for its MAC before giving up and
+/// keying it on its address.
+///
+/// No Koden radar has been available to test against, so a unit that
+/// never answers must still appear: the identity is an improvement when
+/// it arrives, never a precondition for the radar being usable.
+const MAC_REQUEST_BUDGET: Duration = Duration::from_secs(5);
+
+/// Minimum gap between MAC requests to one radar. Without it every
+/// accepted packet would provoke one, and Koden image frames arrive
+/// continuously.
+const MAC_REQUEST_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Clone)]
 struct KodenLocator {
@@ -33,6 +47,10 @@ struct KodenLocator {
     /// changes with the DHCP lease and takes the radar's saved settings
     /// with it.
     macs: HashMap<Ipv4Addr, String>,
+    /// When each radar was first asked for its MAC, and when it was last
+    /// asked, so requests stay bounded and a radar that never answers is
+    /// still registered.
+    asked: HashMap<Ipv4Addr, (Instant, Instant)>,
 }
 
 impl RadarLocator for KodenLocator {
@@ -57,17 +75,66 @@ impl KodenLocator {
         KodenLocator {
             args,
             macs: HashMap::new(),
+            asked: HashMap::new(),
         }
     }
 
     /// Record the MAC from a `0xA7` response. Returns whether it was new,
     /// so the caller only logs a radar's identity once.
+    ///
+    /// Only a complete, correctly terminated response is trusted: a
+    /// truncated or malformed one would yield a hardware id that is not
+    /// the radar's, and two radars could end up sharing it.
     fn record_mac(&mut self, radar_addr: &Ipv4Addr, report: &[u8]) -> bool {
-        if report.len() < MAC_RESPONSE_LEN {
+        if report.len() != MAC_RESPONSE_LEN || report[MAC_RESPONSE_LEN - 1] != PACKET_END {
+            log::debug!("{}: ignoring a malformed MAC response", radar_addr);
             return false;
         }
         let mac: String = report[2..8].iter().map(|b| format!("{:02x}", b)).collect();
         self.macs.insert(*radar_addr, mac).is_none()
+    }
+
+    /// Ask a radar for its MAC, at most once every
+    /// [`MAC_REQUEST_INTERVAL`], and report whether the budget for an
+    /// answer has run out.
+    fn chase_mac(&mut self, radar_addr: &SocketAddrV4) -> bool {
+        let now = Instant::now();
+        let (first, last) = self
+            .asked
+            .entry(*radar_addr.ip())
+            .or_insert((now, now - MAC_REQUEST_INTERVAL));
+
+        if now.duration_since(*first) >= MAC_REQUEST_BUDGET {
+            return true;
+        }
+        if now.duration_since(*last) >= MAC_REQUEST_INTERVAL {
+            *last = now;
+            request_mac(radar_addr);
+        }
+        false
+    }
+
+    /// What to key this radar on: `Some(Some(mac))` once it has reported
+    /// one, `Some(None)` to fall back to its address, and `None` while it
+    /// is still being asked.
+    ///
+    /// A Koden radar will tell us its own MAC, and it answers on the port
+    /// discovery already listens on. Waiting briefly for that is worth
+    /// it, because an address-derived key moves with the DHCP lease. But
+    /// only briefly: no Koden unit has been available to test against, so
+    /// one that never answers must still appear.
+    fn identity_for(&mut self, radar_addr: &SocketAddrV4) -> Option<Option<String>> {
+        if let Some(mac) = self.macs.get(radar_addr.ip()) {
+            return Some(Some(mac.clone()));
+        }
+        if self.chase_mac(radar_addr) {
+            log::info!(
+                "{}: no MAC reported, keying the radar on its address",
+                radar_addr
+            );
+            return Some(None);
+        }
+        None
     }
 
     fn process_locator_report(
@@ -136,13 +203,7 @@ impl KodenLocator {
         let report_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
         let send_command_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
 
-        // A Koden radar will tell us its own MAC if asked. Until it has,
-        // hold off rather than key it on an address a later DHCP lease
-        // would change: the radar answers on the port discovery already
-        // listens on, and keeps talking, so the next packet brings us
-        // back here with an identity in hand.
-        let Some(hardware_id) = self.macs.get(radar_addr.ip()).cloned() else {
-            request_mac(&radar_addr);
+        let Some(hardware_id) = self.identity_for(&radar_addr) else {
             return;
         };
 
@@ -151,7 +212,7 @@ impl KodenLocator {
             &self.args,
             Brand::Koden,
             None, // serial number discovered later
-            Some(hardware_id.as_str()),
+            hardware_id.as_deref(),
             None, // no dual range
             PIXEL_VALUES,
             SPOKES,
@@ -251,5 +312,104 @@ mod tests {
 
         assert!(!locator.record_mac(&RADAR, &short));
         assert!(locator.macs.is_empty());
+    }
+
+    /// Malformed responses must not become an identity: a wrong hardware
+    /// id is worse than none, since two radars could share it.
+    #[test]
+    fn malformed_mac_responses_are_refused() {
+        let mut locator = locator();
+        let good = [
+            STATUS_PREFIX,
+            CMD_MAC_ADDRESS,
+            0x00,
+            0x0e,
+            0xc6,
+            0x12,
+            0x34,
+            0x56,
+            PACKET_END,
+        ];
+
+        let mut no_terminator = good;
+        no_terminator[MAC_RESPONSE_LEN - 1] = 0x00;
+        assert!(!locator.record_mac(&RADAR, &no_terminator));
+
+        let mut overlong = good.to_vec();
+        overlong.push(0x00);
+        assert!(!locator.record_mac(&RADAR, &overlong));
+
+        assert!(locator.macs.is_empty(), "nothing malformed may be cached");
+        assert!(
+            locator.record_mac(&RADAR, &good),
+            "a clean response is taken"
+        );
+    }
+
+    /// A radar that answers is keyed on the MAC it reported.
+    #[test]
+    fn a_radar_that_reports_its_mac_is_keyed_on_it() {
+        let mut locator = locator();
+        let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
+        let response = [
+            STATUS_PREFIX,
+            CMD_MAC_ADDRESS,
+            0x00,
+            0x0e,
+            0xc6,
+            0x12,
+            0x34,
+            0x56,
+            PACKET_END,
+        ];
+
+        assert_eq!(locator.identity_for(&addr), None, "asked, and waiting");
+        assert!(locator.record_mac(&RADAR, &response));
+        assert_eq!(
+            locator.identity_for(&addr),
+            Some(Some("000ec6123456".to_string()))
+        );
+    }
+
+    /// A radar that never answers must still appear. No Koden unit has
+    /// been available to test against, so the address fallback is what
+    /// keeps an unresponsive one usable.
+    #[test]
+    fn a_silent_radar_falls_back_to_its_address() {
+        let mut locator = locator();
+        let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
+
+        assert_eq!(locator.identity_for(&addr), None, "waits while asking");
+
+        // Exhaust the budget rather than sleeping through it.
+        let expired = Instant::now() - MAC_REQUEST_BUDGET - Duration::from_secs(1);
+        locator.asked.insert(RADAR, (expired, expired));
+
+        assert_eq!(
+            locator.identity_for(&addr),
+            Some(None),
+            "an unresponsive radar is keyed on its address"
+        );
+    }
+
+    /// Koden image frames arrive continuously, so a request per accepted
+    /// packet would be a flood.
+    #[test]
+    fn mac_requests_are_rate_limited() {
+        let mut locator = locator();
+        let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
+
+        locator.identity_for(&addr);
+        let (_, after_first) = locator.asked[&RADAR];
+
+        for _ in 0..50 {
+            locator.identity_for(&addr);
+        }
+        let (_, after_many) = locator.asked[&RADAR];
+
+        assert_eq!(
+            after_first, after_many,
+            "no further request inside the interval"
+        );
     }
 }

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -39,6 +39,20 @@ const MAC_REQUEST_BUDGET: Duration = Duration::from_secs(5);
 /// continuously.
 const MAC_REQUEST_INTERVAL: Duration = Duration::from_millis(500);
 
+/// What to key a radar on, once [`KodenLocator::identity_for`] has looked
+/// at what the radar has told us so far.
+#[derive(Debug, PartialEq, Eq)]
+enum Identity {
+    /// The radar reported this MAC; key on it.
+    Known(String),
+    /// Nothing yet, and it is time to ask again.
+    Ask,
+    /// Nothing yet; an answer may still arrive, so do not ask again.
+    Wait,
+    /// The radar never answered. Key on its address, as before.
+    UseAddress,
+}
+
 #[derive(Clone)]
 struct KodenLocator {
     args: Cli,
@@ -94,10 +108,22 @@ impl KodenLocator {
         self.macs.insert(*radar_addr, mac).is_none()
     }
 
-    /// Ask a radar for its MAC, at most once every
-    /// [`MAC_REQUEST_INTERVAL`], and report whether the budget for an
-    /// answer has run out.
-    fn chase_mac(&mut self, radar_addr: &SocketAddrV4) -> bool {
+    /// What to key a radar on, and whether it is time to ask it for its
+    /// MAC again.
+    ///
+    /// Deciding is separate from asking: this touches only local state, so
+    /// it can be exercised without putting a datagram on the network.
+    ///
+    /// A Koden radar will tell us its own MAC, and it answers on the port
+    /// discovery already listens on. Waiting briefly for that is worth it,
+    /// because an address-derived key moves with the DHCP lease. But only
+    /// briefly: no Koden unit has been available to test against, so one
+    /// that never answers must still appear.
+    fn identity_for(&mut self, radar_addr: &SocketAddrV4) -> Identity {
+        if let Some(mac) = self.macs.get(radar_addr.ip()) {
+            return Identity::Known(mac.clone());
+        }
+
         let now = Instant::now();
         let (first, last) = self
             .asked
@@ -105,36 +131,17 @@ impl KodenLocator {
             .or_insert((now, now - MAC_REQUEST_INTERVAL));
 
         if now.duration_since(*first) >= MAC_REQUEST_BUDGET {
-            return true;
-        }
-        if now.duration_since(*last) >= MAC_REQUEST_INTERVAL {
-            *last = now;
-            request_mac(radar_addr);
-        }
-        false
-    }
-
-    /// What to key this radar on: `Some(Some(mac))` once it has reported
-    /// one, `Some(None)` to fall back to its address, and `None` while it
-    /// is still being asked.
-    ///
-    /// A Koden radar will tell us its own MAC, and it answers on the port
-    /// discovery already listens on. Waiting briefly for that is worth
-    /// it, because an address-derived key moves with the DHCP lease. But
-    /// only briefly: no Koden unit has been available to test against, so
-    /// one that never answers must still appear.
-    fn identity_for(&mut self, radar_addr: &SocketAddrV4) -> Option<Option<String>> {
-        if let Some(mac) = self.macs.get(radar_addr.ip()) {
-            return Some(Some(mac.clone()));
-        }
-        if self.chase_mac(radar_addr) {
             log::info!(
                 "{}: no MAC reported, keying the radar on its address",
                 radar_addr
             );
-            return Some(None);
+            return Identity::UseAddress;
         }
-        None
+        if now.duration_since(*last) >= MAC_REQUEST_INTERVAL {
+            *last = now;
+            return Identity::Ask;
+        }
+        Identity::Wait
     }
 
     fn process_locator_report(
@@ -203,8 +210,14 @@ impl KodenLocator {
         let report_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
         let send_command_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
 
-        let Some(hardware_id) = self.identity_for(&radar_addr) else {
-            return;
+        let hardware_id = match self.identity_for(&radar_addr) {
+            Identity::Known(mac) => Some(mac),
+            Identity::Ask => {
+                request_mac(&radar_addr);
+                return;
+            }
+            Identity::Wait => return,
+            Identity::UseAddress => None,
         };
 
         let radar_info = RadarInfo::new(
@@ -363,11 +376,11 @@ mod tests {
             PACKET_END,
         ];
 
-        assert_eq!(locator.identity_for(&addr), None, "asked, and waiting");
+        assert_eq!(locator.identity_for(&addr), Identity::Ask);
         assert!(locator.record_mac(&RADAR, &response));
         assert_eq!(
             locator.identity_for(&addr),
-            Some(Some("000ec6123456".to_string()))
+            Identity::Known("000ec6123456".to_string())
         );
     }
 
@@ -379,7 +392,7 @@ mod tests {
         let mut locator = locator();
         let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
 
-        assert_eq!(locator.identity_for(&addr), None, "waits while asking");
+        assert_eq!(locator.identity_for(&addr), Identity::Ask);
 
         // Exhaust the budget rather than sleeping through it.
         let expired = Instant::now() - MAC_REQUEST_BUDGET - Duration::from_secs(1);
@@ -387,29 +400,25 @@ mod tests {
 
         assert_eq!(
             locator.identity_for(&addr),
-            Some(None),
+            Identity::UseAddress,
             "an unresponsive radar is keyed on its address"
         );
     }
 
     /// Koden image frames arrive continuously, so a request per accepted
-    /// packet would be a flood.
+    /// packet would be a flood. Only the first asks; the rest wait.
     #[test]
     fn mac_requests_are_rate_limited() {
         let mut locator = locator();
         let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
 
-        locator.identity_for(&addr);
-        let (_, after_first) = locator.asked[&RADAR];
-
+        assert_eq!(locator.identity_for(&addr), Identity::Ask);
         for _ in 0..50 {
-            locator.identity_for(&addr);
+            assert_eq!(
+                locator.identity_for(&addr),
+                Identity::Wait,
+                "no further request inside the interval"
+            );
         }
-        let (_, after_many) = locator.asked[&RADAR];
-
-        assert_eq!(
-            after_first, after_many,
-            "no further request inside the interval"
-        );
     }
 }

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 use std::time::{Duration, Instant};
@@ -65,6 +65,10 @@ struct KodenLocator {
     /// asked, so requests stay bounded and a radar that never answers is
     /// still registered.
     asked: HashMap<Ipv4Addr, (Instant, Instant)>,
+    /// Radars already registered on their address because no MAC arrived
+    /// in time. Nothing re-keys a registered radar, so the decision has
+    /// to stand for the session.
+    settled: HashSet<Ipv4Addr>,
 }
 
 impl RadarLocator for KodenLocator {
@@ -90,6 +94,7 @@ impl KodenLocator {
             args,
             macs: HashMap::new(),
             asked: HashMap::new(),
+            settled: HashSet::new(),
         }
     }
 
@@ -102,6 +107,18 @@ impl KodenLocator {
     fn record_mac(&mut self, radar_addr: &Ipv4Addr, report: &[u8]) -> bool {
         if report.len() != MAC_RESPONSE_LEN || report[MAC_RESPONSE_LEN - 1] != PACKET_END {
             log::debug!("{}: ignoring a malformed MAC response", radar_addr);
+            return false;
+        }
+        if self.settled.contains(radar_addr) {
+            // The radar is already registered under its address. Taking
+            // the MAC now would build a differently keyed RadarInfo, and
+            // SharedRadars::add dedupes on the exact key — so the same
+            // unit would be registered twice. It keys on its MAC from the
+            // next start, where the saved settings follow it across.
+            log::debug!(
+                "{}: MAC arrived after the radar was keyed on its address, ignoring",
+                radar_addr
+            );
             return false;
         }
         let mac: String = report[2..8].iter().map(|b| format!("{:02x}", b)).collect();
@@ -120,6 +137,9 @@ impl KodenLocator {
     /// briefly: no Koden unit has been available to test against, so one
     /// that never answers must still appear.
     fn identity_for(&mut self, radar_addr: &SocketAddrV4) -> Identity {
+        if self.settled.contains(radar_addr.ip()) {
+            return Identity::UseAddress;
+        }
         if let Some(mac) = self.macs.get(radar_addr.ip()) {
             return Identity::Known(mac.clone());
         }
@@ -135,6 +155,8 @@ impl KodenLocator {
                 "{}: no MAC reported, keying the radar on its address",
                 radar_addr
             );
+            self.asked.remove(radar_addr.ip());
+            self.settled.insert(*radar_addr.ip());
             return Identity::UseAddress;
         }
         if now.duration_since(*last) >= MAC_REQUEST_INTERVAL {
@@ -420,5 +442,62 @@ mod tests {
                 "no further request inside the interval"
             );
         }
+    }
+
+    /// Once a radar has been registered on its address, that stands for
+    /// the session: nothing re-keys a registered radar, and building a
+    /// differently keyed RadarInfo would register the same unit twice,
+    /// since SharedRadars::add dedupes on the exact key.
+    #[test]
+    fn a_late_mac_does_not_re_key_a_settled_radar() {
+        let mut locator = locator();
+        let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
+        let response = [
+            STATUS_PREFIX,
+            CMD_MAC_ADDRESS,
+            0x00,
+            0x0e,
+            0xc6,
+            0x12,
+            0x34,
+            0x56,
+            PACKET_END,
+        ];
+
+        // Spend the budget, so the radar is registered on its address.
+        let expired = Instant::now() - MAC_REQUEST_BUDGET - Duration::from_secs(1);
+        locator.asked.insert(RADAR, (expired, expired));
+        assert_eq!(locator.identity_for(&addr), Identity::UseAddress);
+
+        // The radar answers afterwards. It must change nothing.
+        assert!(
+            !locator.record_mac(&RADAR, &response),
+            "a MAC arriving late must not be taken"
+        );
+        assert_eq!(
+            locator.identity_for(&addr),
+            Identity::UseAddress,
+            "the radar keeps the identity it was registered under"
+        );
+    }
+
+    /// And having settled, the radar is left alone: no further requests.
+    #[test]
+    fn a_settled_radar_is_not_asked_again() {
+        let mut locator = locator();
+        let addr = SocketAddrV4::new(RADAR, RADAR_PORT);
+
+        let expired = Instant::now() - MAC_REQUEST_BUDGET - Duration::from_secs(1);
+        locator.asked.insert(RADAR, (expired, expired));
+        assert_eq!(locator.identity_for(&addr), Identity::UseAddress);
+
+        for _ in 0..50 {
+            assert_eq!(
+                locator.identity_for(&addr),
+                Identity::UseAddress,
+                "a settled radar must never be asked again"
+            );
+        }
+        assert!(!locator.asked.contains_key(&RADAR), "nothing left to chase");
     }
 }

--- a/src/lib/brand/koden/mod.rs
+++ b/src/lib/brand/koden/mod.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::io;
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
 
 use crate::locator::LocatorAddress;
@@ -15,13 +16,23 @@ mod report;
 mod settings;
 
 use protocol::{
-    BEACON_ADDRESS, CONTROL_PREFIX, IMAGE_MARKER, IMG_MIN_SIZE, KEEPALIVE_PACKET, PIXEL_VALUES,
-    RADAR_PORT, RESP_POWER, RESP_WARMUP, SPOKE_LEN, SPOKES, STATUS_PREFIX,
+    BEACON_ADDRESS, CMD_MAC_ADDRESS, CONTROL_PREFIX, IMAGE_MARKER, IMG_MIN_SIZE, KEEPALIVE_PACKET,
+    MAC_ADDRESS_REQUEST, PIXEL_VALUES, RADAR_PORT, RESP_POWER, RESP_WARMUP, SPOKE_LEN, SPOKES,
+    STATUS_PREFIX,
 };
+
+/// Length of a `0xA7` MAC address response: prefix, command, six bytes
+/// of MAC, terminator.
+const MAC_RESPONSE_LEN: usize = 9;
 
 #[derive(Clone)]
 struct KodenLocator {
     args: Cli,
+    /// The MAC each radar reported for itself, from its `0xA7` response.
+    /// A Koden radar is keyed on this rather than on its address, which
+    /// changes with the DHCP lease and takes the radar's saved settings
+    /// with it.
+    macs: HashMap<Ipv4Addr, String>,
 }
 
 impl RadarLocator for KodenLocator {
@@ -43,7 +54,20 @@ impl RadarLocator for KodenLocator {
 
 impl KodenLocator {
     fn new(args: Cli) -> Self {
-        KodenLocator { args }
+        KodenLocator {
+            args,
+            macs: HashMap::new(),
+        }
+    }
+
+    /// Record the MAC from a `0xA7` response. Returns whether it was new,
+    /// so the caller only logs a radar's identity once.
+    fn record_mac(&mut self, radar_addr: &Ipv4Addr, report: &[u8]) -> bool {
+        if report.len() < MAC_RESPONSE_LEN {
+            return false;
+        }
+        let mac: String = report[2..8].iter().map(|b| format!("{:02x}", b)).collect();
+        self.macs.insert(*radar_addr, mac).is_none()
     }
 
     fn process_locator_report(
@@ -83,6 +107,13 @@ impl KodenLocator {
             return Ok(());
         }
 
+        if first == STATUS_PREFIX
+            && report[1] == CMD_MAC_ADDRESS
+            && self.record_mac(from.ip(), report)
+        {
+            log::debug!("{}: Koden radar reported its MAC", from);
+        }
+
         log::debug!(
             "Koden radar detected at {} via {} (packet: {})",
             from,
@@ -95,7 +126,7 @@ impl KodenLocator {
     }
 
     fn found(
-        &self,
+        &mut self,
         radar_addr: SocketAddrV4,
         nic_addr: Ipv4Addr,
         radars: &SharedRadars,
@@ -105,12 +136,22 @@ impl KodenLocator {
         let report_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
         let send_command_addr = SocketAddrV4::new(*radar_addr.ip(), RADAR_PORT);
 
+        // A Koden radar will tell us its own MAC if asked. Until it has,
+        // hold off rather than key it on an address a later DHCP lease
+        // would change: the radar answers on the port discovery already
+        // listens on, and keeps talking, so the next packet brings us
+        // back here with an identity in hand.
+        let Some(hardware_id) = self.macs.get(radar_addr.ip()).cloned() else {
+            request_mac(&radar_addr);
+            return;
+        };
+
         let radar_info = RadarInfo::new(
             radars,
             &self.args,
             Brand::Koden,
             None, // serial number discovered later
-            None, // no MAC on the wire
+            Some(hardware_id.as_str()),
             None, // no dual range
             PIXEL_VALUES,
             SPOKES,
@@ -148,5 +189,67 @@ pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
             vec![&KEEPALIVE_PACKET],
             Box::new(KodenLocator::new(args.clone())),
         ));
+    }
+}
+
+/// Ask a radar for its MAC address. Fire-and-forget: the answer arrives
+/// as a `0xA7` status packet on the port the locator already listens on,
+/// and the radar is asked again on its next packet if it does not reply.
+fn request_mac(radar_addr: &SocketAddrV4) {
+    if let Ok(socket) = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)) {
+        let _ = socket.set_nonblocking(true);
+        let _ = socket.send_to(&MAC_ADDRESS_REQUEST, radar_addr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    const RADAR: Ipv4Addr = Ipv4Addr::new(172, 31, 3, 12);
+
+    fn locator() -> KodenLocator {
+        KodenLocator::new(Cli::parse_from(["mayara-server"]))
+    }
+
+    /// A `0xA7` response: prefix, command, the radar's own six MAC bytes,
+    /// terminator. The identity must come out in the same compact hex form
+    /// other brands use, so keys look alike however they were obtained.
+    #[test]
+    fn mac_response_yields_the_radar_identity() {
+        let mut locator = locator();
+        let report = [
+            STATUS_PREFIX,
+            CMD_MAC_ADDRESS,
+            0x00,
+            0x0e,
+            0xc6,
+            0x12,
+            0x34,
+            0x56,
+            0x0d,
+        ];
+
+        assert!(locator.record_mac(&RADAR, &report), "first MAC is new");
+        assert_eq!(
+            locator.macs.get(&RADAR).map(String::as_str),
+            Some("000ec6123456")
+        );
+        assert!(
+            !locator.record_mac(&RADAR, &report),
+            "the same MAC again is not news"
+        );
+    }
+
+    /// A truncated response must leave the radar unidentified rather than
+    /// produce a short identity that could collide with another unit's.
+    #[test]
+    fn truncated_mac_response_is_ignored() {
+        let mut locator = locator();
+        let short = [STATUS_PREFIX, CMD_MAC_ADDRESS, 0x00, 0x0e, 0xc6];
+
+        assert!(!locator.record_mac(&RADAR, &short));
+        assert!(locator.macs.is_empty());
     }
 }

--- a/src/lib/brand/koden/protocol.rs
+++ b/src/lib/brand/koden/protocol.rs
@@ -172,6 +172,13 @@ pub(crate) const STARTUP_REQUEST: [u8; 20] = [
     0x26, 0x72, 0xFF, 0x0D, // Request model code
 ];
 
+/// Standalone MAC address request. The radar answers with a `0xA7`
+/// status packet carrying its own MAC, on the same port discovery runs
+/// on — so the locator can ask for a radar's identity before it decides
+/// what to call it, rather than waiting for the report receiver's
+/// [`STARTUP_REQUEST`].
+pub(crate) const MAC_ADDRESS_REQUEST: [u8; 4] = [0x26, CMD_MAC_ADDRESS, 0x11, 0x0D];
+
 /// Keep-alive packet (4 bytes).
 pub(crate) const KEEPALIVE_PACKET: [u8; 4] = [0x26, 0x69, 0x22, 0x0D];
 

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -382,12 +382,21 @@ impl RaymarineLocator {
                         beacon_report
                     };
 
+                    // The beacons' link_id is the radar's own hardware
+                    // identity: stable across reboots, unique per unit, and
+                    // independent of the address it is reachable on. Its low
+                    // half identifies the unit and its high half the role
+                    // (0xd680 radar, 0xcbc0 the W3 bridge in the same
+                    // housing), so the tail of the formatted value is what
+                    // distinguishes one radar from another.
+                    let hardware_id = format!("{:08x}", link_id);
+
                     let location_info: RadarInfo = RadarInfo::new(
                         radars,
                         &self.args,
                         Brand::Raymarine,
                         None,
-                        None,
+                        Some(hardware_id.as_str()),
                         None,
                         0,
                         spokes_per_revolution,
@@ -800,6 +809,7 @@ pub(super) fn new(args: &Cli, addresses: &mut Vec<LocatorAddress>) {
 
 #[cfg(test)]
 mod tests {
+
     use std::net::{Ipv4Addr, SocketAddrV4};
 
     use clap::Parser;
@@ -1111,6 +1121,15 @@ mod tests {
             .expect("radar should be created");
         assert_eq!(model, BaseModel::RD);
         assert_eq!(info.controls.model_name(), Some("RD".to_string()));
+        // Identity comes from the beacons' link_id (0xb8c0c053), not from
+        // the address: this dome's IP changes with its DHCP lease, and its
+        // report address is a multicast group shared with its listeners.
+        assert_eq!(
+            info.hardware_id.as_deref(),
+            Some("b8c0c053"),
+            "the radar's identity must be its link_id"
+        );
+        assert_eq!(info.key(), "rayc053");
         assert_eq!(
             info.send_command_addr,
             SocketAddrV4::new(Ipv4Addr::new(10, 18, 106, 155), 2573)

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -350,31 +350,36 @@ impl Persistence {
         }
     }
 
-    /// Settings saved under a radar's old address-derived key, when it has
-    /// none under its current one. Returns `None` once the radar has been
-    /// saved under its new key, so this only ever fires on the first run
-    /// after the upgrade.
-    fn adopt_legacy_entry(&self, info: &RadarInfo) -> Option<&Radar> {
-        let legacy = crate::radar::legacy_address_key(info);
-        if legacy == info.key() {
-            return None;
+    /// Move settings saved under a radar's address-derived key across to
+    /// the key it is known by now, once.
+    ///
+    /// The move matters as much as the copy: leaving the old entry behind
+    /// would have every later start find it again, and would let a
+    /// different radar that happens to take the same address inherit the
+    /// settings of the one it replaced.
+    fn take_legacy_entry(&mut self, key: &str, legacy: &str) -> bool {
+        if legacy == key || self.config.radars.contains_key(key) {
+            return false;
         }
-        let p = self.config.radars.get(&legacy)?;
+        let Some(entry) = self.config.radars.remove(legacy) else {
+            return false;
+        };
         log::info!(
-            "{}: adopting settings saved under its previous key '{}'",
-            info.key(),
+            "{}: adopting the settings saved under its previous key '{}'",
+            key,
             legacy
         );
-        Some(p)
+        self.config.radars.insert(key.to_string(), entry);
+        if !self.path.as_os_str().is_empty() {
+            self.save();
+        }
+        true
     }
 
-    pub(crate) fn update_info_from_persistence(&self, info: &mut RadarInfo) {
-        if let Some(p) = self
-            .config
-            .radars
-            .get(&info.key())
-            .or_else(|| self.adopt_legacy_entry(info))
-        {
+    pub(crate) fn update_info_from_persistence(&mut self, info: &mut RadarInfo) {
+        self.take_legacy_entry(&info.key(), &crate::radar::legacy_address_key(info));
+
+        if let Some(p) = self.config.radars.get(&info.key()) {
             if let Some(model_name) = p.model_name.as_ref() {
                 info.controls.set_model_name(model_name.clone());
             }
@@ -427,5 +432,79 @@ impl Persistence {
             info.controls.set_arpa_max_speed(p.arpa_max_speed);
             info.controls.set_doppler_auto_track(p.doppler_auto_track);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn persistence_with(key: &str, user_name: &str) -> Persistence {
+        let mut radars = HashMap::new();
+        radars.insert(
+            key.to_string(),
+            Radar {
+                user_name: user_name.to_string(),
+                ..Default::default()
+            },
+        );
+        Persistence {
+            config: Config { radars },
+            timestamp: SystemTime::UNIX_EPOCH,
+            path: PathBuf::new(),
+        }
+    }
+
+    /// Settings follow a radar to its new key exactly once, and the old
+    /// entry does not linger: leaving it would have every later start find
+    /// it again, and would let a different radar that later takes the same
+    /// address inherit the settings of the one it replaced.
+    #[test]
+    fn legacy_settings_move_to_the_stable_key() {
+        let mut p = persistence_with("kod0102", "Bow Radar");
+
+        assert!(p.take_legacy_entry("kod3456", "kod0102"));
+        assert_eq!(
+            p.config.radars.get("kod3456").map(|r| r.user_name.as_str()),
+            Some("Bow Radar")
+        );
+        assert!(
+            !p.config.radars.contains_key("kod0102"),
+            "the old entry must not linger"
+        );
+
+        assert!(
+            !p.take_legacy_entry("kod3456", "kod0102"),
+            "a second start has nothing left to move"
+        );
+    }
+
+    /// A radar that already has settings under its stable key keeps them:
+    /// whatever is under an address key is older and must not win.
+    #[test]
+    fn an_existing_stable_entry_is_not_overwritten() {
+        let mut p = persistence_with("kod0102", "Old Name");
+        p.config.radars.insert(
+            "kod3456".to_string(),
+            Radar {
+                user_name: "Current Name".to_string(),
+                ..Default::default()
+            },
+        );
+
+        assert!(!p.take_legacy_entry("kod3456", "kod0102"));
+        assert_eq!(
+            p.config.radars.get("kod3456").map(|r| r.user_name.as_str()),
+            Some("Current Name")
+        );
+    }
+
+    /// Brands that never had an identity key on their address as before,
+    /// so there is nothing to move.
+    #[test]
+    fn a_radar_still_keyed_on_its_address_moves_nothing() {
+        let mut p = persistence_with("gar0102", "Radar");
+        assert!(!p.take_legacy_entry("gar0102", "gar0102"));
+        assert!(p.config.radars.contains_key("gar0102"));
     }
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -350,8 +350,31 @@ impl Persistence {
         }
     }
 
+    /// Settings saved under a radar's old address-derived key, when it has
+    /// none under its current one. Returns `None` once the radar has been
+    /// saved under its new key, so this only ever fires on the first run
+    /// after the upgrade.
+    fn adopt_legacy_entry(&self, info: &RadarInfo) -> Option<&Radar> {
+        let legacy = crate::radar::legacy_address_key(info);
+        if legacy == info.key() {
+            return None;
+        }
+        let p = self.config.radars.get(&legacy)?;
+        log::info!(
+            "{}: adopting settings saved under its previous key '{}'",
+            info.key(),
+            legacy
+        );
+        Some(p)
+    }
+
     pub(crate) fn update_info_from_persistence(&self, info: &mut RadarInfo) {
-        if let Some(p) = self.config.radars.get(&info.key()) {
+        if let Some(p) = self
+            .config
+            .radars
+            .get(&info.key())
+            .or_else(|| self.adopt_legacy_entry(info))
+        {
             if let Some(model_name) = p.model_name.as_ref() {
                 info.controls.set_model_name(model_name.clone());
             }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -473,6 +473,23 @@ fn base_key<'a>(key: &'a str, dual: Option<&str>) -> &'a str {
     }
 }
 
+/// The key this radar had before it was identified by a stable hardware
+/// identity — the address-derived fallback, and nothing else.
+///
+/// Radars that gained an identity change key exactly once, on the upgrade
+/// that introduced it. Deriving the old key through the very same function
+/// that produced it keeps the two from drifting apart: a migration that
+/// guessed the format wrongly would silently adopt nothing.
+pub(crate) fn legacy_address_key(info: &RadarInfo) -> String {
+    radar_key(
+        info.brand.to_prefix(),
+        None,
+        None,
+        info.dual.as_deref(),
+        &info.addr,
+    )
+}
+
 impl RadarInfo {
     #[allow(clippy::too_many_arguments)] // every radar field comes flat from per-brand discovery; the brands are the only callers
     pub fn new<F>(
@@ -2349,6 +2366,18 @@ mod tests {
         assert_eq!(
             radar_key("fur", Some(""), Some("00d01d057045"), None, &test_addr()),
             "fur7045"
+        );
+    }
+
+    #[test]
+    fn legacy_address_key_matches_the_address_fallback() {
+        // The migration key must be byte-identical to what a radar with no
+        // serial and no hardware identity used to be called, or settings
+        // saved under the old key would never be found.
+        assert_eq!(radar_key("ray", None, None, None, &test_addr()), "ray0102");
+        assert_eq!(
+            radar_key("ray", None, None, Some("B"), &test_addr()),
+            "ray0102B"
         );
     }
 

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -473,13 +473,12 @@ fn base_key<'a>(key: &'a str, dual: Option<&str>) -> &'a str {
     }
 }
 
-/// The key this radar had before it was identified by a stable hardware
-/// identity — the address-derived fallback, and nothing else.
+/// The key a radar has when nothing identifies it but its address.
 ///
-/// Radars that gained an identity change key exactly once, on the upgrade
-/// that introduced it. Deriving the old key through the very same function
-/// that produced it keeps the two from drifting apart: a migration that
-/// guessed the format wrongly would silently adopt nothing.
+/// Used to find settings saved before the radar had a hardware identity.
+/// Deriving it through the very function that produces the real key keeps
+/// the two from drifting apart: a lookup that guessed the format wrongly
+/// would silently find nothing.
 pub(crate) fn legacy_address_key(info: &RadarInfo) -> String {
     radar_key(
         info.brand.to_prefix(),

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -77,6 +77,16 @@ async fn replay_garmin_xhd() {
                         if info.controls.model_name().is_some() && !info.ranges.all.is_empty() {
                             assert!(key.starts_with("gar"), "expected Garmin key, got: {}", key);
                             assert_eq!(info.brand, mayara::Brand::Garmin);
+                            // Keyed on the heartbeat's unique id (0x08d40aa0),
+                            // not the address: Garmin puts every radar on
+                            // 172.16.2.0, so the address tells radars apart
+                            // on no boat at all.
+                            assert_eq!(
+                                info.hardware_id.as_deref(),
+                                Some("08d40aa0"),
+                                "identity must come from the CDM heartbeat"
+                            );
+                            assert_eq!(key, "gar0aa0A", "dual-range radar keeps its range suffix");
                             let model = info.controls.model_name().unwrap();
                             assert!(model.contains("xHD"), "expected xHD model, got: {}", model);
                             assert!(!info.doppler, "xHD should not support Doppler");

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -89,6 +89,22 @@ async fn replay_raymarine_quantum() {
                             );
                             assert!(info.doppler, "Quantum should support Doppler");
                             assert_eq!(info.spokes_per_revolution, 250);
+                            // Identity and serial come from different places
+                            // and must not be confused. The key is the
+                            // beacons' link_id (0xd68168b4), which survives a
+                            // change of address; the serial is the real one
+                            // off the 0x280001 info report, for display.
+                            assert_eq!(key, "ray68b4", "key must come from link_id");
+                            assert_eq!(
+                                info.serial_no.as_deref(),
+                                Some("1140360"),
+                                "the radar's real serial must be reported"
+                            );
+                            assert!(
+                                info.controls.user_name().contains("1140360"),
+                                "the serial should reach the user-visible name, got: {}",
+                                info.controls.user_name()
+                            );
                             break;
                         }
                     }


### PR DESCRIPTION
A radar's saved settings — gain, range units, guard zones, the name you gave it — were lost whenever its IP address changed. On a boat where the radar picks up a new DHCP lease, it came back looking like a radar mayara had never seen. Two radars of the same brand could also collide on one identity and only one of them would appear.

Radars were identified by the low 16 bits of their address, because nothing better was being read off the wire. In fact every brand publishes something better, and mayara was already receiving it.

## Where each identity comes from

| brand | identity | message |
|---|---|---|
| Raymarine | `link_id` | 36/56-byte beacons |
| Garmin | unique id | `0x038E` CDM heartbeat |
| Koden | its own MAC | `0xA7` response |

All three are available at discovery, before a radar is named, and all three are stable across reboots and independent of the address. Verified against recordings: Raymarine link_ids hold across five separate captures of one unit and across a power-up; Garmin's id is unchanged across a cold boot; both arrive from two different source IPs for the same device.

Koden already asked for its MAC — the answer was logged and discarded. The request now comes from the locator, which listens on the port the answer arrives on.

The address remains the last resort for anything that publishes nothing.

## Upgrade effect

Radars that gain an identity change key once. Settings saved under the old address-derived key are adopted automatically on the first run, so nothing is lost. The old key is derived by calling the very function that produced it, so the migration cannot drift out of step with the format it is looking for.

## Also fixed

Garmin's `product_id` and its device name and alias were stored under the CDM port and looked up under the radar's data port, so they never reached the radar: the model name fell back to capability inference and a user's own alias was ignored. Keyed by address now. It is a prerequisite for the identity work above rather than a separate change, but happy to split it if you would rather review it on its own.

## Testing

Unit tests for each brand's identity parse, including truncated input, plus replay assertions against the shipped fixtures pinning the key to the identity — `ray68b4` from a link_id, `gar0aa0A` from a heartbeat id — and, for Raymarine, pinning the key apart from the real serial number that is shown to the operator.

## Note

Earlier revisions of this branch derived identity from the host's ARP cache. That is gone: it needed a wait, platform-specific table reads, and traffic to provoke resolution, and it could not work in replay. Reading each brand's own protocol removes all of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Use stable protocol-provided identifiers for radar identity:

- Raymarine uses beacon `link_id`.
- Garmin uses the CDM heartbeat `unique_id`.
- Koden uses the device MAC address.
- The IP address remains the fallback.

Migrate saved settings from the previous address-derived key. Key Garmin metadata by IP address instead of CDM port. Keep radars visible while identity is unavailable. Add identity parsing, truncated-message, malformed-response, retry, throttling, migration, and replay tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->