### PR TITLE
feat(controls): snap a numeric value to the nearest settable one

### DIFF
--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -992,8 +992,13 @@ impl SharedControls {
                     cv
                 );
 
-                // Reject values not in the valid set (e.g. sparse capability bitmasks)
-                if let Some(ref valid_values) = c.item.valid_values
+                // Reject a value the control does not offer, when "nearest"
+                // would be a guess: an Enum's valid values are distinct
+                // options, not points on a scale. Numbers are snapped
+                // instead, further down in Control::set, so a client can
+                // ask for any range and get the closest one the radar has.
+                if c.item.data_type != ControlDataType::Number
+                    && let Some(ref valid_values) = c.item.valid_values
                     && let Some(ref v) = cv.value
                     && let Some(f) = v.as_f64()
                 {
@@ -2883,6 +2888,36 @@ impl Control {
     /// Return Ok(Some(())) when the value changed or it always needs
     /// to be broadcast to listeners.
     ///
+    /// The nearest value this control will accept, or `value` unchanged
+    /// when it accepts anything.
+    fn snap_to_valid_value(&self, value: f64) -> f64 {
+        let Some(valid) = self.item.valid_values.as_ref() else {
+            return value;
+        };
+        let Some(nearest) = valid
+            .iter()
+            .min_by(|a, b| {
+                let da = (**a as f64 - value).abs();
+                let db = (**b as f64 - value).abs();
+                // Ties go to the lower value, so the choice is stable
+                // rather than dependent on the order of the list.
+                da.partial_cmp(&db).unwrap().then(a.cmp(b))
+            })
+            .map(|v| *v as f64)
+        else {
+            return value;
+        };
+        if nearest != value {
+            log::debug!(
+                "{}: snapped {} to the nearest settable value {}",
+                self.item.control_id,
+                value,
+                nearest
+            );
+        }
+        nearest
+    }
+
     pub fn set(
         &mut self,
         mut value: f64,
@@ -2976,6 +3011,21 @@ impl Control {
             }
         }
         log::trace!("{} map value to rounded {}", self.item.control_id, value);
+
+        // A numeric control's valid_values are points on a continuum, so a
+        // value between two of them means the nearest one. Radars report
+        // ranges that are in no table at all — a Navico driving its range
+        // from a chart overlay sweeps whatever suits the chart, 9888 m
+        // between the 4 and 6 nm entries — and clients should not each
+        // have to work out what that means.
+        //
+        // Only for numbers. An Enum's valid_values are distinct options,
+        // where "nearest" has no meaning: Power lists [1, 2] for Standby
+        // and Transmit, and rounding a stray 4 to the closest entry would
+        // start the radar transmitting.
+        if self.item.data_type == ControlDataType::Number {
+            value = self.snap_to_valid_value(value);
+        }
 
         if let Some(av) = auto_value {
             let si = self.item.wire_units.map(|u| u.to_si(av).1).unwrap_or(av);
@@ -3597,6 +3647,56 @@ mod test {
     /// A guard zone dragged by its start angle arrives as that one field.
     /// The other three numbers and the enabled flag must survive, or the
     /// zone collapses to 0-0 and can never trigger.
+    /// Navico radars driving their range from a chart overlay sweep
+    /// whatever suits the chart: 9888 m sits between the 4 nm and 6 nm
+    /// entries and is in no table at all. Observed on a HALO24 — 2700,
+    /// 4517, 6543, 9888, 12645 m and more, none of them settable.
+    #[test]
+    fn a_numeric_control_snaps_a_reported_value_to_the_nearest_settable_one() {
+        let (_, mut range) = new_numeric(ControlId::Range, 57., 88896.).take();
+        range.set_valid_values(vec![7408, 11112, 14816]);
+
+        range.set(9888., None, None, None).unwrap();
+        assert_eq!(range.value, Some(11112.), "9888 is nearest 11112");
+
+        range.set(8000., None, None, None).unwrap();
+        assert_eq!(range.value, Some(7408.), "8000 is nearest 7408");
+
+        range.set(14816., None, None, None).unwrap();
+        assert_eq!(range.value, Some(14816.), "a settable value is untouched");
+    }
+
+    /// Ties go to the lower value so the result does not depend on the
+    /// order the radar happened to report its ranges in.
+    #[test]
+    fn snapping_breaks_ties_towards_the_lower_value() {
+        let (_, mut range) = new_numeric(ControlId::Range, 0., 100000.).take();
+        range.set_valid_values(vec![1000, 2000]);
+
+        range.set(1500., None, None, None).unwrap();
+        assert_eq!(range.value, Some(1000.));
+    }
+
+    /// An Enum's valid values are distinct options, where "nearest" means
+    /// nothing. Power offers [1, 2] — Standby and Transmit — so rounding a
+    /// stray Fault (4) to the closest entry would start the radar.
+    #[test]
+    fn an_enum_control_is_never_snapped() {
+        let (_, mut power) = new_list(
+            ControlId::Power,
+            &["Off", "Standby", "Transmit", "Preparing", "Fault"],
+        )
+        .take();
+        power.set_valid_values(vec![1, 2]);
+
+        power.set(4., None, None, None).unwrap();
+        assert_eq!(
+            power.value,
+            Some(4.),
+            "a Fault report must stay a Fault, not become Transmit"
+        );
+    }
+
     #[test]
     fn partial_zone_update_keeps_unsupplied_fields() {
         let (_, mut zone) = new_zone(

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -971,6 +971,36 @@ impl SharedControls {
     ) -> Result<(), RadarError> {
         match self.get(&control_value.id) {
             Some(c) => {
+                // Snap a requested number to the nearest settable value, so
+                // a client can ask for any range and get the closest one the
+                // radar has. Nearly every control is sent straight to the
+                // radar rather than stored locally, so the snap in
+                // Control::set only ever sees what the radar reports back —
+                // the request has to be normalised here too.
+                //
+                // Only when the client left the units to us, which is what
+                // they all do; a value in explicit units would have to be
+                // converted before it could be compared with valid_values,
+                // and the radar can deal with that rarity itself.
+                let control_value = if c.item.data_type == ControlDataType::Number
+                    && control_value.units.is_none()
+                {
+                    let snapped = control_value
+                        .value
+                        .as_ref()
+                        .and_then(|v| v.as_f64())
+                        .map(|v| c.snap_to_valid_value(v));
+                    match snapped {
+                        Some(v) => ControlValue {
+                            value: Some(v.into()),
+                            ..control_value
+                        },
+                        None => control_value,
+                    }
+                } else {
+                    control_value
+                };
+
                 let cv_orig = control_value.clone();
                 let (units, value) =
                     Self::convert_to_wire_number(control_value.units, control_value.value, &c)?;
@@ -2899,9 +2929,11 @@ impl Control {
             .min_by(|a, b| {
                 let da = (**a as f64 - value).abs();
                 let db = (**b as f64 - value).abs();
+                // total_cmp rather than partial_cmp: an unorderable
+                // distance must not be able to panic here.
                 // Ties go to the lower value, so the choice is stable
                 // rather than dependent on the order of the list.
-                da.partial_cmp(&db).unwrap().then(a.cmp(b))
+                da.total_cmp(&db).then(a.cmp(b))
             })
             .map(|v| *v as f64)
         else {
@@ -2971,6 +3003,16 @@ impl Control {
             value,
             self.item.units.unwrap_or(Units::None)
         );
+
+        // A NaN passes every comparison below — it is neither below the
+        // minimum nor above the maximum — so refuse it here rather than
+        // let it settle into a control as a value nothing can reason about.
+        if !value.is_finite() {
+            return Err(ControlError::Invalid(
+                self.item.control_id,
+                format!("{}", value),
+            ));
+        }
 
         // RANGE MAPPING
         if let (Some(min_value), Some(max_value)) = (self.item.min_value, self.item.max_value) {
@@ -3644,9 +3686,71 @@ mod test {
         assert_eq!(range.reported_auto(), None);
     }
 
-    /// A guard zone dragged by its start angle arrives as that one field.
-    /// The other three numbers and the enabled flag must survive, or the
-    /// zone collapses to 0-0 and can never trigger.
+    fn test_controls() -> SharedControls {
+        let (sk_tx, _sk_rx) = tokio::sync::broadcast::channel(16);
+        SharedControls::new(
+            "test".to_string(),
+            sk_tx,
+            &Cli::parse_from(["mayara-server"]),
+            HashMap::new(),
+        )
+    }
+
+    /// A client asking for a range the radar does not offer gets the
+    /// nearest one it does. Nearly every control is forwarded to the radar
+    /// rather than stored, so what matters is the value that leaves for
+    /// the radar — the local control only changes when the radar reports
+    /// back.
+    #[test]
+    fn a_client_request_for_an_unlisted_range_is_snapped() {
+        let controls = test_controls();
+        for v in [7408, 11112, 14816] {
+            controls.add_valid_value(&ControlId::Range, v);
+        }
+        let mut sent = controls.control_update_subscribe();
+        let (reply_tx, _reply_rx) = tokio::sync::mpsc::channel(8);
+
+        // 9888 m: between 4 nm and 6 nm, and in no table.
+        let cv = ControlValue::new(ControlId::Range, 9888.into());
+        controls.process_client_request(cv, reply_tx).unwrap();
+
+        let forwarded = sent.try_recv().expect("a request reaches the radar");
+        let value = forwarded
+            .control_value
+            .value
+            .and_then(|v| v.as_f64())
+            .expect("with a value");
+        assert_eq!(
+            value, 11112.,
+            "the radar is asked for the nearest settable range, not 9888"
+        );
+    }
+
+    /// The same path must still refuse an enum value the control does not
+    /// offer. Power lists Standby and Transmit; a request for Fault has no
+    /// nearest neighbour worth guessing, and guessing would start the
+    /// radar.
+    #[test]
+    fn a_client_request_for_an_unlisted_enum_is_refused() {
+        let controls = test_controls();
+        let (reply_tx, _reply_rx) = tokio::sync::mpsc::channel(8);
+
+        let cv = ControlValue::new(ControlId::Power, 4.into());
+        let result = controls.process_client_request(cv, reply_tx);
+
+        assert!(
+            matches!(
+                result,
+                Err(RadarError::ControlError(ControlError::Invalid(
+                    ControlId::Power,
+                    _
+                )))
+            ),
+            "a Fault request must be refused, not rounded to Transmit: {:?}",
+            result
+        );
+    }
+
     /// Navico radars driving their range from a chart overlay sweep
     /// whatever suits the chart: 9888 m sits between the 4 nm and 6 nm
     /// entries and is in no table at all. Observed on a HALO24 — 2700,
@@ -3697,6 +3801,9 @@ mod test {
         );
     }
 
+    /// A guard zone dragged by its start angle arrives as that one field.
+    /// The other three numbers and the enabled flag must survive, or the
+    /// zone collapses to 0-0 and can never trigger.
     #[test]
     fn partial_zone_update_keeps_unsupplied_fields() {
         let (_, mut zone) = new_zone(


### PR DESCRIPTION
A radar does not restrict itself to the ranges it offers for selection, so `controls/range` regularly reported a value that was not in its own `validValues` — leaving every client to work out what that meant, and any client that looked the value up in the list to find nothing.

Measured on a HALO24 with the chart overlay driving the range. The radar swept, among others:

```
2700 m (1.45 nm)   4517 m (2.43 nm)   6543 m (3.53 nm)   9888 m (5.33 nm)
12645 m (6.82 nm)  16308 m (8.80 nm)  21157 m (11.42 nm) 35918 m (19.39 nm)
```

Of a run of 22 distinct values, two were in the table. The MFD displayed "2.5 nm" at one point — a range that cannot be selected on that radar at all. The values even jitter: 65433 and 65434 decimetres for one nominal setting.

## Approach

Snap a numeric value to the nearest one the control offers, in both directions:

- **What the radar reports**, in `Control::set`. Verified on the water: the radar that had been reporting 9888 m now reports 11112 m.
- **What a client asks for**, in `process_client_request`. This half is needed separately because all but two controls are forwarded to the radar rather than stored locally, so a client's value never passes through `Control::set`. A client can now ask for any range and the radar is asked for the closest one it has.

The request-path snap applies when the client leaves `units` unset, which is what clients do. A value in explicit units would have to be converted to SI before it could be compared with `validValues`, and the radar can deal with that rarity itself.

**Numbers only.** An enum's `valid_values` are distinct options, where "nearest" has no meaning — `Power` offers `[1, 2]` for Standby and Transmit, so rounding a stray `4` (Fault) to the closest entry would start the radar transmitting. Enums are still refused, as before.

A non-finite value is now refused rather than stored. NaN passes every bound — it is neither below the minimum nor above the maximum — so it would otherwise have settled into a control as a value nothing can reason about.

## What this does not change

The displayed picture stays correctly scaled. The renderer divides the spoke extent by the reported range (`scale = actual / range`), so the canvas edge always represents `range` metres and a target's distance reads back the same whatever `range` is. Snapping shifts the zoom level by at most one step, not the accuracy of any distance. Spoke geometry, ARPA target positions and guard zone masks all derive from the spoke header range and are untouched.

The one visible consequence: mayara's displayed extent now steps between settable ranges while an overlay-driven MFD glides continuously, so the two can differ by up to a step.

## Testing

Unit tests for nearest-value snapping, stable tie-breaking towards the lower value, and a settable value passing through unchanged; boundary tests through `process_client_request` for a snapped numeric request and for an enum request still being refused; and the guard that a `Power` report of Fault does not become Transmit.