### PR TITLE
feat(api): accept a bulk PUT on /controls

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -35,6 +35,7 @@ mayara-server --openapi
 | GET    | `/signalk/v2/api/vessels/self/radars/diagnostics`            | Download a gzipped JSON network diagnostics snapshot |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/capabilities`      | Get radar capabilities and legend                  |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/controls`          | Get all control values                             |
+| PUT    | `/signalk/v2/api/vessels/self/radars/{id}/controls`          | Set several control values in one request          |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/controls/{cid}`    | Get specific control value                         |
 | PUT    | `/signalk/v2/api/vessels/self/radars/{id}/controls/{cid}`    | Set control value                                  |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/targets`           | List tracked targets                               |

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -74,6 +74,7 @@ const RADAR_TARGET_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/t
         diagnostics::get_diagnostics,
         get_radar,
         get_control_values,
+        set_control_values,
         get_control_value,
         set_control_value,
         get_targets,
@@ -111,7 +112,10 @@ pub(crate) fn routes(axum: axum::Router<Web>) -> axum::Router<Web> {
         .route(SPOKES_URI, get(spokes_handler))
         .route(RADAR_URI, get(get_radar_info))
         .route(RADAR_CAPABILITIES_URI, get(get_radar))
-        .route(RADAR_CONTROLS_URI, get(get_control_values))
+        .route(
+            RADAR_CONTROLS_URI,
+            get(get_control_values).put(set_control_values),
+        )
         .route(
             RADAR_CONTROL_URI,
             get(get_control_value).put(set_control_value),
@@ -561,20 +565,7 @@ async fn set_control_value(
     let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel(1);
 
     // Check if this control should trigger persistence save
-    let needs_persistence = matches!(
-        control_value.id,
-        ControlId::GuardZone1
-            | ControlId::GuardZone2
-            | ControlId::ExclusionZone1
-            | ControlId::ExclusionZone2
-            | ControlId::ExclusionZone3
-            | ControlId::ExclusionZone4
-            | ControlId::ExclusionRect1
-            | ControlId::ExclusionRect2
-            | ControlId::ExclusionRect3
-            | ControlId::ExclusionRect4
-            | ControlId::UserName
-    );
+    let needs_persistence = control_needs_persistence(control_value.id);
 
     // Send the control request
     if let Err(e) = controls.process_client_request(control_value, reply_tx) {
@@ -999,6 +990,129 @@ async fn get_control_values(Path(radar_id): Path<String>, State(state): State<We
         Some(radar) => Json(get_controls(&radar)).into_response(),
         None => no_such_radar(&radar_id, &state.radars),
     }
+}
+
+#[utoipa::path(
+    put,
+    path = "/signalk/v2/api/vessels/self/radars/{radar_id}/controls",
+    summary = "Set several control values",
+    description = "Sets several radar controls in one request. The body is a map of control id \
+                   to the same value object `PUT /controls/{control_id}` accepts, mirroring the \
+                   shape returned by `GET /controls`. Controls are applied in the order given; \
+                   if any fail the response is 400 and names them, while the others still apply.",
+    params(
+        ("radar_id" = String, Path, description = "Radar identifier", example = "nav1034A")
+    ),
+    request_body(
+        content = Object,
+        description = "Map of control id to control value",
+        example = json!({"gain": {"value": 50, "auto": false}, "range": {"value": 1852}})
+    ),
+    responses(
+        (status = 200, description = "All control values set successfully"),
+        (status = 400, description = "One or more controls were unknown, out of range or invalid"),
+        (status = 404, description = "Radar not found")
+    ),
+    tag = "Controls"
+)]
+async fn set_control_values(
+    Path(radar_id): Path<String>,
+    State(state): State<Web>,
+    extract::Json(request): extract::Json<HashMap<String, BareControlValue>>,
+) -> Response {
+    log::info!("PUT {} controls for radar {}", request.len(), radar_id);
+
+    // Resolve everything up front so the radar lock is not held across an await.
+    let (controls, resolved, radar_key) = {
+        match state.radars.get_by_key(&radar_id) {
+            Some(radar) => {
+                // Any control PUT means someone is interacting with this radar
+                // — exit idle synchronously, as the single-control PUT does.
+                radar.wake_up();
+                let mut resolved = Vec::with_capacity(request.len());
+                let mut unknown = Vec::new();
+                for (control_id, value) in request {
+                    match radar.controls.get_by_id(&control_id) {
+                        Some(c) => {
+                            resolved.push(ControlValue::from_request(c.item().control_id, value))
+                        }
+                        None => unknown.push(control_id),
+                    }
+                }
+                if !unknown.is_empty() {
+                    // Nothing has been applied yet, so reject the whole request
+                    // rather than leave the radar half-updated.
+                    unknown.sort();
+                    let all = radar.controls.get_control_keys();
+                    return (
+                        StatusCode::NOT_FOUND,
+                        format!("Unknown control(s) {:?} -- use {:?} instead", unknown, all),
+                    )
+                        .into_response();
+                }
+                (radar.controls.clone(), resolved, radar.key())
+            }
+            None => {
+                return no_such_radar(&radar_id, &state.radars);
+            }
+        }
+    };
+    // Lock is released here
+
+    let needs_persistence = resolved.iter().any(|cv| control_needs_persistence(cv.id));
+
+    let mut failures: Vec<String> = Vec::new();
+    for control_value in resolved {
+        let id = control_value.id;
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel(1);
+
+        if let Err(e) = controls.process_client_request(control_value, reply_tx) {
+            failures.push(format!("{:?}: {}", id, e));
+            continue;
+        }
+
+        // Same brief wait as the single-control PUT: most controls only reply
+        // on error.
+        tokio::select! {
+            reply = reply_rx.recv() => {
+                if let Some(cv) = reply
+                    && let Some(err) = cv.error
+                {
+                    failures.push(format!("{:?}: {}", id, err));
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+        }
+    }
+
+    if needs_persistence {
+        state.radars.save_persistence(&radar_key);
+    }
+
+    if failures.is_empty() {
+        StatusCode::OK.into_response()
+    } else {
+        failures.sort();
+        (StatusCode::BAD_REQUEST, failures.join("; ")).into_response()
+    }
+}
+
+/// Controls whose value survives a restart and so must be written to disk.
+fn control_needs_persistence(id: ControlId) -> bool {
+    matches!(
+        id,
+        ControlId::GuardZone1
+            | ControlId::GuardZone2
+            | ControlId::ExclusionZone1
+            | ControlId::ExclusionZone2
+            | ControlId::ExclusionZone3
+            | ControlId::ExclusionZone4
+            | ControlId::ExclusionRect1
+            | ControlId::ExclusionRect2
+            | ControlId::ExclusionRect3
+            | ControlId::ExclusionRect4
+            | ControlId::UserName
+    )
 }
 
 fn get_controls(info: &RadarInfo) -> Value {

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -51,6 +51,10 @@ const RADAR_CONTROL_URI: &str =
 const RADAR_TARGETS_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/targets";
 const RADAR_TARGET_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/targets/{target_id}";
 
+/// How long a control PUT waits for the radar to object before it reports
+/// success. Most controls only send a reply when they reject a value.
+const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
 #[derive(OpenApi)]
 #[openapi(
     info(
@@ -588,7 +592,7 @@ async fn set_control_value(
                 _ => {}
             }
         }
-        _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+        _ = tokio::time::sleep(CONTROL_REPLY_TIMEOUT) => {
             // No error reply within timeout, assume success
         }
     }
@@ -998,8 +1002,10 @@ async fn get_control_values(Path(radar_id): Path<String>, State(state): State<We
     summary = "Set several control values",
     description = "Sets several radar controls in one request. The body is a map of control id \
                    to the same value object `PUT /controls/{control_id}` accepts, mirroring the \
-                   shape returned by `GET /controls`. Controls are applied in the order given; \
-                   if any fail the response is 400 and names them, while the others still apply.",
+                   shape returned by `GET /controls`. A JSON object has no inherent order, so \
+                   controls are applied in a deterministic order by control id rather than the \
+                   order they appear in the body; if any fail the response is 400 and names \
+                   them, while the others still apply.",
     params(
         ("radar_id" = String, Path, description = "Radar identifier", example = "nav1034A")
     ),
@@ -1010,15 +1016,16 @@ async fn get_control_values(Path(radar_id): Path<String>, State(state): State<We
     ),
     responses(
         (status = 200, description = "All control values set successfully"),
-        (status = 400, description = "One or more controls were unknown, out of range or invalid"),
-        (status = 404, description = "Radar not found")
+        (status = 400, description = "A control was named twice, or one or more values were \
+                                      out of range or refused by the radar"),
+        (status = 404, description = "Radar not found, or a control id is not known to it")
     ),
     tag = "Controls"
 )]
 async fn set_control_values(
     Path(radar_id): Path<String>,
     State(state): State<Web>,
-    extract::Json(request): extract::Json<HashMap<String, BareControlValue>>,
+    extract::Json(request): extract::Json<BTreeMap<String, BareControlValue>>,
 ) -> Response {
     log::info!("PUT {} controls for radar {}", request.len(), radar_id);
 
@@ -1050,6 +1057,23 @@ async fn set_control_values(
                     )
                         .into_response();
                 }
+                // Distinct keys can name the same control, because control ids
+                // are parsed rather than matched literally. Applying both would
+                // make the result depend on which the map yielded last, so say
+                // so instead of silently picking one.
+                let mut seen = HashSet::new();
+                let duplicates: Vec<String> = resolved
+                    .iter()
+                    .filter(|cv| !seen.insert(cv.id))
+                    .map(|cv| format!("{:?}", cv.id))
+                    .collect();
+                if !duplicates.is_empty() {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        format!("Control(s) {:?} named more than once", duplicates),
+                    )
+                        .into_response();
+                }
                 (radar.controls.clone(), resolved, radar.key())
             }
             None => {
@@ -1057,7 +1081,6 @@ async fn set_control_values(
             }
         }
     };
-    // Lock is released here
 
     let needs_persistence = resolved.iter().any(|cv| control_needs_persistence(cv.id));
 
@@ -1081,7 +1104,7 @@ async fn set_control_values(
                     failures.push(format!("{:?}: {}", id, err));
                 }
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+            _ = tokio::time::sleep(CONTROL_REPLY_TIMEOUT) => {}
         }
     }
 

--- a/tests/api_rest.rs
+++ b/tests/api_rest.rs
@@ -534,3 +534,115 @@ async fn test_openapi_spec() {
     let paths = json["paths"].as_object().unwrap();
     assert!(paths.contains_key("/signalk/v2/api/vessels/self/radars"));
 }
+
+// ---------------------------------------------------------------------------
+// Bulk control PUT
+// ---------------------------------------------------------------------------
+//
+// These assert on controls the emulator actually applies (userName, range,
+// targetTrails). Gain is deliberately avoided: the emulator accepts a gain PUT
+// and reports success but never reflects the value, on the single-control path
+// as much as this one, so asserting a gain round-trip would test the emulator
+// rather than the endpoint.
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_set_control_values_bulk() {
+    let id = first_radar_id().await;
+    let path = format!("/signalk/v2/api/vessels/self/radars/{}/controls", id);
+
+    let response = put_json(
+        &path,
+        &serde_json::json!({
+            "userName": {"value": "BulkTest"},
+            "range": {"value": 1852},
+            "targetTrails": {"value": 2}
+        }),
+    )
+    .await;
+    assert!(
+        response.status().is_success(),
+        "bulk PUT should succeed, got {}",
+        response.status()
+    );
+
+    let controls = get_json(&path).await;
+    assert_eq!(controls["userName"]["value"], "BulkTest");
+    assert_eq!(controls["range"]["value"], 1852);
+    assert_eq!(controls["targetTrails"]["value"], 2);
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_set_control_values_rejects_unknown_control_atomically() {
+    let id = first_radar_id().await;
+    let path = format!("/signalk/v2/api/vessels/self/radars/{}/controls", id);
+
+    put_json(&path, &serde_json::json!({"range": {"value": 1852}})).await;
+    let before = get_json(&path).await;
+    assert_eq!(before["range"]["value"], 1852, "test precondition");
+
+    // One good control, one that does not exist. Nothing should be applied.
+    let response = put_json(
+        &path,
+        &serde_json::json!({
+            "range": {"value": 926},
+            "notAControl": {"value": 1}
+        }),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        404,
+        "an unknown control id should be rejected with 404"
+    );
+
+    let after = get_json(&path).await;
+    assert_eq!(
+        after["range"]["value"], 1852,
+        "the valid control must not be applied when another id is unknown"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_set_control_values_rejects_duplicate_control() {
+    let id = first_radar_id().await;
+    let path = format!("/signalk/v2/api/vessels/self/radars/{}/controls", id);
+
+    // Control ids are parsed, not matched literally, so these two keys name the
+    // same control and the result would otherwise depend on map ordering.
+    let response = put_json(
+        &path,
+        &serde_json::json!({"range": {"value": 926}, "Range": {"value": 1852}}),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        400,
+        "naming one control twice should be rejected"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_set_control_values_persists_a_persistent_control() {
+    let id = first_radar_id().await;
+    let path = format!("/signalk/v2/api/vessels/self/radars/{}/controls", id);
+
+    // userName is written to disk; the bulk path must save persistence just as
+    // the single-control path does.
+    let response = put_json(
+        &path,
+        &serde_json::json!({"userName": {"value": "BulkPersist"}}),
+    )
+    .await;
+    assert!(
+        response.status().is_success(),
+        "setting a persistent control should succeed, got {}",
+        response.status()
+    );
+
+    let controls = get_json(&path).await;
+    assert_eq!(controls["userName"]["value"], "BulkPersist");
+}

--- a/tests/api_rest.rs
+++ b/tests/api_rest.rs
@@ -535,11 +535,7 @@ async fn test_openapi_spec() {
     assert!(paths.contains_key("/signalk/v2/api/vessels/self/radars"));
 }
 
-// ---------------------------------------------------------------------------
-// Bulk control PUT
-// ---------------------------------------------------------------------------
-//
-// These assert on controls the emulator actually applies (userName, range,
+// The bulk-PUT tests assert on controls the emulator actually applies (userName, range,
 // targetTrails). Gain is deliberately avoided: the emulator accepts a gain PUT
 // and reports success but never reflects the value, on the single-control path
 // as much as this one, so asserting a gain round-trip would test the emulator
@@ -624,14 +620,20 @@ async fn test_set_control_values_rejects_duplicate_control() {
     );
 }
 
+/// Covers the persistence branch of the bulk path — userName is one of the
+/// controls `control_needs_persistence` matches, so this is the case that
+/// reaches `save_persistence` — and checks the value is applied.
+///
+/// It does not prove the write reached disk: the read returns the live
+/// in-memory value, which is set either way. Proving that needs a restart
+/// between the PUT and the read, and these tests drive a server they did not
+/// start (see `MAYARA_TEST_URL`), so they cannot restart it.
 #[tokio::test]
 #[ignore = "requires running server"]
-async fn test_set_control_values_persists_a_persistent_control() {
+async fn test_set_control_values_applies_a_persistent_control() {
     let id = first_radar_id().await;
     let path = format!("/signalk/v2/api/vessels/self/radars/{}/controls", id);
 
-    // userName is written to disk; the bulk path must save persistence just as
-    // the single-control path does.
     let response = put_json(
         &path,
         &serde_json::json!({"userName": {"value": "BulkPersist"}}),


### PR DESCRIPTION
## Summary

`GET /radars/{id}/controls` returns every control as a map, but there was no way to write that map back — only `PUT /controls/{control_id}`, one request per control. `PUT /controls` answered **405**.

That gap is not merely an inconvenience. The Signal K Radar API exposes a bulk `PUT /radars/{id}` backed by a provider `setControls` method, and signalk-plugin implements `setControls` against this endpoint — so that entire path returned 400 for every client that used it. Found while debugging why guard zones could not be set from a new client.

This accepts the same map shape `GET /controls` produces: control id to the value object `PUT /controls/{control_id}` already takes.

```
PUT /signalk/v2/api/vessels/self/radars/nav1034A/controls
{ "gain": { "value": 50, "auto": false }, "range": { "value": 1852 } }
```

Behaviour:

- **Unknown control ids are rejected up front** with 404, before anything is applied, so a typo cannot leave the radar half-updated.
- Once the ids resolve, controls are applied in turn. Any that fail are named in a 400 while the rest still take effect — a radar rejecting one value should not silently discard the others.
- `wake_up()` is called once, matching the single-control PUT.
- Persistence is saved once for the whole request instead of once per control, and the persistence predicate is now shared with the single-control handler rather than duplicated.

## Tested

- `cargo build`, `cargo clippy` and `cargo fmt --check` clean; `cargo test --lib` 372 passing.
- Ran the build and confirmed the route is live and documented: the endpoint list now reports `PUT /signalk/v2/api/vessels/self/radars/{radar_id}/controls`, and the generated OpenAPI spec shows `get` and `put` on that path.

Not covered: an end-to-end write against hardware. The handler reuses the single-control path (`get_by_id` → `ControlValue::from_request` → `process_client_request` → reply channel with the same 100 ms error window), so per-control semantics are unchanged, but a run against a real radar before merge would be worth it.

Related: SignalK/signalk-server#2935 and #2936, and MarineYachtRadar/mayara-server-signalk-plugin#105 — the other three pieces of the same guard-zone failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds bulk `PUT /radars/{radar_id}/controls` support.

- Accepts the control map returned by `GET /controls`.
- Rejects unknown or duplicate control IDs with `404` or `400` before applying changes.
- Processes controls sequentially and deterministically.
- Aggregates and sorts failures in a `400` response while applying other controls.
- Calls `wake_up()` once and persists settings once per request.
- Shares persistence detection with the single-control handler.
- Registers the route, OpenAPI documentation, and REST endpoint documentation.
- Passes build, clippy, formatting, library tests, and emulator-backed integration tests. Hardware end-to-end testing is not performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->