### PR TITLE
fix(gui): give every REST request a deadline

### DIFF
--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -43,6 +43,48 @@ export function wsBase(path) {
   return `${wsProtocol}//${window.location.host}${basePrefix()}${path}`;
 }
 
+// Every request carries a deadline. A browser `fetch` has no timeout of its
+// own, so a stall anywhere below HTTP — an mDNS answer that never arrives for
+// a `.local` host, a radar that dropped off the LAN, a Wi-Fi handover — leaves
+// the promise pending forever. The GUI then shows a frozen control or an empty
+// panel with nothing in the console, which is indistinguishable from a bug in
+// mayara itself.
+const REQUEST_TIMEOUT_MS = 10000;
+
+// An upload carries a whole recording over the boat's Wi-Fi, so it gets a
+// deadline of its own rather than the interactive one.
+const UPLOAD_TIMEOUT_MS = 300000;
+
+/**
+ * `fetch` with a deadline. Rejects with a descriptive `Error` when the request
+ * outlives `timeoutMs`, so callers report "timed out" rather than hanging or
+ * reporting an opaque `AbortError`.
+ *
+ * @param {string} url - Request URL
+ * @param {Object} [options] - `fetch` options
+ * @param {number} [timeoutMs] - Deadline in milliseconds
+ * @returns {Promise<Response>}
+ */
+export async function apiFetch(
+  url,
+  options = {},
+  timeoutMs = REQUEST_TIMEOUT_MS
+) {
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (e) {
+    if (e.name === "TimeoutError") {
+      throw new Error(
+        `${options.method || "GET"} ${url} timed out after ${timeoutMs} ms`
+      );
+    }
+    throw e;
+  }
+}
+
 // Detected mode (null = not detected yet)
 let detectedMode = null;
 
@@ -60,7 +102,7 @@ export async function detectMode() {
 
   // Try standalone first - check if / returns server mayara
   try {
-    const response = await fetch(apiBase(ENDPOINT_API), {
+    const response = await apiFetch(apiBase(ENDPOINT_API), {
       headers: { Accept: "application/json" },
     });
     const data = await response.json();
@@ -75,7 +117,9 @@ export async function detectMode() {
 
   // Try SignalK - check if endpoint returns 200
   try {
-    const response = await fetch(apiBase(SIGNALK_RADARS_API), { method: "HEAD" });
+    const response = await apiFetch(apiBase(SIGNALK_RADARS_API), {
+      method: "HEAD",
+    });
     if (response.ok) {
       detectedMode = "signalk";
       console.log("Detected SignalK mode");
@@ -122,7 +166,7 @@ export function getDiagnosticsUrl() {
 export async function fetchRadarIds() {
   await detectMode();
 
-  const response = await fetch(getRadarsPath());
+  const response = await apiFetch(getRadarsPath());
   const data = await response.json();
   assertCompatibleApiVersion(data);
 
@@ -136,7 +180,7 @@ export async function fetchRadarIds() {
 export async function fetchRadars() {
   await detectMode();
 
-  const response = await fetch(getRadarsPath());
+  const response = await apiFetch(getRadarsPath());
   const data = await response.json();
   assertCompatibleApiVersion(data);
   return radarsMap(data);
@@ -204,7 +248,7 @@ export async function fetchCapabilities(radarId) {
   const url = `${getRadarsPath()}/${radarId}/capabilities`;
   console.log(`Fetching capabilities: GET ${url}`);
 
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   if (!response.ok) {
     throw new Error(`Failed to fetch capabilities: ${response.status}`);
   }
@@ -224,7 +268,7 @@ export async function fetchInterfaces() {
     return null;
   }
 
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   return response.json();
 }
 
@@ -261,7 +305,7 @@ export async function acquireTarget(radarId, bearing, distance) {
   console.log(`Acquiring target: POST ${url}`, body);
 
   try {
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -308,7 +352,7 @@ export async function setControl(radarId, controlId, body) {
   console.log(`Setting control: PUT ${url}`, bodyStr);
 
   try {
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -361,7 +405,7 @@ export async function listRecordings(subdirectory) {
   const url = subdirectory
     ? `${RECORDINGS_API}/files?dir=${encodeURIComponent(subdirectory)}`
     : `${RECORDINGS_API}/files`;
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   if (!response.ok) {
     throw new Error(`Failed to list recordings: ${response.status}`);
   }
@@ -378,7 +422,7 @@ export async function listRecordings(subdirectory) {
  */
 export async function getRecordingInfo(filename, subdirectory) {
   const params = subdirectory ? `?dir=${encodeURIComponent(subdirectory)}` : "";
-  const response = await fetch(
+  const response = await apiFetch(
     `${RECORDINGS_API}/files/${encodeURIComponent(filename)}${params}`
   );
   if (!response.ok) {
@@ -395,7 +439,7 @@ export async function getRecordingInfo(filename, subdirectory) {
  */
 export async function deleteRecording(filename, subdirectory) {
   const params = subdirectory ? `?dir=${encodeURIComponent(subdirectory)}` : "";
-  const response = await fetch(
+  const response = await apiFetch(
     `${RECORDINGS_API}/files/${encodeURIComponent(filename)}${params}`,
     {
       method: "DELETE",
@@ -411,7 +455,7 @@ export async function deleteRecording(filename, subdirectory) {
  * @returns {Promise<Object>} Result with new filename
  */
 export async function renameRecording(oldFilename, newFilename) {
-  const response = await fetch(
+  const response = await apiFetch(
     `${RECORDINGS_API}/files/${encodeURIComponent(oldFilename)}`,
     {
       method: "PUT",
@@ -437,13 +481,17 @@ export async function renameRecording(oldFilename, newFilename) {
  * @returns {Promise<Object>} Upload result with filename and size
  */
 export async function uploadRecording(file) {
-  const response = await fetch(`${RECORDINGS_API}/files/upload`, {
-    method: "POST",
-    headers: {
-      "Content-Disposition": `attachment; filename="${file.name}"`,
+  const response = await apiFetch(
+    `${RECORDINGS_API}/files/upload`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Disposition": `attachment; filename="${file.name}"`,
+      },
+      body: file,
     },
-    body: file,
-  });
+    UPLOAD_TIMEOUT_MS
+  );
 
   if (!response.ok) {
     const error = await response
@@ -473,7 +521,7 @@ export function getRecordingDownloadUrl(filename, subdirectory) {
  * @returns {Promise<Object[]>} Array of radar info objects
  */
 export async function getRecordableRadars() {
-  const response = await fetch(`${RECORDINGS_API}/radars`);
+  const response = await apiFetch(`${RECORDINGS_API}/radars`);
   if (!response.ok) {
     throw new Error(`Failed to get recordable radars: ${response.status}`);
   }
@@ -492,7 +540,7 @@ export async function startRecording(radarId, filename, subdirectory) {
   if (filename) body.filename = filename;
   if (subdirectory) body.subdirectory = subdirectory;
 
-  const response = await fetch(`${RECORDINGS_API}/record/start`, {
+  const response = await apiFetch(`${RECORDINGS_API}/record/start`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -509,7 +557,7 @@ export async function startRecording(radarId, filename, subdirectory) {
  * @returns {Promise<Object>} Final recording status
  */
 export async function stopRecording() {
-  const response = await fetch(`${RECORDINGS_API}/record/stop`, {
+  const response = await apiFetch(`${RECORDINGS_API}/record/stop`, {
     method: "POST",
   });
   if (!response.ok) {
@@ -523,7 +571,7 @@ export async function stopRecording() {
  * @returns {Promise<Object>} Recording status
  */
 export async function getRecordingStatus() {
-  const response = await fetch(`${RECORDINGS_API}/record/status`);
+  const response = await apiFetch(`${RECORDINGS_API}/record/status`);
   if (!response.ok) {
     throw new Error(`Failed to get recording status: ${response.status}`);
   }
@@ -540,7 +588,7 @@ export async function loadPlayback(filename, subdirectory) {
   const body = { filename };
   if (subdirectory) body.subdirectory = subdirectory;
 
-  const response = await fetch(`${RECORDINGS_API}/playback/load`, {
+  const response = await apiFetch(`${RECORDINGS_API}/playback/load`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -557,7 +605,7 @@ export async function loadPlayback(filename, subdirectory) {
  * @returns {Promise<Object>} Playback status
  */
 export async function playPlayback() {
-  const response = await fetch(`${RECORDINGS_API}/playback/play`, {
+  const response = await apiFetch(`${RECORDINGS_API}/playback/play`, {
     method: "POST",
   });
   if (!response.ok) {
@@ -571,7 +619,7 @@ export async function playPlayback() {
  * @returns {Promise<Object>} Playback status
  */
 export async function pausePlayback() {
-  const response = await fetch(`${RECORDINGS_API}/playback/pause`, {
+  const response = await apiFetch(`${RECORDINGS_API}/playback/pause`, {
     method: "POST",
   });
   if (!response.ok) {
@@ -585,7 +633,7 @@ export async function pausePlayback() {
  * @returns {Promise<Object>} Playback status
  */
 export async function stopPlayback() {
-  const response = await fetch(`${RECORDINGS_API}/playback/stop`, {
+  const response = await apiFetch(`${RECORDINGS_API}/playback/stop`, {
     method: "POST",
   });
   if (!response.ok) {
@@ -600,7 +648,7 @@ export async function stopPlayback() {
  * @returns {Promise<Object>} Playback status
  */
 export async function seekPlayback(positionMs) {
-  const response = await fetch(`${RECORDINGS_API}/playback/seek`, {
+  const response = await apiFetch(`${RECORDINGS_API}/playback/seek`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ positionMs }),
@@ -617,7 +665,7 @@ export async function seekPlayback(positionMs) {
  * @returns {Promise<Object>} Playback status
  */
 export async function setPlaybackSettings(settings) {
-  const response = await fetch(`${RECORDINGS_API}/playback/settings`, {
+  const response = await apiFetch(`${RECORDINGS_API}/playback/settings`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(settings),
@@ -633,7 +681,7 @@ export async function setPlaybackSettings(settings) {
  * @returns {Promise<Object>} Playback status
  */
 export async function getPlaybackStatus() {
-  const response = await fetch(`${RECORDINGS_API}/playback/status`);
+  const response = await apiFetch(`${RECORDINGS_API}/playback/status`);
   if (!response.ok) {
     throw new Error(`Failed to get playback status: ${response.status}`);
   }

--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -70,19 +70,44 @@ export async function apiFetch(
   options = {},
   timeoutMs = REQUEST_TIMEOUT_MS
 ) {
-  try {
-    return await fetch(url, {
-      ...options,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (e) {
-    if (e.name === "TimeoutError") {
-      throw new Error(
+  const deadline = AbortSignal.timeout(timeoutMs);
+  // A caller's own signal is combined with the deadline rather than replaced,
+  // so passing one still cancels the request instead of being ignored.
+  const signal = options.signal
+    ? AbortSignal.any([deadline, options.signal])
+    : deadline;
+
+  // The deadline covers reading the body too, so a response that starts
+  // arriving and then stalls aborts inside `json()`/`blob()` rather than in
+  // `fetch()`. Classify both the same way, or that case reports an opaque
+  // AbortError instead of the timeout the caller is meant to see.
+  const asTimeout = (e) => {
+    if (e.name === "TimeoutError" || (e.name === "AbortError" && deadline.aborted)) {
+      return new Error(
         `${options.method || "GET"} ${url} timed out after ${timeoutMs} ms`
       );
     }
-    throw e;
+    return e;
+  };
+
+  let response;
+  try {
+    response = await fetch(url, { ...options, signal });
+  } catch (e) {
+    throw asTimeout(e);
   }
+
+  for (const read of ["json", "text", "blob", "arrayBuffer", "formData"]) {
+    const original = response[read].bind(response);
+    response[read] = async (...args) => {
+      try {
+        return await original(...args);
+      } catch (e) {
+        throw asTimeout(e);
+      }
+    };
+  }
+  return response;
 }
 
 // Detected mode (null = not detected yet)

--- a/web/gui/debug-panel.js
+++ b/web/gui/debug-panel.js
@@ -11,7 +11,7 @@
 import { createEventTimeline, updateTimeline, selectEvent, clearEvents } from './event-timeline.js';
 import { createPacketView, showPacketDetails, clearPacketView } from './packet-view.js';
 import { createStateDiffView, showStateDiff } from './state-diff.js';
-import { apiBase, wsBase } from './api.js';
+import { apiBase, apiFetch, wsBase } from './api.js';
 
 // ============================================================================
 // State
@@ -49,7 +49,7 @@ const DEBUG_RECORDING_STOP_URL = apiBase('/v2/api/debug/recording/stop');
  */
 export async function isDebugAvailable() {
   try {
-    const response = await fetch(DEBUG_EVENTS_URL, { method: 'HEAD' });
+    const response = await apiFetch(DEBUG_EVENTS_URL, { method: 'HEAD' });
     return response.ok;
   } catch (e) {
     return false;
@@ -183,7 +183,7 @@ async function startRecording() {
       brand: r.brand
     }));
 
-    const response = await fetch(DEBUG_RECORDING_START_URL, {
+    const response = await apiFetch(DEBUG_RECORDING_START_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ radars: radarList })
@@ -203,7 +203,7 @@ async function startRecording() {
 
 async function stopRecording() {
   try {
-    const response = await fetch(DEBUG_RECORDING_STOP_URL, {
+    const response = await apiFetch(DEBUG_RECORDING_STOP_URL, {
       method: 'POST'
     });
 

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -5,6 +5,7 @@ import {
   getDiagnosticsUrl,
   isStandaloneMode,
   detectMode,
+  apiFetch,
 } from "./api.js";
 
 const { a, tr, td, div, p, strong, details, summary, code, br, span, button } =
@@ -776,7 +777,7 @@ async function downloadDiagnostics(btn) {
     document.createTextNode("Generating diagnostics…")
   );
   try {
-    const resp = await fetch(getDiagnosticsUrl());
+    const resp = await apiFetch(getDiagnosticsUrl());
     if (!resp.ok) {
       throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
     }

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -29,6 +29,7 @@ import {
   detectMode,
   fetchRadarIds,
   apiBase,
+  apiFetch,
   wsBase,
 } from "./api.js";
 import "./vendor/protobuf.min.js";
@@ -484,7 +485,7 @@ async function pollUpstreamStatus() {
   let reachable = false;
   let message = null;
   try {
-    const res = await fetch(apiBase("/signalk"), {
+    const res = await apiFetch(apiBase("/signalk"), {
       headers: { Accept: "application/json" },
     });
     if (res.ok) {
@@ -607,7 +608,7 @@ async function subscribeToAisViaSignalK() {
 // silent (mayara standalone doesn't serve this endpoint).
 async function primeAisFromRestSnapshot() {
   try {
-    const res = await fetch(apiBase("/signalk/v1/api/vessels/"));
+    const res = await apiFetch(apiBase("/signalk/v1/api/vessels/"));
     if (!res.ok) return;
     const tree = await res.json();
     const URN = "urn:mrn:imo:mmsi:";


### PR DESCRIPTION
When the network stalls, the radar GUI freezes instead of telling you something is wrong: a control stays on the value you just set, the connection-status line never updates, and nothing appears in the browser console. Seen in the field when mDNS stopped resolving the `.local` hostname the GUI had been opened from — the already-open WebSockets kept painting the PPI, so the display looked alive while every new request silently hung forever.

A control change made in that state is simply lost, with no indication.

## Implementation

A browser `fetch` has no timeout of its own, so any stall below HTTP leaves the promise pending indefinitely. All REST calls now go through an `apiFetch()` helper in `api.js` that attaches an `AbortSignal.timeout` and reports which request expired. Interactive requests get 10 s; recording uploads get their own 5-minute deadline.

Applied to every call site in `api.js`, plus the upstream-status poll and AIS snapshot in `viewer.js`, the diagnostics download in `mayara.js`, and `debug-panel.js`.

## Testing

`cargo test` passes (no Rust changed). The GUI has no JS test harness and CI has no JS step, so the modules were checked with `node --check`; adding a JS test runner would be a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `apiFetch()` to apply request deadlines to GUI REST calls. Interactive requests time out after 10 seconds. Recording uploads time out after 5 minutes. Timeout errors identify the expired request.

Routes REST requests in `api.js`, `viewer.js`, `mayara.js`, and `debug-panel.js` through `apiFetch()` to prevent indefinite hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->