### PR TITLE
fix(signalk): introduce the server the way Signal K servers do

### DIFF
--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -327,8 +327,10 @@ struct Endpoints {
 #[derive(Serialize, ToSchema)]
 struct Endpoint {
     version: String,
-    #[serde(rename = "signalk-http")]
-    http: String,
+    /// Absent for `v1`: mayara serves the v1 stream but not the v1 REST tree,
+    /// and pointing a client at an address that answers nothing helps nobody.
+    #[serde(rename = "signalk-http", skip_serializing_if = "Option::is_none")]
+    http: Option<String>,
     #[serde(rename = "signalk-ws")]
     ws: String,
 }
@@ -585,12 +587,31 @@ async fn endpoints(State(state): State<Web>, headers: hyper::header::HeaderMap) 
         },
         nav: mayara::navdata::nav_status(&state.args),
     };
+    let stream = format!("{}://{}{}", ws_scheme, host, signalk::v2::CONTROL_URI);
+
+    // A Signal K client looks for the stream under the version of the API it
+    // speaks, and the stream mayara serves is `/signalk/v1/stream`. Advertising
+    // it only under `v2` left it undiscoverable to every client that does what
+    // the rest of the ecosystem does.
+    endpoints.endpoints.insert(
+        "v1".to_string(),
+        Endpoint {
+            version: VERSION.to_string(),
+            http: None,
+            ws: stream.clone(),
+        },
+    );
     endpoints.endpoints.insert(
         "v2".to_string(),
         Endpoint {
             version: mayara::SIGNALK_RADAR_API_VERSION.to_string(),
-            http: format!("{}://{}{}", http_scheme, host, signalk::v2::BASE_URI),
-            ws: format!("{}://{}{}", ws_scheme, host, signalk::v2::CONTROL_URI),
+            http: Some(format!(
+                "{}://{}{}",
+                http_scheme,
+                host,
+                signalk::v2::BASE_URI
+            )),
+            ws: stream,
         },
     );
 

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1969,14 +1969,35 @@ struct SignalKHello {
     #[serde(serialize_with = "to_rfc3339")]
     timestamp: DateTime<Utc>,
     roles: Vec<&'static str>,
+    /// Identifies this run of the server. A client that reconnects and finds a
+    /// different one knows the values it cached came from an instance that is
+    /// gone, so anything the new one has not sent again may never arrive.
+    #[serde(rename = "serverStartId")]
+    server_start_id: &'static str,
 }
 
-// Helper that turns a `DateTime` into an RFC‑3339 string when serializing
+/// A value that is the same for every hello this process sends and different
+/// after a restart, which is all a client needs from it. Signal K leaves the
+/// contents opaque; the pid and the moment it started are enough to tell two
+/// runs apart without pulling in a UUID crate to say the same thing.
+fn server_start_id() -> &'static str {
+    static ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    ID.get_or_init(|| {
+        format!(
+            "{:x}-{:x}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        )
+    })
+}
+
+// Milliseconds and a `Z`: the form every other Signal K server sends, and
+// therefore the one every client is known to read.
 fn to_rfc3339<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(&dt.to_rfc3339())
+    serializer.serialize_str(&dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
 }
 
 async fn send_hello(socket: &mut WebSocket) -> Result<(), Error> {
@@ -1985,7 +2006,10 @@ async fn send_hello(socket: &mut WebSocket) -> Result<(), Error> {
         version: VERSION,
         self_context: navdata::get_own_ship_context().unwrap_or_else(|| "vessels.self".to_string()),
         timestamp: Utc::now(),
+        // Not "main": that is the vessel's primary server, and mayara is a
+        // radar source that normally sits behind one.
         roles: vec!["master"],
+        server_start_id: server_start_id(),
     };
     let message: String = serde_json::to_string(&message).unwrap();
     let ws_message = Message::Text(message.into());

--- a/tests/api_rest.rs
+++ b/tests/api_rest.rs
@@ -740,3 +740,35 @@ async fn test_reading_a_control_stays_bare() {
         control
     );
 }
+
+/// A Signal K client looks for the stream under the version of the API it
+/// speaks. mayara serves `/signalk/v1/stream`, so a client reading
+/// `endpoints.v1` has to find it there — advertising it only under `v2` left
+/// it undiscoverable to anything that follows the usual convention.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_discovery_advertises_the_stream_under_v1() {
+    let json = get_json("/signalk").await;
+    let v1 = &json["endpoints"]["v1"];
+
+    let ws = v1["signalk-ws"]
+        .as_str()
+        .expect("v1 must advertise the stream");
+    assert!(
+        ws.ends_with("/signalk/v1/stream"),
+        "v1 stream should be the v1 stream, got {ws}"
+    );
+    assert!(v1.get("version").is_some());
+}
+
+/// mayara serves no v1 REST tree, so it must not name an address for one.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_discovery_claims_no_v1_rest_tree() {
+    let json = get_json("/signalk").await;
+
+    assert!(
+        json["endpoints"]["v1"].get("signalk-http").is_none(),
+        "v1 must not advertise a REST tree mayara does not serve"
+    );
+}

--- a/tests/api_stream.rs
+++ b/tests/api_stream.rs
@@ -605,3 +605,69 @@ async fn test_unreadable_stream_request_is_answered() {
     assert_eq!(response["state"], "FAILED");
     assert_eq!(response["statusCode"], 400);
 }
+
+/// How long a test will wait for the server to introduce itself.
+const HELLO_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn hello() -> Value {
+    let url = format!("{}/signalk/v1/stream?subscribe=none", ws_url());
+    let (ws, _) = connect_async(&url).await.expect("Failed to connect");
+    let (_, mut read) = ws.split();
+
+    let first = timeout(HELLO_TIMEOUT, read.next())
+        .await
+        .expect("Timed out waiting for the hello");
+
+    match first {
+        Some(Ok(Message::Text(text))) => serde_json::from_str(&text).expect("Should be valid JSON"),
+        other => panic!("Expected a hello, got {other:?}"),
+    }
+}
+
+/// A client that reconnects and finds a different id knows the values it
+/// cached came from an instance that is gone.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_hello_carries_a_server_start_id() {
+    let first = hello().await;
+    let id = first["serverStartId"]
+        .as_str()
+        .expect("the hello must carry a serverStartId");
+    assert!(!id.is_empty());
+
+    let second = hello().await;
+    assert_eq!(
+        second["serverStartId"], first["serverStartId"],
+        "the id identifies the run, so it must not change between connections"
+    );
+}
+
+/// Every other Signal K server stamps the hello with milliseconds and a `Z`,
+/// so that is the form clients are known to read. mayara used to send an
+/// offset and nanoseconds, which is valid RFC 3339 and unlike everyone else.
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_hello_timestamp_is_the_shape_clients_read() {
+    let hello = hello().await;
+    let timestamp = hello["timestamp"].as_str().expect("hello has a timestamp");
+
+    assert!(
+        !timestamp.contains("+00:00"),
+        "timestamp should not carry an offset, got {timestamp}"
+    );
+
+    // `Z` on its own would also be satisfied by a whole-second stamp, and the
+    // precision is the half of this that clients actually parse.
+    let (_, fraction) = timestamp
+        .rsplit_once('.')
+        .unwrap_or_else(|| panic!("timestamp should carry a fraction, got {timestamp}"));
+    assert_eq!(
+        fraction.len(),
+        4,
+        "expected three millisecond digits and a Z, got {timestamp}"
+    );
+    assert!(
+        fraction.ends_with('Z') && fraction[..3].chars().all(|c| c.is_ascii_digit()),
+        "expected three millisecond digits and a Z, got {timestamp}"
+    );
+}


### PR DESCRIPTION
Three things a client meets before it reads any data differed from every other Signal K server. Compared side by side against signalk-server 2.31.0 on the same box.

## The stream was undiscoverable

A client finds the stream by reading `endpoints`, under the version of the API it speaks. mayara serves `/signalk/v1/stream` but advertised it only under `v2`, so a client doing what the rest of the ecosystem does found nothing:

```json
"endpoints": { "v2": { "version": "3.4.0", "signalk-http": ".../radars", "signalk-ws": ".../signalk/v1/stream" } }
```

It is now advertised under `v1` as well. That entry carries no `signalk-http`: mayara serves the v1 *stream* but not the v1 REST tree, and naming an address that answers nothing is worse than saying nothing.

`v2` is unchanged, still describing the radar API.

## The hello could not be told apart between restarts

signalk-server sends a `serverStartId`, fresh per start. A client that reconnects and sees a different one knows the values it cached came from an instance that is gone, and that anything the new one has not sent again may never arrive. mayara sent none, so a reconnecting client had no way to know its cache was stale.

The value is opaque, so rather than take a UUID dependency for one string it is built from the pid and the moment the process started — different after every restart, which is the whole contract.

## The timestamp was in a form nothing else sends

```
before  "timestamp": "2026-08-12T05:14:48.503179253+00:00"
after   "timestamp": "2026-08-12T10:31:22.462Z"
```

Both are valid RFC 3339. Only one is what every Signal K client is exercised against — and mayara's own deltas already used `Z`, so this was inconsistent with itself.

## Left deliberately

- **`roles`** stays `["master"]`. signalk-server sends `["master", "main"]`, but `main` means the vessel's primary server, and mayara is a radar source that normally sits behind one. Copying it would be a claim rather than a fix.
- **`nav`** stays. It is a mayara extension, not Signal K, but the GUI reads it to explain why own-ship position or AIS is missing, and a standard client ignores keys it does not know.

## Result

```json
{"name":"mayara","version":"3.8.1","self":"vessels.urn:mrn:imo:mmsi:244060807",
 "timestamp":"2026-08-12T10:31:22.462Z","roles":["master"],"serverStartId":"14312-18cb0830b486d000"}
```

Field for field with signalk-server's hello, apart from `roles` above.

## Testing

Four integration tests: the stream is advertised under `v1`, `v1` claims no REST tree, the hello carries an id that is stable across connections, and its timestamp ends in `Z` without an offset.

Two pre-existing failures in the suites, both reproduced on `main` and unrelated:
- three `test_spoke_stream_*` tests fail because `first_radar_id()` in `api_stream.rs` reads the first key of the whole radars document (`"radars"`) rather than a radar id — fixed in #542.
- `test_set_control_values_*` are flaky: two of them write `userName` on the same emulator radar, and the same command on `main` gives 0 failures one run and 2 the next.

## Scope

This closes the last of the gaps found by comparing mayara against a running signalk-server for #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Advertises `/signalk/v1/stream` under the `v1` endpoint without a REST URL.
- Adds a per-process `serverStartId` to hello messages.
- Formats hello timestamps with millisecond precision and a trailing `Z`.
- Preserves `roles: ["master"]` and the `nav` extension.
- Adds integration tests for endpoint discovery, REST omission, restart identity, and timestamp formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->