### PR TITLE
feat(mdns): let the advertised host name be renamed or turned off

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -182,15 +182,22 @@ impl Web {
         // reachable from the network at all.
         let bound_addr = listener.local_addr().map_err(WebError::Io)?;
         let bound_port = bound_addr.port();
-        let _advertiser = if embedded {
+        let _advertiser = if embedded || self.args.no_mdns {
             None
         } else {
-            match mayara::network::mdns_advertise::Advertiser::start(bound_port, self.tls) {
+            let hostname = self
+                .args
+                .mdns_hostname
+                .as_deref()
+                .unwrap_or(mayara::network::mdns_advertise::DEFAULT_HOSTNAME);
+            match mayara::network::mdns_advertise::Advertiser::start(bound_port, self.tls, hostname)
+            {
                 Ok(advertiser) => {
                     log::info!(
-                        "Advertising {} port {} on mDNS",
+                        "Advertising {} port {} on mDNS as {}",
                         advertiser.fullname(),
-                        bound_port
+                        bound_port,
+                        advertiser.hostname()
                     );
                     Some(advertiser)
                 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -198,6 +198,20 @@ pub struct Cli {
     /// deployments where compression cost exceeds the bandwidth benefit.
     #[arg(long, default_value_t = false)]
     pub no_websocket_compression: bool,
+
+    /// Host name to claim on mDNS, so the GUI is reachable at
+    /// `http://<name>.local:<port>/`. Defaults to `mayara`. Give each server on
+    /// a network its own name; two claiming the same one contend for it, and
+    /// the loser is renamed.
+    #[arg(long, value_name = "NAME", conflicts_with = "no_mdns")]
+    pub mdns_hostname: Option<String>,
+
+    /// Do not advertise on mDNS at all: no service and no host name, so
+    /// `<name>.local` will not resolve to mayara and clients must be given its
+    /// address. Use this when the machine already runs its own mDNS responder
+    /// (Avahi, Bonjour) that should stay the sole authority.
+    #[arg(long, default_value_t = false)]
+    pub no_mdns: bool,
 }
 
 /// Static position data (latitude, longitude, heading)

--- a/src/lib/network/mdns_advertise.rs
+++ b/src/lib/network/mdns_advertise.rs
@@ -2,12 +2,20 @@
 //!
 //! Publishes `_mayara-http._tcp.local.` so clients (browsers, Signal K
 //! servers, plotters) can find mayara without being told its IP address.
-//! The service is registered under the hostname `mayara.local.`, so the GUI
-//! is also reachable at `http://mayara.local:<port>/` from any host with an
-//! mDNS resolver.
+//! By default the service is registered under the host name `mayara.local.`,
+//! so the GUI is also reachable at `http://mayara.local:<port>/` from any host
+//! with an mDNS resolver.
 //!
 //! The daemon probes both names before announcing them, so a second mayara
-//! on the same LAN is renamed rather than clashing with the first.
+//! on the same LAN is renamed rather than clashing with the first. Give each
+//! server its own name (`--mdns-hostname`) and they never contend at all.
+//!
+//! Claiming a host name means owning its address records, which a machine that
+//! already runs its own responder (Avahi, Bonjour) also does for its own name.
+//! A service registration cannot opt out of that while staying advertised —
+//! mdns-sd announces nothing for a service with no addresses — so the way to
+//! leave a resident responder as the sole authority is `--no-mdns`, which
+//! skips the advertisement entirely.
 
 use std::time::Duration;
 
@@ -18,7 +26,20 @@ use crate::{SIGNALK_RADAR_API_VERSION, VERSION};
 /// DNS-SD service type; the name is within the 15-character limit of RFC 6763.
 const SERVICE_TYPE: &str = "_mayara-http._tcp.local.";
 const INSTANCE_NAME: &str = "mayara";
-const HOSTNAME: &str = "mayara.local.";
+/// Host name claimed unless `--mdns-hostname` overrides it.
+pub const DEFAULT_HOSTNAME: &str = "mayara";
+const LOCAL_DOMAIN: &str = ".local.";
+
+/// Turn a bare name into a fully qualified mDNS host name, accepting anything
+/// a user is likely to type: `radar`, `radar.local` or `radar.local.`.
+fn qualify(name: &str) -> String {
+    let bare = name
+        .trim()
+        .trim_end_matches('.')
+        .trim_end_matches(".local")
+        .trim_end_matches('.');
+    format!("{}{}", bare, LOCAL_DOMAIN)
+}
 
 /// How long to wait for the daemon to multicast the goodbye packets.
 const UNREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
@@ -27,23 +48,34 @@ const UNREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
 pub struct Advertiser {
     daemon: ServiceDaemon,
     fullname: String,
+    hostname: String,
 }
 
 impl Advertiser {
     /// Announce a web server listening on `port`; `tls` selects the scheme
-    /// clients should use.
-    pub fn start(port: u16, tls: bool) -> Result<Self, mdns_sd::Error> {
+    /// clients should use and `hostname` the name claimed for it.
+    pub fn start(port: u16, tls: bool, hostname: &str) -> Result<Self, mdns_sd::Error> {
         let daemon = ServiceDaemon::new()?;
-        let info = service_info(port, tls)?;
+        let info = service_info(port, tls, hostname)?;
         let fullname = info.get_fullname().to_string();
+        let hostname = info.get_hostname().to_string();
         daemon.register(info)?;
 
-        Ok(Advertiser { daemon, fullname })
+        Ok(Advertiser {
+            daemon,
+            fullname,
+            hostname,
+        })
     }
 
     /// The instance name as registered, e.g. `mayara._mayara-http._tcp.local.`.
     pub fn fullname(&self) -> &str {
         &self.fullname
+    }
+
+    /// The host name the service points at, e.g. `mayara.local.`.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
     }
 }
 
@@ -60,7 +92,7 @@ impl Drop for Advertiser {
 
 /// The addresses are left to the daemon: `enable_addr_auto` fills in every
 /// host address and keeps the records in step as interfaces come and go.
-fn service_info(port: u16, tls: bool) -> Result<ServiceInfo, mdns_sd::Error> {
+fn service_info(port: u16, tls: bool, hostname: &str) -> Result<ServiceInfo, mdns_sd::Error> {
     let properties = [
         ("version", VERSION),
         ("api", SIGNALK_RADAR_API_VERSION),
@@ -71,7 +103,7 @@ fn service_info(port: u16, tls: bool) -> Result<ServiceInfo, mdns_sd::Error> {
     Ok(ServiceInfo::new(
         SERVICE_TYPE,
         INSTANCE_NAME,
-        HOSTNAME,
+        &qualify(hostname),
         (),
         port,
         &properties[..],
@@ -85,18 +117,18 @@ mod tests {
 
     #[test]
     fn service_info_names_and_port() {
-        let info = service_info(6502, false).unwrap();
+        let info = service_info(6502, false, DEFAULT_HOSTNAME).unwrap();
 
         assert_eq!(info.get_type(), SERVICE_TYPE);
         assert_eq!(info.get_fullname(), "mayara._mayara-http._tcp.local.");
-        assert_eq!(info.get_hostname(), HOSTNAME);
+        assert_eq!(info.get_hostname(), "mayara.local.");
         assert_eq!(info.get_port(), 6502);
         assert!(info.is_addr_auto());
     }
 
     #[test]
     fn service_info_advertises_scheme_and_versions() {
-        let plain = service_info(6502, false).unwrap();
+        let plain = service_info(6502, false, DEFAULT_HOSTNAME).unwrap();
         assert_eq!(plain.get_property_val_str("scheme"), Some("http"));
         assert_eq!(plain.get_property_val_str("version"), Some(VERSION));
         assert_eq!(
@@ -105,7 +137,46 @@ mod tests {
         );
         assert_eq!(plain.get_property_val_str("path"), Some("/signalk"));
 
-        let tls = service_info(443, true).unwrap();
+        let tls = service_info(443, true, DEFAULT_HOSTNAME).unwrap();
         assert_eq!(tls.get_property_val_str("scheme"), Some("https"));
+    }
+
+    #[test]
+    fn overridden_name_is_claimed_however_it_was_typed() {
+        for given in ["radar", "radar.local", "radar.local.", "  radar  "] {
+            let info = service_info(6502, false, given).unwrap();
+            assert_eq!(info.get_hostname(), "radar.local.", "given={given}");
+            // The address records are what make the name resolve, so an
+            // overridden name must still carry them.
+            assert!(info.is_addr_auto(), "given={given}");
+        }
+    }
+
+    #[test]
+    fn qualify_appends_the_local_domain_exactly_once() {
+        assert_eq!(qualify("radar"), "radar.local.");
+        assert_eq!(qualify("radar."), "radar.local.");
+        assert_eq!(qualify("radar.local"), "radar.local.");
+        assert_eq!(qualify("radar.local."), "radar.local.");
+    }
+
+    #[test]
+    fn a_service_without_addresses_is_never_announced() {
+        // Guards the reason `--no-mdns` skips the advertiser wholesale rather
+        // than registering a service that claims no host name: mdns-sd drops
+        // such a service on every interface ("no valid addrs") and it silently
+        // never appears on the network.
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            INSTANCE_NAME,
+            &qualify(DEFAULT_HOSTNAME),
+            (),
+            6502,
+            &[][..] as &[(&str, &str)],
+        )
+        .unwrap();
+
+        assert!(info.get_addresses().is_empty());
+        assert!(!info.is_addr_auto());
     }
 }

--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -42,6 +42,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -39,6 +39,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_raymarine_rd418d.rs
+++ b/tests/replay_raymarine_rd418d.rs
@@ -43,6 +43,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }

--- a/tests/replay_raymarine_rd418hd.rs
+++ b/tests/replay_raymarine_rd418hd.rs
@@ -46,6 +46,8 @@ fn test_args() -> Cli {
         emulator: false,
         merge_targets: false,
         no_websocket_compression: false,
+        mdns_hostname: None,
+        no_mdns: true,
         pcap_max_time: None,
     }
 }


### PR DESCRIPTION
mayara claims the name `mayara.local` so the GUI is reachable at `http://mayara.local:6502/`. Two servers on one network therefore fight over that name, and the loser is silently renamed — so the name can end up pointing at a laptop running a test build rather than at the boat's server. On a machine that already runs Avahi or Bonjour (every Raspberry Pi OS install), mayara also adds a second mDNS responder alongside the resident one.

Until now neither could be avoided: the only thing that suppressed the advertisement was `--parent`, which also confines the web server to localhost and ties mayara's lifetime to another process.

Two new options:

- `--mdns-hostname <NAME>` — claim `<NAME>.local` instead, so each server on a network has its own name and they never contend. Accepts `radar`, `radar.local` or `radar.local.`
- `--no-mdns` — do not advertise at all, leaving a resident responder as the sole authority. Clients must then be given mayara's address.

The default is unchanged: `mayara.local` is still claimed when neither option is given. The two options are mutually exclusive.

## Why `--no-mdns` and not `--no-mdns-hostname`

Keeping the service advertised while declining the host name would be the tidier option, and it is what I tried first. It cannot be done with mdns-sd: a service registered without address records is dropped on every interface (`prepare_announce: no valid addrs`) and silently never appears on the network. A registration inherently carries addresses for its SRV target, so "advertise the service but claim no name" is not expressible. A regression test pins that behaviour so the reasoning is not lost.

## Testing

`cargo test` passes (413 tests, 6 new). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean. All three paths were also exercised against a running server and verified with `dns-sd`:

- default → advertises as `mayara.local.`, resolves
- `--mdns-hostname testradar` → advertises as `testradar.local.`, resolves, service still browsable
- `--no-mdns` → nothing advertised, `mayara.local` does not resolve, HTTP still serves