### PR TITLE
fix(gui): stop AIS overlay subscribing to own ship

### DIFF
--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -567,6 +567,24 @@ async function subscribeToAisViaSignalK() {
       subscribe: [{ path: "*" }],
     };
     socket.send(JSON.stringify(subscription));
+
+    // `vessels.*` matches own ship too, and own ship is the single loudest
+    // context on a real boat — every N2K-derived path (engine, wind, water
+    // temperature, attitude) at native update rate. Measured against a live
+    // Signal K server: 413 deltas/s total, of which 71% were own ship and
+    // only ~110/s were the AIS targets this overlay actually draws. That
+    // volume is parsed on the main thread, which starves spoke rendering —
+    // the radar picture stutters and stalls while the socket is busy.
+    //
+    // The overlay never needs own ship from here: heading and position come
+    // from subscribeToHeading() on `vessels.self`. Unsubscribing keeps the
+    // wildcard path list intact (vessel names ride the empty path, so they
+    // must not be narrowed away) while dropping the bulk of the traffic.
+    const unsubscribeSelf = {
+      context: "vessels.self",
+      unsubscribe: [{ path: "*" }],
+    };
+    socket.send(JSON.stringify(unsubscribeSelf));
   };
 
   socket.onmessage = (event) => {


### PR DESCRIPTION
## Summary

On a boat with a busy NMEA 2000 bus, the radar picture in the GUI stutters, feels sluggish, and the spokes stop filling the screen — while the radar itself is transmitting normally. Switching the renderer (WebGL ↔ WebGPU) makes no difference, because rendering was never the problem.

The AIS overlay subscribes to `vessels.*` with a wildcard path list. That matches **own ship** as well as AIS targets, and on a real boat own ship is by far the loudest context: engine, wind, water temperature and attitude all arrive at native update rate. The browser JSON-parses all of it on the main thread, which starves spoke rendering.

Measured against a live Signal K server with 128 AIS targets visible:

| | rate |
| --- | --- |
| Total deltas received by the viewer | 413/s |
| Of which own ship | 71% |
| Actual AIS targets (what the overlay draws) | ~110/s |

`handleAisDelta` already discards self and own-ship identifiers, so this data was being parsed and then thrown away.

## Approach

Send an `unsubscribe` for `vessels.self` right after the wildcard subscription, so the server stops sending own-ship deltas instead of the client discarding them.

The wildcard path list is deliberately left intact — vessel names ride the empty path, so narrowing by leaf path would silently lose them. Heading and position continue to come from `subscribeToHeading()` on `vessels.self`, which is unaffected.

Throttling with `period` was tried first and rejected: it only halved the rate (413/s → 196/s at 2000 ms, still 150/s at 30000 ms), because the volume comes from many distinct high-rate paths rather than one fast one.

## Tested

- `cargo test` — 405 passed, 0 failed
- Wire measurement against the live Signal K server: 413/s → 110/s with the unsubscribe (73% reduction)
- Rebuilt the binary and A/B'd the old and fixed GUI bundles in a real headless browser: deltas 339 → 83, spoke frames unchanged (78 vs 79), confirming the fix does not affect spoke delivery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The AIS overlay unsubscribes from `vessels.self` after subscribing to `vessels.*`. It continues to receive vessel names through the wildcard subscription. It receives own-ship heading and position through `subscribeToHeading()`. This reduces unnecessary browser processing and GUI stuttering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->