### PR TITLE
feat(gui): welcome first-time users with a tour of the PPI

### DIFF
--- a/web/gui/tour.css
+++ b/web/gui/tour.css
@@ -1,0 +1,104 @@
+/* ============================================
+   First-run tour - overlay, highlight, tooltip
+   ============================================ */
+
+/* Sits above the controls panel (z-index 200) so the panel can be part of
+   the tour. */
+.myr_tour {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 400;
+  pointer-events: none;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+/* Four panels dim everything around the highlight; together they also
+   swallow clicks aimed at the rest of the page. */
+.myr_tour_mask {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.72);
+  pointer-events: auto;
+}
+
+.myr_tour_ring {
+  position: absolute;
+  border: 2px solid #8cf;
+  border-radius: 10px;
+  box-shadow: 0 0 12px rgba(136, 204, 255, 0.6);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.myr_tour_tip {
+  position: absolute;
+  max-width: calc(100vw - 24px);
+  box-sizing: border-box;
+  padding: 14px 16px;
+  background: #111;
+  color: rgb(152, 217, 204);
+  border: 2px solid #446;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6);
+  pointer-events: auto;
+}
+
+.myr_tour_tip_title {
+  color: #8cf;
+  font-size: 15px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.myr_tour_tip_text {
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.myr_tour_tip_footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.myr_tour_progress {
+  flex: 1;
+  color: #779;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.myr_tour_button {
+  padding: 6px 12px;
+  background: #222;
+  color: #8cf;
+  border: 1px solid #446;
+  border-radius: 6px;
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.myr_tour_button:hover:not(:disabled) {
+  background: rgba(30, 40, 60, 0.9);
+  border-color: #668;
+  color: #adf;
+}
+
+.myr_tour_button:disabled {
+  color: #556;
+  cursor: default;
+}
+
+.myr_tour_skip {
+  color: #889;
+}
+
+.myr_tour_next {
+  background: #1a3350;
+  border-color: #668;
+}

--- a/web/gui/tour.js
+++ b/web/gui/tour.js
@@ -1,0 +1,360 @@
+// First-run guided tour of the PPI window. It runs once per browser, the first
+// time the viewer is opened, and walks through the controls sitting around the
+// plot. `viewer.html?tour=1` replays it.
+
+const SEEN_KEY = "mayaraTourSeen";
+
+// The controls panel slides in over 250ms (`div.myr_controller` in layout.css).
+// A step that opens it has to wait for it to come to rest, or the highlight is
+// measured while the panel is still moving and lands off the panel.
+const PANEL_SETTLE_MS = 300;
+
+// Highlight ring padding around its target, and the gap between ring and
+// tooltip.
+const RING_PADDING = 6;
+const TOOLTIP_GAP = 14;
+const TOOLTIP_WIDTH = 300;
+const VIEWPORT_MARGIN = 12;
+
+// Whether the controls panel is open. Each step states which it needs, so
+// stepping backwards puts the panel back the way that step found it.
+let controlsOpen = false;
+
+function setControls(open) {
+  const controller = document.getElementById("myr_controller");
+  if (controller) controller.classList.toggle("myr_controller_open", open);
+  const changed = open !== controlsOpen;
+  controlsOpen = open;
+  return changed;
+}
+
+// A step without a `target` is shown centred on the plot. A step whose target
+// is not on the page is skipped, which is how the radar selector step drops
+// out for anyone with a single radar. `panel: "open"` means the step needs the
+// controls panel open to have something to point at.
+const STEPS = [
+  {
+    title: "This is the PPI plot",
+    text:
+      "Your boat sits at the centre of the plot and the bow points up the " +
+      "screen. As the antenna turns, the radar paints what it sees — land, " +
+      "buoys, other vessels — around you. Here is a quick tour of the " +
+      "controls around the plot.",
+  },
+  {
+    target: "#myr_power_lozenge .myr_power_lozenge_button",
+    title: "Standby and transmit",
+    text:
+      "The power button switches the radar between standby and transmit. It " +
+      "shows yellow on standby, and green once the antenna is turning and " +
+      "transmitting.",
+  },
+  {
+    target: "#myr_power_lozenge_select",
+    title: "Choosing a radar",
+    text:
+      "More than one radar is connected. The radar name next to the power " +
+      "button opens the list — pick another one to show it in this window.",
+  },
+  {
+    target: "#myr_range_lozenge",
+    title: "Range",
+    text:
+      "These buttons set how far the radar looks. + steps down to a shorter " +
+      "range for more detail close in, − steps up to see further out. The " +
+      "range in use is shown between them.",
+  },
+  {
+    target: "#myr_hamburger_button",
+    title: "The controls menu",
+    text:
+      "This button opens the radar controls — gain, sea and rain clutter, " +
+      "and everything else your radar supports.",
+  },
+  {
+    target: "#myr_controller",
+    panel: "open",
+    title: "The settings",
+    text:
+      "The settings are grouped into sections: the everyday ones at the top, " +
+      "with target, trail, advanced and installation settings below. Scroll " +
+      "down for the rest.",
+  },
+  {
+    target: "#myr_close_controls",
+    panel: "open",
+    title: "Closing the menu",
+    text:
+      "Close the controls again with this button. The radar keeps running " +
+      "and the plot stays live behind the panel.",
+  },
+];
+
+let steps = [];
+let stepIndex = 0;
+let elements = null;
+let settleTimer = null;
+
+function hasSeenTour() {
+  try {
+    return localStorage.getItem(SEEN_KEY) === "true";
+  } catch {
+    // localStorage unavailable (private mode) — treat the tour as unseen.
+    return false;
+  }
+}
+
+function markTourSeen() {
+  try {
+    localStorage.setItem(SEEN_KEY, "true");
+  } catch {
+    // ignore quota errors — the tour then reappears next visit.
+  }
+}
+
+function buildOverlay() {
+  const root = document.createElement("div");
+  root.className = "myr_tour";
+
+  const masks = [];
+  for (let i = 0; i < 4; i++) {
+    const mask = document.createElement("div");
+    mask.className = "myr_tour_mask";
+    root.appendChild(mask);
+    masks.push(mask);
+  }
+
+  // The ring covers its target, so clicks during the tour reach the ring
+  // instead of the control underneath: nobody starts transmitting by
+  // following along. Clicking it moves on, so the click is not simply lost.
+  const ring = document.createElement("div");
+  ring.className = "myr_tour_ring";
+  ring.addEventListener("click", next);
+  root.appendChild(ring);
+
+  const tip = document.createElement("div");
+  tip.className = "myr_tour_tip";
+
+  const title = document.createElement("div");
+  title.className = "myr_tour_tip_title";
+
+  const text = document.createElement("div");
+  text.className = "myr_tour_tip_text";
+
+  const footer = document.createElement("div");
+  footer.className = "myr_tour_tip_footer";
+
+  const progress = document.createElement("span");
+  progress.className = "myr_tour_progress";
+
+  const skipBtn = document.createElement("button");
+  skipBtn.type = "button";
+  skipBtn.className = "myr_tour_button myr_tour_skip";
+  skipBtn.textContent = "Skip";
+  skipBtn.addEventListener("click", end);
+
+  const backBtn = document.createElement("button");
+  backBtn.type = "button";
+  backBtn.className = "myr_tour_button";
+  backBtn.textContent = "Back";
+  backBtn.addEventListener("click", back);
+
+  const nextBtn = document.createElement("button");
+  nextBtn.type = "button";
+  nextBtn.className = "myr_tour_button myr_tour_next";
+  nextBtn.addEventListener("click", next);
+
+  footer.appendChild(progress);
+  footer.appendChild(skipBtn);
+  footer.appendChild(backBtn);
+  footer.appendChild(nextBtn);
+
+  tip.appendChild(title);
+  tip.appendChild(text);
+  tip.appendChild(footer);
+  root.appendChild(tip);
+
+  document.body.appendChild(root);
+
+  return { root, masks, ring, tip, title, text, progress, backBtn, nextBtn };
+}
+
+// Cover the whole viewport except `rect`, using one mask above, one below and
+// one on either side of it. A zero-size rect leaves the viewport fully
+// covered, which is what the opening step wants.
+function positionMasks(rect) {
+  const [top, bottom, left, right] = elements.masks;
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+
+  top.style.cssText = `left:0;top:0;width:${w}px;height:${Math.max(0, rect.top)}px`;
+  bottom.style.cssText = `left:0;top:${rect.bottom}px;width:${w}px;height:${Math.max(0, h - rect.bottom)}px`;
+  left.style.cssText = `left:0;top:${rect.top}px;width:${Math.max(0, rect.left)}px;height:${Math.max(0, rect.height)}px`;
+  right.style.cssText = `left:${rect.right}px;top:${rect.top}px;width:${Math.max(0, w - rect.right)}px;height:${Math.max(0, rect.height)}px`;
+}
+
+// Put the tooltip below the highlight, or above / beside it when there is no
+// room, so it never covers what it is describing.
+function positionTooltip(rect, hasTarget) {
+  const tip = elements.tip;
+  tip.style.width = `${TOOLTIP_WIDTH}px`;
+
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  const tipHeight = tip.offsetHeight;
+
+  if (!hasTarget) {
+    tip.style.left = `${Math.round((w - TOOLTIP_WIDTH) / 2)}px`;
+    tip.style.top = `${Math.round((h - tipHeight) / 2)}px`;
+    return;
+  }
+
+  const clamp = (value, max) =>
+    Math.round(Math.min(Math.max(value, VIEWPORT_MARGIN), Math.max(VIEWPORT_MARGIN, max)));
+
+  const below = rect.bottom + TOOLTIP_GAP;
+  const above = rect.top - TOOLTIP_GAP - tipHeight;
+  const beside = clamp(rect.top, h - tipHeight - VIEWPORT_MARGIN);
+
+  if (below + tipHeight + VIEWPORT_MARGIN <= h) {
+    tip.style.top = `${Math.round(below)}px`;
+    tip.style.left = `${clamp(rect.left, w - TOOLTIP_WIDTH - VIEWPORT_MARGIN)}px`;
+  } else if (above >= VIEWPORT_MARGIN) {
+    tip.style.top = `${Math.round(above)}px`;
+    tip.style.left = `${clamp(rect.left, w - TOOLTIP_WIDTH - VIEWPORT_MARGIN)}px`;
+  } else if (rect.left - TOOLTIP_GAP - TOOLTIP_WIDTH >= VIEWPORT_MARGIN) {
+    tip.style.top = `${beside}px`;
+    tip.style.left = `${Math.round(rect.left - TOOLTIP_GAP - TOOLTIP_WIDTH)}px`;
+  } else {
+    tip.style.top = `${beside}px`;
+    tip.style.left = `${clamp(rect.right + TOOLTIP_GAP, w - TOOLTIP_WIDTH - VIEWPORT_MARGIN)}px`;
+  }
+}
+
+function targetRect(step) {
+  if (!step.target) return null;
+  const el = document.querySelector(step.target);
+  if (!el) return null;
+
+  const box = el.getBoundingClientRect();
+  return {
+    top: box.top - RING_PADDING,
+    left: box.left - RING_PADDING,
+    right: box.right + RING_PADDING,
+    bottom: box.bottom + RING_PADDING,
+    width: box.width + 2 * RING_PADDING,
+    height: box.height + 2 * RING_PADDING,
+  };
+}
+
+function layoutStep() {
+  const step = steps[stepIndex];
+  const rect = targetRect(step);
+
+  if (rect) {
+    elements.ring.style.display = "block";
+    elements.ring.style.left = `${Math.round(rect.left)}px`;
+    elements.ring.style.top = `${Math.round(rect.top)}px`;
+    elements.ring.style.width = `${Math.round(rect.width)}px`;
+    elements.ring.style.height = `${Math.round(rect.height)}px`;
+    positionMasks(rect);
+  } else {
+    elements.ring.style.display = "none";
+    const centre = window.innerWidth / 2;
+    const middle = window.innerHeight / 2;
+    positionMasks({
+      top: middle,
+      bottom: middle,
+      left: centre,
+      right: centre,
+      width: 0,
+      height: 0,
+    });
+  }
+
+  positionTooltip(rect, rect !== null);
+}
+
+function showStep() {
+  const step = steps[stepIndex];
+  const panelMoved = setControls(step.panel === "open");
+
+  elements.title.textContent = step.title;
+  elements.text.textContent = step.text;
+  elements.progress.textContent = `Step ${stepIndex + 1} of ${steps.length}`;
+  elements.backBtn.disabled = stepIndex === 0;
+  elements.nextBtn.textContent =
+    stepIndex === steps.length - 1 ? "Done" : "Next";
+
+  clearTimeout(settleTimer);
+  if (panelMoved) {
+    settleTimer = setTimeout(layoutStep, PANEL_SETTLE_MS);
+  } else {
+    layoutStep();
+  }
+}
+
+function next() {
+  if (stepIndex >= steps.length - 1) {
+    end();
+    return;
+  }
+  stepIndex++;
+  showStep();
+}
+
+function back() {
+  if (stepIndex === 0) return;
+  stepIndex--;
+  showStep();
+}
+
+function onKeyDown(event) {
+  if (event.key === "Escape") {
+    end();
+  } else if (event.key === "ArrowRight" || event.key === "Enter") {
+    next();
+  } else if (event.key === "ArrowLeft") {
+    back();
+  } else {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function end() {
+  clearTimeout(settleTimer);
+  window.removeEventListener("resize", layoutStep);
+  document.removeEventListener("keydown", onKeyDown, true);
+
+  if (elements) {
+    elements.root.remove();
+    elements = null;
+  }
+
+  // The tour opens the controls panel to explain it; leave the viewer the way
+  // it was found.
+  setControls(false);
+  markTourSeen();
+}
+
+// Start the tour if this browser has not seen it yet. `?tour=1` forces it.
+export function startTourIfFirstVisit() {
+  const forced =
+    new URLSearchParams(window.location.search).get("tour") === "1";
+  if (!forced && hasSeenTour()) return;
+
+  // An embedded viewer is one pane of a larger page; a tour per pane would
+  // fight for the same screen.
+  if (window.self !== window.top) return;
+
+  steps = STEPS.filter((step) => !step.target || document.querySelector(step.target));
+  if (steps.length === 0) return;
+
+  stepIndex = 0;
+  elements = buildOverlay();
+  document.addEventListener("keydown", onKeyDown, true);
+  window.addEventListener("resize", layoutStep);
+  showStep();
+}

--- a/web/gui/tour.js
+++ b/web/gui/tour.js
@@ -9,6 +9,10 @@ const SEEN_KEY = "mayaraTourSeen";
 // measured while the panel is still moving and lands off the panel.
 const PANEL_SETTLE_MS = 300;
 
+// One mask per side of the highlight; `positionMasks` takes them in this
+// order.
+const MASK_COUNT = 4;
+
 // Highlight ring padding around its target, and the gap between ring and
 // tooltip.
 const RING_PADDING = 6;
@@ -117,7 +121,7 @@ function buildOverlay() {
   root.className = "myr_tour";
 
   const masks = [];
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < MASK_COUNT; i++) {
     const mask = document.createElement("div");
     mask.className = "myr_tour_mask";
     root.appendChild(mask);
@@ -312,7 +316,7 @@ function back() {
 function onKeyDown(event) {
   if (event.key === "Escape") {
     end();
-  } else if (event.key === "ArrowRight" || event.key === "Enter") {
+  } else if (event.key === "ArrowRight") {
     next();
   } else if (event.key === "ArrowLeft") {
     back();

--- a/web/gui/viewer.html
+++ b/web/gui/viewer.html
@@ -11,6 +11,7 @@
     <link type="text/css" rel="stylesheet" href="layout.css?v=1" />
     <link type="text/css" rel="stylesheet" href="controls.css?v=1" />
     <link type="text/css" rel="stylesheet" href="responsive.css?v=1" />
+    <link type="text/css" rel="stylesheet" href="tour.css?v=1" />
     <script type="module" src="viewer.js"></script>
 </head>
 <body>

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -37,6 +37,7 @@ import "./vendor/protobuf.min.js";
 import { WebGPURenderer } from "./render_webgpu.js";
 import { WebGLRenderer } from "./render_webgl.js";
 import { PPI } from "./ppi.js";
+import { startTourIfFirstVisit } from "./tour.js";
 
 var webSocket;
 var headingSocket;
@@ -262,6 +263,9 @@ window.onload = async function () {
 
   // Create range lozenge
   createRangeLozenge();
+
+  // Walk a first-time visitor around the controls just created.
+  startTourIfFirstVisit();
 
   window.onresize = function () {
     ppi.redrawCanvas();


### PR DESCRIPTION
Opening the radar picture for the first time drops you in front of a plot ringed with unlabelled buttons, with nothing saying what any of them do. This adds a short guided tour that runs once, the first time someone opens the viewer.

It dims the plot and walks through, one highlight at a time:

- what the PPI plot is — own ship at the centre, bow up
- the power button: standby and transmit
- the radar selector, when more than one radar is connected
- the range + and − buttons
- the menu button that opens the radar controls
- the settings inside the panel, and how they are grouped
- the button that closes the panel again

Next / Back / Skip, arrow keys and Escape all work. The tour is dismissed for good once finished or skipped.

## Implementation

`web/gui/tour.js` plus `tour.css`, started from `viewer.js` once the lozenges exist. The dimming is four masks around the highlight rather than a raised target, because `.myr_controller` creates a stacking context that a raised `z-index` cannot escape. The masks also swallow clicks, so following along cannot put the radar into transmit.

Steps declare their target as a selector and are skipped when it is absent — that is how the radar selector step drops out on a single-radar server, and it is also why this PR does not depend on #529. Steps declare whether they need the controls panel open, so Back restores the panel state instead of leaving it hanging open.

Seen state is `mayaraTourSeen` in localStorage, with the same try/catch treatment as the other GUI preferences; `viewer.html?tour=1` replays it.

Not verified in a browser on my side — no working browser automation this session. Checked by hand: both files are served by the embedded web server, `viewer.js` imports and calls the entry point, and the module parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a first-time guided tour to the PPI viewer.

- Explains the PPI plot and own-ship orientation.
- Highlights key viewer controls with dimming masks and tooltips.
- Skips unavailable targets and embedded viewers.
- Supports Next, Back, Skip, arrow keys, and Escape.
- Restores panel state when navigating backward or exiting.
- Stores completion in `localStorage`.
- Supports replay with `viewer.html?tour=1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->