### PR TITLE
fix(controls): stop numeric controls reporting a value they never had

### DIFF
--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -3836,6 +3836,7 @@ mod test {
         let (_, gain) = new_auto(ControlId::Gain, 0., 100., HAS_AUTO_NOT_ADJUSTABLE).take();
         assert_eq!(gain.value, None, "auto-capable numerics too");
         assert_eq!(gain.timestamp, None);
+        assert_eq!(gain.item.min_value, Some(0.), "its bound survives too");
 
         // Enum controls still seed 0 and are deliberately left alone here: for
         // an enum, 0 is usually a real option (the first list entry), so

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -3824,6 +3824,10 @@ mod test {
         let (_, range) = new_numeric(ControlId::Range, 0., 100_000.).take();
         assert_eq!(range.value, None, "range must not report a phantom 0");
         assert_eq!(
+            range.timestamp, None,
+            "and no timestamp — a stamped value is what made it look observed"
+        );
+        assert_eq!(
             range.item.min_value,
             Some(0.),
             "the minimum is still a bound"
@@ -3831,6 +3835,7 @@ mod test {
 
         let (_, gain) = new_auto(ControlId::Gain, 0., 100., HAS_AUTO_NOT_ADJUSTABLE).take();
         assert_eq!(gain.value, None, "auto-capable numerics too");
+        assert_eq!(gain.timestamp, None);
 
         // Enum controls still seed 0 and are deliberately left alone here: for
         // an enum, 0 is usually a real option (the first list entry), so

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -2455,7 +2455,11 @@ pub(crate) fn new_numeric(control_id: ControlId, min_value: f64, max_value: f64)
     let control = Control::new(ControlDefinition::new(
         control_id,
         ControlDataType::Number,
-        min_value,
+        // No default: the minimum is a bound, not a reading. Seeding it made
+        // the control indistinguishable from one the radar had actually
+        // reported — a Furuno dual-range B channel published range 0 with a
+        // timestamp before it was ever activated.
+        None,
         None,
         false,
         min_value,
@@ -2486,7 +2490,8 @@ pub(crate) fn new_auto(
     let control = Control::new(ControlDefinition::new(
         control_id,
         ControlDataType::Number,
-        min_value,
+        // See new_numeric: the minimum is a bound, not a reading.
+        None,
         Some(automatic),
         false,
         min_value,
@@ -3806,6 +3811,33 @@ mod test {
             Some(4.),
             "a Fault report must stay a Fault, not become Transmit"
         );
+    }
+
+    /// A numeric control must start with no value at all. Seeding it with the
+    /// minimum made "never reported" indistinguishable from "the radar says
+    /// zero": a Furuno dual-range B channel published range 0, timestamped, on
+    /// a channel that had never been activated. Clients then either drew that
+    /// as a real range or, once a snap-to-nearest pass runs over reported
+    /// values, rounded it up to the shortest settable range.
+    #[test]
+    fn numeric_controls_start_without_a_value() {
+        let (_, range) = new_numeric(ControlId::Range, 0., 100_000.).take();
+        assert_eq!(range.value, None, "range must not report a phantom 0");
+        assert_eq!(
+            range.item.min_value,
+            Some(0.),
+            "the minimum is still a bound"
+        );
+
+        let (_, gain) = new_auto(ControlId::Gain, 0., 100., HAS_AUTO_NOT_ADJUSTABLE).take();
+        assert_eq!(gain.value, None, "auto-capable numerics too");
+
+        // Enum controls still seed 0 and are deliberately left alone here: for
+        // an enum, 0 is usually a real option (the first list entry), so
+        // dropping it is a separate judgement per control rather than the
+        // clear-cut "a bound is not a reading" this change makes.
+        let (_, mode) = new_list(ControlId::Mode, &["Harbor", "Offshore"]).take();
+        assert_eq!(mode.value, Some(0.));
     }
 
     /// A guard zone dragged by its start angle arrives as that one field.

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1362,6 +1362,37 @@ function buildSingleControl(k, v) {
 // Control Value Setting (from v1 setControl)
 // ============================================================================
 
+/**
+ * Render a control the radar has not reported a value for. The display shows
+ * a dash rather than a number, and any input is left untouched so it does not
+ * present an invented setting as the current one.
+ */
+function showUnsetControl(i, control, cv) {
+  if (control.isReadOnly || control.readOnly) {
+    i.innerHTML = "&mdash;";
+    return;
+  }
+  if (
+    control.dataType === "sector" ||
+    control.dataType === "zone" ||
+    control.dataType === "rect"
+  ) {
+    return;
+  }
+  const n =
+    document.getElementById(control_prefix + cv.id + "_display") ||
+    i.parentNode.querySelector(".myr_numeric");
+  if (n) {
+    n.innerHTML = "&mdash;";
+  }
+  const d =
+    document.getElementById(control_prefix + cv.id + "_desc") ||
+    i.parentNode.querySelector(".myr_description");
+  if (d) {
+    d.innerHTML = "";
+  }
+}
+
 function setControlValue(cv) {
   myr_control_values[cv.id] = cv;
 
@@ -1376,6 +1407,16 @@ function setControlValue(cv) {
       value = cv.autoValue;
     } else {
       value = cv.value;
+    }
+
+    // A control the radar has not reported yet carries no value at all — a
+    // Furuno dual-range B channel has no range until its first command
+    // activates it. Show a placeholder rather than letting `undefined` reach
+    // innerHTML, which renders the literal text "undefined" (or "undefined m"
+    // once units are appended).
+    if (value === undefined || value === null) {
+      showUnsetControl(i, control, cv);
+      return;
     }
 
     let html = value;

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1411,16 +1411,18 @@ function setControlValue(cv) {
 
     // A control the radar has not reported yet carries no value at all — a
     // Furuno dual-range B channel has no range until its first command
-    // activates it. Show a placeholder rather than letting `undefined` reach
-    // innerHTML, which renders the literal text "undefined" (or "undefined m"
-    // once units are appended).
-    if (value === undefined || value === null) {
+    // activates it. Only the value rendering is skipped: `undefined` reaching
+    // innerHTML shows the literal text "undefined" (or "undefined m" once
+    // units are appended). Everything below — auto and enabled state, the
+    // allowed flag, errors, and the callbacks — still applies, because those
+    // are independent of whether a value has arrived.
+    const unset = value === undefined || value === null;
+    if (unset) {
       showUnsetControl(i, control, cv);
-      return;
     }
 
     let html = value;
-    if (control.units && cv.id !== "range") {
+    if (!unset && control.units && cv.id !== "range") {
       [units, value] = toUser(control.units, value);
       if (control.stepValue) {
         value = roundToStep(value, control.stepValue, control.minValue ?? 0);
@@ -1434,7 +1436,8 @@ function setControlValue(cv) {
 
     // For read-only controls, update the element directly (it's a span with myr_info_value)
     if (control.isReadOnly || control.readOnly) {
-      i.innerHTML = html;
+      // showUnsetControl already wrote the placeholder here.
+      if (!unset) i.innerHTML = html;
     } else if (control && control.dataType === "sector") {
       updateSectorUI(cv.id, control, cv);
     } else if (control && control.dataType === "zone") {
@@ -1447,7 +1450,7 @@ function setControlValue(cv) {
       if (!n) {
         n = i.parentNode.querySelector(".myr_numeric");
       }
-      if (n) {
+      if (n && !unset) {
         n.innerHTML = html;
       }
 
@@ -1456,7 +1459,7 @@ function setControlValue(cv) {
       if (!d) {
         d = i.parentNode.querySelector(".myr_description");
       }
-      if (d) {
+      if (d && !unset) {
         let description = control.descriptions
           ? control.descriptions[value]
           : undefined;
@@ -1477,8 +1480,9 @@ function setControlValue(cv) {
         d.innerHTML = description;
       }
 
-      // Set input value after setting min/max
-      i.value = value;
+      // Set input value after setting min/max. Left alone when unset, so the
+      // slider does not present an invented position as the current setting.
+      if (!unset) i.value = value;
 
       // Update tick marks for discrete sliders
       if (i.classList.contains("myr_slider_discrete")) {

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1459,20 +1459,28 @@ function setControlValue(cv) {
       if (!d) {
         d = i.parentNode.querySelector(".myr_description");
       }
+      // The slider's bounds follow the auto mode, not the value: switching
+      // auto on an auto-adjustable control changes which range the slider
+      // spans. Applied even when unset, so a control still waiting for its
+      // first report has the right bounds the moment a value arrives — and
+      // regardless of whether a description element exists to render into.
+      if (control.hasAutoAdjustable) {
+        if (cv.auto) {
+          i.min = control.autoAdjustMinValue;
+          i.max = control.autoAdjustMaxValue;
+        } else {
+          i.min = control.minValue;
+          i.max = control.maxValue;
+        }
+      }
+
       if (d && !unset) {
         let description = control.descriptions
           ? control.descriptions[value]
           : undefined;
-        if (!description && control.hasAutoAdjustable) {
-          if (cv.auto) {
-            description =
-              "A" + (value > 0 ? "+" + value : "") + (value < 0 ? value : "");
-            i.min = control.autoAdjustMinValue;
-            i.max = control.autoAdjustMaxValue;
-          } else {
-            i.min = control.minValue;
-            i.max = control.maxValue;
-          }
+        if (!description && control.hasAutoAdjustable && cv.auto) {
+          description =
+            "A" + (value > 0 ? "+" + value : "") + (value < 0 ? value : "");
         }
         if (!description) {
           description = html;


### PR DESCRIPTION
## Summary

Follow-up to #479, taking the fix to the root rather than special-casing it in the GUI as discussed there.

A control whose range the radar has never reported showed a value anyway. On a Furuno dual-range antenna, Range B has no range until its first command activates the channel, but mayara published range `0` — timestamped, and so indistinguishable from a reading. A client either drew that as a real setting or, once #515's snap-to-nearest runs over reported values, rounded it up to the shortest settable range: a range the operator never chose, on a channel that is not transmitting.

The cause is not Furuno-specific. `new_numeric` and `new_auto` passed `min_value` as the control's `default_value`, and `Control::new` seeds the value from it **and stamps it with the current time**. Every numeric control on every brand was therefore born holding its own minimum, looking observed.

Both now pass no default, so the value stays absent until something sets it. The minimum remains as `min_value`, where it belongs — a bound, not a reading.

Enum controls still seed `0` and are deliberately untouched: for an enum `0` is usually a real option (the first list entry), so dropping it is a per-control judgement rather than the clear-cut case this makes. Worth a separate look — `Power` listing `[1, 2]` is the example from #515 of why it needs care.

The second commit fixes a **pre-existing** GUI bug that this change makes reachable: a control with no value reached `innerHTML` as `undefined`, rendering the literal text "undefined" (or "undefined m" with units). It is in this PR rather than a separate one because shipping the server change alone would leave a window where absent values print as "undefined" in the panel. Verified present on `main` today, independently of the server change.

## Tested

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` — 414 passed, 0 failed
- Replay fixtures (`replay_furuno_drs2d`, `replay_navico_4g`) pass, so real captured traffic is unaffected
- Against a live DRS4D-NXT, before and after:

  | | Range B `range` | Range A `range` |
  | --- | --- | --- |
  | before | `{"value": 0}`, stamped at startup | 463 m, live |
  | after | absent | 463 m, live |

- Headless browser on the Range B panel: `main` renders "undefined", this branch renders a dash, no page errors either way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Leave numeric and auto control values and timestamps unset until the radar reports them. Keep minimum values as validation bounds. Keep enum controls seeded to `0`.
- Display a dash for unset GUI values instead of `undefined`. Continue applying auto toggles, enabled state, allowed state, errors, callbacks, and automatic slider bounds.
- Add tests for unset numeric and auto values and timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->