### PR TITLE
docs(readme): list the applications that use Mayara for radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Mayara translates proprietary radar network protocols into a well-described, ope
 
 Mayara can serve multiple clients simultaneously — PPI displays, chart applications with radar overlay, or autonomous navigation systems that act on the radar image.
 
+## Clients
+
+Besides Mayara's own GUI, these applications use it for radar support:
+
+- [**mayara_pi**](https://github.com/opencpn-radar-pi/mayara_pi) — OpenCPN plugin that draws the radar as a chart overlay and in a PPI window
+- [**Freeboard-SK**](https://github.com/SignalK/freeboard-sk) — Signal K chart plotter with a radar overlay
+- [**Binnacle**](https://github.com/NearlCrews/signalk-binnacle) — WebGL chart plotter for Signal K with a radar overlay and controls
+- [**signalk-beluga-core**](https://github.com/matztam/signalk-beluga-core) — Signal K plugin that forwards Mayara's radar to the ORCA app
+
 ## Radar support
 
 Fully supported and tested with real hardware:


### PR DESCRIPTION
Someone landing on the README could not tell which chart plotters and apps they can actually use with Mayara — the radar backend was described, but not what displays it.

The README now has a **Clients** section listing the applications that use Mayara for radar support: mayara_pi (OpenCPN), Freeboard-SK, Binnacle, and signalk-beluga-core (the ORCA app bridge).

Each entry was checked against the project's own README to confirm it really consumes Mayara or the Signal K Radar API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## README

- Adds a **Clients** section listing applications that use Mayara or the Signal K Radar API:
  - mayara_pi
  - Freeboard-SK
  - Binnacle
  - signalk-beluga-core

<!-- end of auto-generated comment: release notes by coderabbit.ai -->