### PR TITLE
fix(api): accept numbers sent as strings

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -627,15 +627,31 @@ async fn set_control_value(
 }))]
 struct AcquireTargetRequest {
     /// Target bearing in radians true [0, 2π).
+    #[serde(
+        default,
+        deserialize_with = "mayara::util::deserialize_optional_number"
+    )]
     #[schema(example = 1.0)]
     bearing: Option<f64>,
     /// Target distance in meters
+    #[serde(
+        default,
+        deserialize_with = "mayara::util::deserialize_optional_number"
+    )]
     #[schema(example = 1852.0)]
     distance: Option<f64>,
     /// Target latitude in decimal degrees (alternative to bearing/distance)
+    #[serde(
+        default,
+        deserialize_with = "mayara::util::deserialize_optional_number"
+    )]
     #[schema(example = 52.3702)]
     latitude: Option<f64>,
     /// Target longitude in decimal degrees (alternative to bearing/distance)
+    #[serde(
+        default,
+        deserialize_with = "mayara::util::deserialize_optional_number"
+    )]
     #[schema(example = 4.8952)]
     longitude: Option<f64>,
 }

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -1880,13 +1880,29 @@ pub struct ControlValue {
     pub units: Option<Units>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub auto_value: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub end_value: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub start_distance: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub end_distance: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
@@ -1895,15 +1911,35 @@ pub struct ControlValue {
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     // Rectangular exclusion zone fields (corner-based, meters from radar position)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub x1: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub y1: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub x2: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub y2: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub width: Option<f64>,
     /// Timestamp when the control value was last changed
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2072,18 +2108,34 @@ pub struct RadarControlValue {
     #[schema(example = false)]
     pub auto: Option<bool>,
     /// Current auto-computed value (read-only, server-to-client only)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     pub auto_value: Option<f64>,
     /// End angle for guard zones (degrees)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 90.0)]
     pub end_value: Option<f64>,
     /// Start distance for guard zones (meters)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 100.0)]
     pub start_distance: Option<f64>,
     /// End distance for guard zones (meters)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 500.0)]
     pub end_distance: Option<f64>,
     /// Enable/disable the control (for guard zones)
@@ -2097,23 +2149,43 @@ pub struct RadarControlValue {
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// First corner X for rectangular exclusion zones (meters from radar, positive = east)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 100.0)]
     pub x1: Option<f64>,
     /// First corner Y for rectangular exclusion zones (meters from radar, positive = north)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 200.0)]
     pub y1: Option<f64>,
     /// Second corner X for rectangular exclusion zones (meters from radar, positive = east)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 300.0)]
     pub x2: Option<f64>,
     /// Second corner Y for rectangular exclusion zones (meters from radar, positive = north)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 200.0)]
     pub y2: Option<f64>,
     /// Width of rectangular exclusion zone (perpendicular to edge, meters)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 50.0)]
     pub width: Option<f64>,
     /// Timestamp when the control value was last changed (ISO 8601 format)
@@ -2229,19 +2301,35 @@ pub struct BareControlValue {
     #[schema(example = false)]
     pub auto: Option<bool>,
     /// Adjustment of the auto algorithm when auto=true
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = -5.0)]
     pub auto_value: Option<f64>,
     /// End angle for sector and zone (radians)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 0.78593)]
     pub end_value: Option<f64>,
     /// Inner radius for zones (meters)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 100.0)]
     pub start_distance: Option<f64>,
     /// Outer radius for zones (meters)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 500.0)]
     pub end_distance: Option<f64>,
     /// Whether the user has enabled the control
@@ -2257,23 +2345,43 @@ pub struct BareControlValue {
     #[schema(read_only = true)]
     pub error: Option<String>,
     /// First corner X for rectangular exclusion zones (meters from radar, positive = east)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 100.0)]
     pub x1: Option<f64>,
     /// First corner Y for rectangular exclusion zones (meters from radar, positive = north)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 200.0)]
     pub y1: Option<f64>,
     /// Second corner X for rectangular exclusion zones (meters from radar, positive = east)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 300.0)]
     pub x2: Option<f64>,
     /// Second corner Y for rectangular exclusion zones (meters from radar, positive = north)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 200.0)]
     pub y2: Option<f64>,
     /// Width of rectangular exclusion zone (perpendicular to edge, meters)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::util::deserialize_optional_number"
+    )]
     #[schema(example = 50.0)]
     pub width: Option<f64>,
     /// Timestamp when the control value was last changed (ISO 8601 format)
@@ -4137,5 +4245,37 @@ mod test {
             controls.get(&ControlId::Power).unwrap().item.valid_values,
             Some(vec![0, 1, 2])
         );
+    }
+
+    /// The GUI builds a request from slider positions, which are strings. A
+    /// control adjustment used to be refused outright over the quotes, so the
+    /// whole request failed and the radar was never told anything.
+    #[test]
+    fn control_request_accepts_numbers_written_as_strings() {
+        let quoted: BareControlValue =
+            serde_json::from_str(r#"{"auto": true, "autoValue": "-26"}"#).unwrap();
+        let bare: BareControlValue =
+            serde_json::from_str(r#"{"auto": true, "autoValue": -26}"#).unwrap();
+
+        assert_eq!(quoted.auto_value, Some(-26.));
+        assert_eq!(quoted.auto_value, bare.auto_value);
+        assert_eq!(quoted.auto, Some(true));
+    }
+
+    /// Guard zone geometry arrives from the same kind of form input, and is
+    /// spread over several numeric fields that each have to give.
+    #[test]
+    fn control_request_accepts_string_geometry() {
+        let zone: BareControlValue = serde_json::from_str(
+            r#"{"value": "0.5", "endValue": "1.5", "startDistance": "100", "endDistance": "500"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(zone.end_value, Some(1.5));
+        assert_eq!(zone.start_distance, Some(100.));
+        assert_eq!(zone.end_distance, Some(500.));
+        // `value` takes any JSON and is converted where it is read, so it is
+        // left exactly as sent.
+        assert_eq!(zone.value, Some(serde_json::json!("0.5")));
     }
 }

--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -120,6 +120,50 @@ impl fmt::Display for PrintableSpoke<'_> {
     }
 }
 
+/// Deserialize an optional number that a client may have sent as a string.
+///
+/// Web clients build requests out of form and slider values, which are strings
+/// whatever they hold — an `<input type="range">` has no numeric type at all.
+/// A control value has always been accepted either way, so the numbers
+/// alongside it are read the same way rather than failing the whole request
+/// over a pair of quotes.
+///
+/// Anything that is not a number is still refused, as are the non-finite
+/// values a string can express but JSON cannot.
+pub fn deserialize_optional_number<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    use serde::de::{Error, Unexpected};
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumberOrString {
+        Number(f64),
+        String(String),
+    }
+
+    let expected = "a number, or a string holding one";
+    let number = match Option::<NumberOrString>::deserialize(deserializer)? {
+        None => return Ok(None),
+        Some(NumberOrString::Number(n)) => n,
+        Some(NumberOrString::String(s)) => s
+            .trim()
+            .parse()
+            .map_err(|_| D::Error::invalid_value(Unexpected::Str(&s), &expected))?,
+    };
+
+    if !number.is_finite() {
+        return Err(D::Error::invalid_value(
+            Unexpected::Float(number),
+            &expected,
+        ));
+    }
+
+    Ok(Some(number))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,6 +196,49 @@ mod tests {
         let encoded: [u8; 5] = [0xEF, 0xBE, 0xAD, 0xDE, 0x01];
         let decoded: WireSample = decode_bin(&encoded).expect("decode_bin must succeed");
         assert_eq!(decoded, expected);
+    }
+
+    #[derive(Debug, serde::Deserialize, PartialEq)]
+    struct Sample {
+        #[serde(default, deserialize_with = "deserialize_optional_number")]
+        n: Option<f64>,
+    }
+
+    fn parse(json: &str) -> Result<Option<f64>, serde_json::Error> {
+        serde_json::from_str::<Sample>(json).map(|s| s.n)
+    }
+
+    /// A slider hands its position over as a string, so the number a client
+    /// means has to survive the quotes it arrives in.
+    #[test]
+    fn optional_number_reads_numbers_written_as_strings() {
+        assert_eq!(parse(r#"{"n": -26}"#).unwrap(), Some(-26.));
+        assert_eq!(parse(r#"{"n": "-26"}"#).unwrap(), Some(-26.));
+        assert_eq!(parse(r#"{"n": "50"}"#).unwrap(), Some(50.));
+        assert_eq!(parse(r#"{"n": "1.5"}"#).unwrap(), Some(1.5));
+        assert_eq!(parse(r#"{"n": " 7 "}"#).unwrap(), Some(7.));
+    }
+
+    /// Absent and null both mean "not given", and must not become zero — a
+    /// control left out of a request has to stay untouched.
+    #[test]
+    fn optional_number_keeps_absent_apart_from_zero() {
+        assert_eq!(parse(r#"{}"#).unwrap(), None);
+        assert_eq!(parse(r#"{"n": null}"#).unwrap(), None);
+        assert_eq!(parse(r#"{"n": 0}"#).unwrap(), Some(0.));
+        assert_eq!(parse(r#"{"n": "0"}"#).unwrap(), Some(0.));
+    }
+
+    /// Tolerating strings must not extend to values that are not numbers at
+    /// all, nor to the non-finite ones JSON itself cannot express.
+    #[test]
+    fn optional_number_still_refuses_what_is_not_a_number() {
+        assert!(parse(r#"{"n": "abc"}"#).is_err());
+        assert!(parse(r#"{"n": ""}"#).is_err());
+        assert!(parse(r#"{"n": true}"#).is_err());
+        assert!(parse(r#"{"n": []}"#).is_err());
+        assert!(parse(r#"{"n": "NaN"}"#).is_err());
+        assert!(parse(r#"{"n": "inf"}"#).is_err());
     }
 
     /// Garbage bytes shorter than the expected struct must surface


### PR DESCRIPTION
A client that builds a request out of form or slider values sends its numbers as strings, because that is what an HTML input holds. mayara accepted that for a control's value but refused it for every number beside it, so any request carrying one was rejected whole and the radar was never told anything. Nothing appeared in the server log either — the rejection happens during deserialization, before the handler that logs — so from the outside the setting simply did nothing.

This is the server-side counterpart to #533. That fixed the GUI's own request; this stops any client hitting the same wall.

## What changed

`util::deserialize_optional_number` reads a JSON number or a string holding one, and is applied to every optional number the API accepts:

- `ControlValue`, `RadarControlValue`, `BareControlValue` — the auto adjustment, sector and zone geometry, rectangular zone corners
- `AcquireTargetRequest` — bearing, distance, latitude, longitude

Tolerance stops at numbers. `"abc"`, `true`, `[]` and `""` are still refused, as are `"NaN"` and `"inf"` — a string can express those but JSON cannot, and no caller means them.

```
PUT …/controls/sea  {"auto":true,"autoValue":"-26"}   → 200   (was 422)
PUT …/controls/sea  {"auto":true,"autoValue":"abc"}   → 422   invalid value: string "abc",
                                                              expected a number, or a string holding one
```

`value` is untouched: it is `serde_json::Value` because it genuinely carries strings for name and version controls, and it is converted where it is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)