### PR TITLE
fix(gui): send the auto adjustment as a number

### DIFF
--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1587,8 +1587,12 @@ function do_change(v) {
   update.auto = auto;
   message.auto = auto;
   if (auto && control.hasAutoAdjustable) {
-    update.autoValue = storeValue;
-    message.autoValue = value;
+    // An auto adjustment is always a number, and the server only accepts one
+    // there — unlike `value`, which it takes as any JSON. A slider hands us
+    // its position as a string, so a control without units (Sea clutter, for
+    // one) would otherwise send `"-26"` and have the whole request rejected.
+    update.autoValue = Number(storeValue);
+    message.autoValue = Number(value);
   } else {
     update.value = storeValue;
     message.value = value;


### PR DESCRIPTION
Dragging the adjustment slider of a control that is on auto did nothing whatsoever. On a HALO that is Sea clutter's -50..+50 adjustment: the slider moved, the radar carried on unchanged, and the control fell back to showing as unconfirmed. Nothing reached the radar, because nothing reached mayara — the browser's request was rejected before any handler saw it.

Verified on a HALO24: the adjustment now takes effect, and the radar reports it back.

## Root cause

A range input hands out its position as a string. `do_change` converted that to a number only for controls that carry `user_units`, and Sea clutter has none, so the string went out untouched.

The server takes `value` as any JSON and coerces it, which is why the manual slider worked with the same string. `autoValue` is an `Option<f64>` and is strict, so the auto adjustment 422'd on every drag:

```
PUT …/controls/sea  {"auto":true,"autoValue":"-26"}
→ 422  autoValue: invalid type: string "-26", expected f64
```

An auto adjustment is numeric by definition, so it is now converted at the point it is put into the request. `value` is left alone — string-valued controls go through the same path, and the server already handles the numeric ones.

## Related

Separate from #532, which fixes the byte encoding of the same command. That one was masked by this: the request never arrived, so the encoding was never exercised from the GUI. Both are needed for the adjustment to work, and both are confirmed on the water. Neither closes #466, which is about mode changes reaching the stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)