### PR TITLE
fix(stream): say nothing to a client that subscribed to nothing

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1459,7 +1459,13 @@ async fn ws_signalk_delta(
     let mut subscriptions = ActiveSubscriptions::new(subscribe);
 
     let mut sk_delta = SignalKDelta::new();
-    sk_delta.add_meta_updates(&radars, &mut meta_radar_data_sent);
+
+    // A client that asked for nothing gets nothing, control definitions
+    // included — they describe data it has not subscribed to. Once it does
+    // subscribe, the definitions travel with the first values it receives.
+    if subscribe != Subscribe::None {
+        sk_delta.add_meta_updates(&radars, &mut meta_radar_data_sent);
+    }
 
     // Radar controls are own-ship data, so send the cached values on connect for
     // both `self` and `all` — only `none` waits for an explicit subscription.

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1544,7 +1544,7 @@ async fn ws_signalk_delta(
                     Some(Ok(message)) => {
                         match message {
                             Message::Text(message) => {
-                                handle_client_request(socket, message.as_str(), &mut subscriptions, &radars, reply_tx.clone()).await;
+                                handle_client_request(socket, message.as_str(), &mut subscriptions, &radars, reply_tx.clone(), &mut meta_radar_data_sent).await;
                             },
                             _ => {
                                 log::debug!("Dropping unexpected message {:?}", message);
@@ -1564,7 +1564,7 @@ async fn ws_signalk_delta(
             }
 
             _ = tokio::time::sleep(subscriptions.get_timeout()) => {
-                if let Err(e) = send_all_subscribed(socket, &radars, &mut subscriptions).await
+                if let Err(e) = send_all_subscribed(socket, &radars, &mut subscriptions, &mut meta_radar_data_sent).await
                 {
                     log::warn!("Cannot send subscribed data to websocket");
                     break Err(e);
@@ -1639,6 +1639,7 @@ async fn handle_client_request(
     subscriptions: &mut ActiveSubscriptions,
     radars: &SharedRadars,
     reply_tx: mpsc::Sender<ControlValue>,
+    meta_sent: &mut HashSet<String>,
 ) {
     log::info!("Stream request: {}", message);
 
@@ -1649,7 +1650,7 @@ async fn handle_client_request(
     if let Ok(stream_request) = stream_request {
         let r = match stream_request {
             StreamRequest::Subscription(subscription) => {
-                handle_subscription(socket, radars, subscriptions, subscription).await
+                handle_subscription(socket, radars, subscriptions, subscription, meta_sent).await
             }
             StreamRequest::Desubscription(desubscription) => {
                 subscriptions.desubscribe(desubscription)
@@ -1720,9 +1721,10 @@ async fn handle_subscription(
     radars: &SharedRadars,
     subscriptions: &mut ActiveSubscriptions,
     subscription: Subscription,
+    meta_sent: &mut HashSet<String>,
 ) -> Result<(), RadarError> {
     let ais_subscribed = subscriptions.subscribe(subscription)?;
-    send_all_subscribed(socket, radars, subscriptions).await?;
+    send_all_subscribed(socket, radars, subscriptions, meta_sent).await?;
 
     // If AIS was just subscribed, send all known AIS vessels
     if ais_subscribed {
@@ -1771,6 +1773,7 @@ async fn send_all_subscribed(
     socket: &mut WebSocket,
     radars: &SharedRadars,
     subscriptions: &mut ActiveSubscriptions,
+    meta_sent: &mut HashSet<String>,
 ) -> Result<(), RadarError> {
     let mut rcvs: Vec<RadarControlValue> = Vec::with_capacity(80);
 
@@ -1786,6 +1789,10 @@ async fn send_all_subscribed(
     if !rcvs.is_empty() {
         let mut delta: SignalKDelta = SignalKDelta::new();
         delta.add_updates(rcvs);
+        // A value means nothing without the definition that says what it is,
+        // and a client subscribing after `subscribe=none` has been told
+        // nothing yet — these are the first values it has seen.
+        delta.add_meta_from_updates(radars, meta_sent);
         send_message(socket, delta.build().unwrap()).await?;
     }
 

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -311,11 +311,21 @@ impl SignalKDelta {
         }
     }
 
-    pub fn build(self) -> Option<Self> {
-        if !self.updates.is_empty() {
-            return Some(self);
+    /// The delta to send, or nothing when there is nothing left to say.
+    ///
+    /// Filtering a delta against a client's subscriptions empties the values
+    /// it did not ask for, which can leave an update carrying only a source
+    /// and a timestamp. Sending that tells the client nothing, and a client
+    /// subscribed to little enough receives a steady stream of it, so drop
+    /// updates that carry neither values nor meta before deciding.
+    pub fn build(mut self) -> Option<Self> {
+        self.updates
+            .retain(|update| !update.values.is_empty() || !update.meta.is_empty());
+
+        if self.updates.is_empty() {
+            return None;
         }
-        None
+        Some(self)
     }
 }
 
@@ -1455,5 +1465,78 @@ mod test {
 
         assert!(!subs.is_subscribed_path("radars.nav1.controls.gain", false));
         assert_eq!(last_sent_of(&subs, "nav1", ControlId::Gain), Some(pinned));
+    }
+}
+
+#[cfg(test)]
+mod build_tests {
+    use super::*;
+    use crate::radar::settings::new_numeric;
+
+    fn update(values: Vec<DeltaValue>) -> DeltaUpdate {
+        DeltaUpdate {
+            source: Some(PACKAGE.to_string()),
+            timestamp: Some(Utc::now()),
+            meta: Vec::new(),
+            values,
+        }
+    }
+
+    fn navigation_value() -> DeltaValue {
+        DeltaValue::Navigation {
+            path: "navigation.headingTrue".to_string(),
+            value: 1.5,
+        }
+    }
+
+    fn delta_of(updates: Vec<DeltaUpdate>) -> SignalKDelta {
+        let mut delta = SignalKDelta::new();
+        delta.updates = updates;
+        delta
+    }
+
+    /// Filtering a delta against a subscription empties the values the client
+    /// did not ask for, leaving an update carrying only a source and a
+    /// timestamp. Sending that says nothing, and a client subscribed to little
+    /// enough gets a steady stream of it — `subscribe=none` turned every
+    /// own-ship update into one.
+    #[test]
+    fn an_update_with_nothing_left_in_it_is_not_sent() {
+        let delta = delta_of(vec![update(vec![])]);
+
+        assert!(delta.build().is_none());
+    }
+
+    #[test]
+    fn a_delta_with_values_is_sent() {
+        let delta = delta_of(vec![update(vec![navigation_value()])]);
+
+        assert_eq!(delta.build().map(|d| d.updates.len()), Some(1));
+    }
+
+    /// A control is described before its value ever changes, so an update
+    /// carrying only meta still has something to say.
+    #[test]
+    fn a_delta_carrying_only_meta_is_sent() {
+        let (_, control) = new_numeric(ControlId::Gain, 0., 100.).take();
+        let mut delta = SignalKDelta::new();
+        delta.add_meta_for_control("nav1034A", &control);
+
+        assert_eq!(delta.build().map(|d| d.updates.len()), Some(1));
+    }
+
+    /// An emptied update must not take a full one down with it, nor survive
+    /// alongside it.
+    #[test]
+    fn only_the_emptied_updates_are_dropped() {
+        let delta = delta_of(vec![
+            update(vec![]),
+            update(vec![navigation_value()]),
+            update(vec![]),
+        ]);
+
+        let built = delta.build().expect("a delta with values is sent");
+        assert_eq!(built.updates.len(), 1);
+        assert_eq!(built.updates[0].values.len(), 1);
     }
 }

--- a/tests/api_stream.rs
+++ b/tests/api_stream.rs
@@ -38,7 +38,15 @@ async fn first_radar_id() -> String {
         .json()
         .await
         .unwrap();
-    json.as_object().unwrap().keys().next().unwrap().clone()
+    // The document is `{"version": ..., "radars": {...}}`, so the ids are one
+    // level in — taking the first key of the document itself yields "radars".
+    json["radars"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .next()
+        .unwrap()
+        .clone()
 }
 
 fn text_msg(v: &Value) -> Message {
@@ -167,16 +175,29 @@ async fn test_control_stream_set_control_via_stream() {
     write.send(text_msg(&msg)).await.unwrap();
     let _ = timeout(Duration::from_secs(2), read.next()).await;
 
-    // Set a control value via the stream
-    let msg = json!({
-        "updates": [{"values": [{"path": format!("radars.{}.controls.gain", id), "value": {"value": 60}}]}]
-    });
+    // Set a control value via the stream. The stream takes the control value
+    // itself, not a delta wrapped around it — the shape this used to send
+    // matched no request at all, and the frame that made the test pass was
+    // unrelated traffic that happened to arrive.
+    let path = format!("radars.{}.controls.gain", id);
+    let msg = json!({ "path": path, "value": 60 });
     write.send(text_msg(&msg)).await.unwrap();
 
-    let result = timeout(Duration::from_secs(5), read.next()).await;
+    // The radar reporting the new value back is what says the write landed.
+    let mut reported = false;
+    for _ in 0..10 {
+        let Ok(Some(Ok(Message::Text(text)))) = timeout(Duration::from_secs(2), read.next()).await
+        else {
+            break;
+        };
+        if text.contains(&path) {
+            reported = true;
+            break;
+        }
+    }
     assert!(
-        result.is_ok(),
-        "Should receive response after setting control"
+        reported,
+        "the control set over the stream was never reported"
     );
 }
 
@@ -383,4 +404,82 @@ async fn test_websocket_without_deflate() {
         response.headers().get("sec-websocket-extensions").is_none(),
         "Server should not negotiate deflate when client doesn't offer it"
     );
+}
+
+/// How long to watch a stream that should have nothing to say.
+const SILENCE_WINDOW: Duration = Duration::from_secs(2);
+
+/// `subscribe=none` means what it says: after introducing itself the server
+/// stops until asked for something. Filtering used to empty each update
+/// without dropping it, so a client that had asked for nothing still received
+/// a message for every own-ship update on the boat.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_subscribe_none_says_nothing_after_the_hello() {
+    let url = format!("{}/signalk/v1/stream?subscribe=none", ws_url());
+    let (ws, _) = connect_async(&url).await.expect("Failed to connect");
+    let (_, mut read) = ws.split();
+
+    let hello = timeout(Duration::from_secs(5), read.next())
+        .await
+        .expect("Timed out waiting for the hello");
+    match hello {
+        Some(Ok(Message::Text(text))) => {
+            let json: Value = serde_json::from_str(&text).expect("Should be valid JSON");
+            assert!(json.get("self").is_some(), "expected the hello, got {json}");
+        }
+        other => panic!("Expected a hello, got {other:?}"),
+    }
+
+    match timeout(SILENCE_WINDOW, read.next()).await {
+        Err(_) => {} // Nothing said, which is the whole point.
+        Ok(Some(Ok(Message::Text(text)))) => {
+            panic!("a client that subscribed to nothing was sent: {text}")
+        }
+        Ok(other) => panic!("unexpected frame on a silent stream: {other:?}"),
+    }
+}
+
+/// A control cannot be read without knowing what it is, so the definitions
+/// have to arrive no later than the values they describe — they are held back
+/// on connect only until the client asks for the data.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_subscribing_brings_the_definitions_with_the_values() {
+    let url = format!("{}/signalk/v1/stream?subscribe=none", ws_url());
+    let (ws, _) = connect_async(&url).await.expect("Failed to connect");
+    let (mut write, mut read) = ws.split();
+
+    let subscribe = json!({
+        "subscribe": [{"path": "radars.*.controls.*", "policy": "instant"}]
+    });
+    write
+        .send(text_msg(&subscribe))
+        .await
+        .expect("Failed to subscribe");
+
+    let mut seen_meta = false;
+    for _ in 0..10 {
+        let frame = match timeout(Duration::from_secs(2), read.next()).await {
+            Ok(Some(Ok(Message::Text(text)))) => text,
+            _ => break,
+        };
+        let json: Value = serde_json::from_str(&frame).expect("Should be valid JSON");
+        let Some(updates) = json["updates"].as_array() else {
+            continue;
+        };
+
+        if updates.iter().any(|u| u.get("meta").is_some()) {
+            seen_meta = true;
+        }
+        if updates.iter().any(|u| u.get("values").is_some()) {
+            assert!(
+                seen_meta,
+                "control values arrived before anything said what they are: {frame}"
+            );
+            return;
+        }
+    }
+
+    panic!("subscribing produced no control values");
 }


### PR DESCRIPTION
A client that opened the stream with `subscribe=none` — Signal K's way of saying "send me nothing until I ask" — got the control definitions for every radar, and then a message for every own-ship update on the boat. Each had been stripped of the values the client had not subscribed to, so what arrived was a source and a timestamp and nothing else:

```json
{"context":"vessels.urn:mrn:imo:mmsi:244060807","updates":[{"$source":"canboat183.CJ","timestamp":"2026-08-12T06:02:59.528560042Z"}]}
```

Measured on a HALO24 with live nav data, twelve seconds of `subscribe=none`: **32 messages, 31 of which said nothing**. signalk-server on the same box answers the hello and stops.

## Cause

Two separate things, both visible only once a subscription filtered something out:

- `apply_subscriptions` empties `update.values` for paths the client did not ask for, but leaves the emptied `DeltaUpdate` in place. `build()` only asked whether the *vec* was empty, and it was not — it held one update carrying nothing.
- `add_meta_updates` ran unconditionally on connect, so the definitions went out even to a client that had subscribed to nothing.

`build()` now drops updates carrying neither values nor meta, which covers every send path since they all funnel through it. Definitions wait until the client subscribes, and then travel with the first values it receives — `add_meta_from_updates` already handles that.

## Measured after

| | before | after | signalk-server |
| --- | --- | --- | --- |
| `subscribe=none` | 32 messages | **1** (hello) | 1 |
| `subscribe=self` | 33, some empty | 33, **0 empty** | — |

Deployed to a HALO24 to confirm; `subscribe=self` and the default are unchanged in what they carry.

## Scope

Part of #462. The remaining stream gap — a Signal K `put` over the socket drawing no reply at all — follows separately, as does the hello/discovery work.

## Testing

Four unit tests on `build()`: an emptied update, one with values, one carrying only meta (built through `add_meta_for_control` so it is the real shape), and a mix where only the emptied ones are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Filters empty Signal K updates from `SignalKDelta::build`.
- Preserves updates that contain values, metadata, or both.
- Delays radar control metadata for clients using `subscribe=none`.
- Adds unit tests for empty, value-only, metadata-only, and mixed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->