### PR TITLE
fix(gui): flag controls the radar never confirmed

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1576,6 +1576,62 @@ function do_input() {
   // Real-time feedback while dragging (optional)
 }
 
+// How long the radar gets to report a setting back before the GUI stops
+// presenting it as applied.
+const CONTROL_CONFIRM_TIMEOUT_MS = 5000;
+
+// Controls whose value the radar reports over the state stream, learned as
+// those reports arrive. A write-only action such as "clear trails" never comes
+// back with a value, so it must never be judged unconfirmed.
+const reportedControls = new Set();
+
+// controlId -> pending confirmation timer
+const unconfirmedTimers = new Map();
+
+/** The `.myr_control` box a control lives in, or null if it is not on screen. */
+function controlElement(controlId) {
+  const el =
+    get_element_by_server_id(controlId) ||
+    document.getElementById(`myr_${controlId}`);
+  return el ? el.closest(".myr_control") : null;
+}
+
+/**
+ * Flag a control as not applied. The GUI updates a control optimistically the
+ * moment the user moves it, so without this a request the radar never adopted
+ * — or never even received — stays on screen looking like the live setting.
+ */
+function markControlUnconfirmed(controlId, reason) {
+  clearConfirmationTimer(controlId);
+
+  console.warn(`Control ${controlId} unconfirmed: ${reason}`);
+  const box = controlElement(controlId);
+  if (box) {
+    box.classList.add("myr_control_unconfirmed");
+    box.title = reason;
+  }
+}
+
+function clearConfirmationTimer(controlId) {
+  const timer = unconfirmedTimers.get(controlId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    unconfirmedTimers.delete(controlId);
+  }
+}
+
+/** Called when the radar reports a value: the control is live again. */
+function confirmControl(controlId) {
+  reportedControls.add(controlId);
+  clearConfirmationTimer(controlId);
+
+  const box = controlElement(controlId);
+  if (box) {
+    box.classList.remove("myr_control_unconfirmed");
+    box.removeAttribute("title");
+  }
+}
+
 async function sendControlToServer(controlId, message) {
   if (playbackMode) {
     console.log(`Playback mode: ignoring control ${controlId}`);
@@ -1584,7 +1640,24 @@ async function sendControlToServer(controlId, message) {
 
   console.log(`Sending control: ${controlId} = ${JSON.stringify(message)}`);
 
-  const success = await apiSetControl(radarId, controlId, message);
+  if (reportedControls.has(controlId)) {
+    clearConfirmationTimer(controlId);
+    unconfirmedTimers.set(
+      controlId,
+      setTimeout(
+        () =>
+          markControlUnconfirmed(
+            controlId,
+            "The radar did not confirm this setting"
+          ),
+        CONTROL_CONFIRM_TIMEOUT_MS
+      )
+    );
+  }
+
+  if (!(await apiSetControl(radarId, controlId, message))) {
+    markControlUnconfirmed(controlId, "Could not reach mayara to set this");
+  }
 }
 
 // ============================================================================
@@ -1708,6 +1781,7 @@ function connectStateStream(streamUrl, radarIdParam) {
                 );
 
                 const cv = { ...item.value, id: controlId };
+                confirmControl(controlId);
                 setControlValue(cv);
               }
               // Notify stream message callbacks for all values (targets, etc.)

--- a/web/gui/controls.css
+++ b/web/gui/controls.css
@@ -290,6 +290,19 @@ div.myr_range_buttons {
   background-color: #112;
 }
 
+/* The radar never reported this setting back, so what is shown is what was
+   asked for, not what the radar is doing. */
+.myr_control_unconfirmed {
+  border-color: #c84;
+  background-color: #221a11;
+}
+
+.myr_control_unconfirmed .myr_control_label::after {
+  content: " (unconfirmed)";
+  color: #fb6;
+  font-weight: normal;
+}
+
 .myr_control_header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Move a slider and the GUI shows the new value straight away — but that is only what was *asked for*. If the radar never applies it, or the request never reaches mayara at all, the control goes on displaying the requested value as though it were the live setting. There is no way to tell a setting that took effect from one that vanished.

Such a control is now marked "unconfirmed" — amber border, a suffix on the label, and a tooltip explaining why — and the mark clears the moment a value for that control arrives from the radar. The requested value stays on screen rather than snapping back, so what you asked for is not lost.

## Implementation

`sendControlToServer` arms a 5 s timer, cleared when mayara reports a value for that control over the state stream. The timer also fires immediately if the PUT itself fails.

Two sources of false positives are avoided:

- **Write-only actions.** Only controls the radar has actually reported are watched, so "clear trails" and "clear targets" — which never come back with a value — are never flagged.
- **No-op writes.** `Control::set` suppresses the broadcast when a value is unchanged, but `radar/mod.rs` calls `set_refresh` after a successful client PUT, so the next radar report re-broadcasts regardless. Setting a control to the value it already has is therefore still confirmed.

## Testing

`cargo test` passes (no Rust changed). The GUI has no JS test harness and CI has no JS step, so the modules were checked with `node --check`.