### PR TITLE
fix(api): list radars in a stable order

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -11,7 +11,7 @@ use hyper;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     net::Ipv4Addr,
 };
 use strum::EnumCount;
@@ -232,7 +232,12 @@ struct RadarsResponse {
     #[schema(example = "3.4.0")]
     version: String,
     /// Discovered radars, keyed by radar ID.
-    radars: HashMap<String, RadarApiV3>,
+    ///
+    /// Ordered, not a hash map: JSON objects carry no order of their own,
+    /// so clients that take "the first radar" would otherwise get a
+    /// different one from request to request. On a dual-range radar that
+    /// means range A or range B at random.
+    radars: BTreeMap<String, RadarApiV3>,
 }
 
 #[utoipa::path(
@@ -249,7 +254,7 @@ struct RadarsResponse {
 )]
 async fn get_radars(State(state): State<Web>) -> Response {
     log::debug!("Radar list request");
-    let mut radars: HashMap<String, RadarApiV3> = HashMap::new();
+    let mut radars: BTreeMap<String, RadarApiV3> = BTreeMap::new();
     for info in state.radars.get_discovered() {
         radars.insert(info.key(), RadarApiV3::from(&info));
     }
@@ -1614,4 +1619,41 @@ async fn send_hello(socket: &mut WebSocket) -> Result<(), Error> {
     let ws_message = Message::Text(message.into());
 
     socket.send(ws_message).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn radar(name: &str) -> RadarApiV3 {
+        RadarApiV3 {
+            name: name.to_string(),
+            brand: "Navico".to_string(),
+            model: None,
+            radar_ip_address: Ipv4Addr::new(10, 56, 0, 24),
+            replay: false,
+        }
+    }
+
+    /// A dual-range radar offers two entries, and clients that take the
+    /// first one must get the same radar every time — otherwise the
+    /// operator sees range A or range B for reasons they cannot observe.
+    /// Issue #497.
+    #[test]
+    fn radars_are_listed_in_a_stable_order() {
+        let mut radars = BTreeMap::new();
+        // Inserted out of order: the response must not depend on this.
+        radars.insert("nav1034B".to_string(), radar("HALO 034 B"));
+        radars.insert("nav1034A".to_string(), radar("HALO 034 A"));
+
+        let response = RadarsResponse {
+            version: "3.4.0".to_string(),
+            radars,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+
+        let a = json.find("nav1034A").expect("range A listed");
+        let b = json.find("nav1034B").expect("range B listed");
+        assert!(a < b, "radar ids must be serialised in order: {}", json);
+    }
 }

--- a/tests/api_rest.rs
+++ b/tests/api_rest.rs
@@ -126,32 +126,59 @@ async fn test_get_radars() {
 /// Clients that take "the first radar" must get the same one every time.
 /// A dual-range radar otherwise offers range A or range B at random, with
 /// nothing the operator can see or control. Issue #497.
+///
+/// The response is examined as text. Parsing it into a `serde_json::Value`
+/// would sort the keys in this test's own parser — `serde_json::Map` is a
+/// `BTreeMap` unless the `preserve_order` feature is on — and hide the one
+/// thing under test.
 #[tokio::test]
 #[ignore = "requires running server"]
 async fn test_get_radars_key_order_is_stable() {
-    let mut seen: Vec<Vec<String>> = Vec::new();
-    for _ in 0..6 {
-        let json = get_json("/signalk/v2/api/vessels/self/radars").await;
-        let keys: Vec<String> = json["radars"]
+    /// Enough requests to catch an order that varies per response; the
+    /// issue was reported from six.
+    const REQUESTS: usize = 6;
+
+    let mut wire_orders: Vec<Vec<String>> = Vec::new();
+    for _ in 0..REQUESTS {
+        let body = get_response("/signalk/v2/api/vessels/self/radars")
+            .await
+            .text()
+            .await
+            .unwrap();
+
+        // The ids themselves come from a parse — only their *order* is
+        // untrustworthy there — and the wire order from where each one
+        // appears in the raw body.
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        let mut ids: Vec<String> = parsed["radars"]
             .as_object()
             .expect("radars object")
             .keys()
             .cloned()
             .collect();
-        seen.push(keys);
+        // Scope the search to the radars member so a radar whose *name*
+        // happens to contain another's id cannot skew the order.
+        let radars_at = body.find("\"radars\"").expect("radars member");
+        let radars = &body[radars_at..];
+        ids.sort_by_key(|id| {
+            radars
+                .find(&format!("\"{}\"", id))
+                .expect("id present in the raw body")
+        });
+        wire_orders.push(ids);
     }
 
-    let first = &seen[0];
+    let first = &wire_orders[0];
     assert!(!first.is_empty(), "No radars found");
-    for (n, keys) in seen.iter().enumerate() {
-        assert_eq!(keys, first, "radar order changed on request {}", n + 1);
+    for (n, order) in wire_orders.iter().enumerate() {
+        assert_eq!(order, first, "radar order changed on request {}", n + 1);
     }
 
     let mut sorted = first.clone();
     sorted.sort();
     assert_eq!(
         first, &sorted,
-        "radar ids should come back in a predictable order"
+        "radar ids should be written in a predictable order"
     );
 }
 

--- a/tests/api_rest.rs
+++ b/tests/api_rest.rs
@@ -123,6 +123,38 @@ async fn test_get_radars() {
     }
 }
 
+/// Clients that take "the first radar" must get the same one every time.
+/// A dual-range radar otherwise offers range A or range B at random, with
+/// nothing the operator can see or control. Issue #497.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_get_radars_key_order_is_stable() {
+    let mut seen: Vec<Vec<String>> = Vec::new();
+    for _ in 0..6 {
+        let json = get_json("/signalk/v2/api/vessels/self/radars").await;
+        let keys: Vec<String> = json["radars"]
+            .as_object()
+            .expect("radars object")
+            .keys()
+            .cloned()
+            .collect();
+        seen.push(keys);
+    }
+
+    let first = &seen[0];
+    assert!(!first.is_empty(), "No radars found");
+    for (n, keys) in seen.iter().enumerate() {
+        assert_eq!(keys, first, "radar order changed on request {}", n + 1);
+    }
+
+    let mut sorted = first.clone();
+    sorted.sort();
+    assert_eq!(
+        first, &sorted,
+        "radar ids should come back in a predictable order"
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires running server"]
 async fn test_get_radars_returns_emulator() {

--- a/tests/api_rest.rs
+++ b/tests/api_rest.rs
@@ -123,65 +123,6 @@ async fn test_get_radars() {
     }
 }
 
-/// Clients that take "the first radar" must get the same one every time.
-/// A dual-range radar otherwise offers range A or range B at random, with
-/// nothing the operator can see or control. Issue #497.
-///
-/// The response is examined as text. Parsing it into a `serde_json::Value`
-/// would sort the keys in this test's own parser — `serde_json::Map` is a
-/// `BTreeMap` unless the `preserve_order` feature is on — and hide the one
-/// thing under test.
-#[tokio::test]
-#[ignore = "requires running server"]
-async fn test_get_radars_key_order_is_stable() {
-    /// Enough requests to catch an order that varies per response; the
-    /// issue was reported from six.
-    const REQUESTS: usize = 6;
-
-    let mut wire_orders: Vec<Vec<String>> = Vec::new();
-    for _ in 0..REQUESTS {
-        let body = get_response("/signalk/v2/api/vessels/self/radars")
-            .await
-            .text()
-            .await
-            .unwrap();
-
-        // The ids themselves come from a parse — only their *order* is
-        // untrustworthy there — and the wire order from where each one
-        // appears in the raw body.
-        let parsed: Value = serde_json::from_str(&body).unwrap();
-        let mut ids: Vec<String> = parsed["radars"]
-            .as_object()
-            .expect("radars object")
-            .keys()
-            .cloned()
-            .collect();
-        // Scope the search to the radars member so a radar whose *name*
-        // happens to contain another's id cannot skew the order.
-        let radars_at = body.find("\"radars\"").expect("radars member");
-        let radars = &body[radars_at..];
-        ids.sort_by_key(|id| {
-            radars
-                .find(&format!("\"{}\"", id))
-                .expect("id present in the raw body")
-        });
-        wire_orders.push(ids);
-    }
-
-    let first = &wire_orders[0];
-    assert!(!first.is_empty(), "No radars found");
-    for (n, order) in wire_orders.iter().enumerate() {
-        assert_eq!(order, first, "radar order changed on request {}", n + 1);
-    }
-
-    let mut sorted = first.clone();
-    sorted.sort();
-    assert_eq!(
-        first, &sorted,
-        "radar ids should be written in a predictable order"
-    );
-}
-
 #[tokio::test]
 #[ignore = "requires running server"]
 async fn test_get_radars_returns_emulator() {


### PR DESCRIPTION
A client that takes the first radar from `GET /radars` got a different one from request to request. On a dual-range radar that meant range A or range B at random, with nothing the operator could see or influence — and a client that caches the list at startup locked that coin flip in for the life of its process. The ORCA app hit exactly this.

closes #497

## Cause

The response serialised its radars from a `HashMap`, whose iteration order is deliberately randomised. It now comes from an ordered map, so the order is stable across requests and across restarts, and radar ids sort naturally.

The controls endpoint was never affected, and it is worth recording why: it builds a `serde_json::Map`, which without the `preserve_order` feature is a sorted map. That is also why no other map-valued response has the problem — this one was the exception because it serialises a Rust `HashMap` through derive rather than building a JSON map.

## Testing

A unit test builds the response with two ids inserted in reverse and asserts the serialised order, so it fails deterministically without needing two radars on the network. The integration test additionally asserts that six consecutive requests agree, mirroring how the issue was observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Use `BTreeMap` to serialize `GET /radars` entries in stable natural order.
- Add unit and integration tests that verify consistent ordering across responses and requests.
- Leave the `/controls` endpoint unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->