### PR TITLE
fix(stream): let a radar wildcard reach that radar's targets

### DIFF
--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -718,6 +718,21 @@ impl ActiveSubscriptions {
         for path_desubscription in subscription.desubscribe {
             let path = &path_desubscription.path;
 
+            // Mirror of the fan-out in `subscribe`: `*` put a wildcard in every
+            // category, so taking it back has to remove it from every category.
+            // Falls through to the control handler below, as the fan-out does.
+            if path == "*" {
+                log::debug!("Desubscribing from all paths");
+                for list in [
+                    &mut self.navigation_subscriptions,
+                    &mut self.notification_subscriptions,
+                    &mut self.vessel_subscriptions,
+                ] {
+                    list.retain(|p| p != "*");
+                }
+                desubscribe_targets(&mut self.target_subscriptions, "*", "*");
+            }
+
             // Handle navigation desubscriptions (e.g., "navigation.headingTrue")
             if path.starts_with("navigation.") {
                 log::debug!("Desubscribing from navigation path: {}", path);
@@ -733,12 +748,7 @@ impl ActiveSubscriptions {
                     radar_id,
                     target_pattern
                 );
-                if let Some(patterns) = self.target_subscriptions.get_mut(radar_id) {
-                    patterns.retain(|p| p != target_pattern);
-                    if patterns.is_empty() {
-                        self.target_subscriptions.remove(radar_id);
-                    }
-                }
+                desubscribe_targets(&mut self.target_subscriptions, radar_id, target_pattern);
                 continue;
             }
 
@@ -758,6 +768,12 @@ impl ActiveSubscriptions {
 
             // Handle control desubscriptions (existing logic)
             let (radar_id, control_id) = extract_path(path);
+
+            // The counterpart of subscribing to everything about a radar.
+            if control_id == "*" {
+                desubscribe_targets(&mut self.target_subscriptions, radar_id, "*");
+            }
+
             let paths = self.paths.get_mut(radar_id);
             if paths.is_none() {
                 continue;
@@ -1015,6 +1031,21 @@ impl ActiveSubscriptions {
     }
 }
 
+/// Drop a target subscription, and the radar's bucket with it once nothing is
+/// left in it, so an empty bucket never reads as "subscribed to this radar".
+fn desubscribe_targets(
+    subscriptions: &mut HashMap<String, Vec<String>>,
+    radar_id: &str,
+    pattern: &str,
+) {
+    if let Some(patterns) = subscriptions.get_mut(radar_id) {
+        patterns.retain(|p| p != pattern);
+        if patterns.is_empty() {
+            subscriptions.remove(radar_id);
+        }
+    }
+}
+
 /// Record a target subscription, keyed by radar id, without duplicating a
 /// pattern the client already asked for.
 fn subscribe_targets(
@@ -1245,10 +1276,9 @@ mod test {
         assert_eq!(patterns[0], "targets.*");
     }
 
-    /// `radars.*` is how a client asks for everything a radar has, and it is
-    /// what the Signal K plugin subscribes with. It used to register controls
-    /// alone, so targets never reached the Signal K data model at all and the
-    /// only way to see one was to name `.targets.` outright.
+    /// `radars.*` asks for everything a radar has, which is more than its
+    /// controls: a client that subscribes that way — as the Signal K plugin
+    /// does — must receive tracked targets without naming `.targets.` itself.
     #[test]
     fn a_radar_wildcard_covers_targets_as_well_as_controls() {
         let mut subs = ActiveSubscriptions::new(Subscribe::None);
@@ -1277,9 +1307,7 @@ mod test {
         );
     }
 
-    /// Subscribing to everything has to mean everything: the fan-out seeded
-    /// navigation, notifications and vessels but left targets out, so even `*`
-    /// delivered none.
+    /// Subscribing to everything has to mean everything, targets included.
     #[test]
     fn subscribing_to_everything_includes_targets() {
         let mut subs = ActiveSubscriptions::new(Subscribe::None);
@@ -1290,6 +1318,67 @@ mod test {
 
         assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
         assert!(subs.is_subscribed_path("radars.nav1.controls.gain", false));
+    }
+
+    /// A wildcard subscription has to be as easy to take back as it was to
+    /// make: whatever asking for it added, unasking has to remove, or a client
+    /// keeps receiving what it just said it no longer wants.
+    #[test]
+    fn a_radar_wildcard_can_be_taken_back() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("radars.*")],
+        })
+        .unwrap();
+        assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("radars.*")],
+        })
+        .unwrap();
+
+        assert!(!subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(!subs.is_subscribed_path("radars.nav1.controls.gain", false));
+    }
+
+    /// The same for the everything wildcard, which reaches further: it seeds
+    /// navigation, notifications and vessels alongside the radar categories.
+    #[test]
+    fn everything_can_be_taken_back() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("*")],
+        })
+        .unwrap();
+        assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(subs.is_subscribed_path("navigation.headingTrue", false));
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("*")],
+        })
+        .unwrap();
+
+        assert!(!subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(!subs.is_subscribed_path("navigation.headingTrue", false));
+        assert!(!subs.is_subscribed_path("radars.nav1.controls.gain", false));
+    }
+
+    /// Taking back one radar must leave the others alone.
+    #[test]
+    fn taking_back_one_radar_leaves_another_subscribed() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("radars.nav1.*"), path("radars.nav2.*")],
+        })
+        .unwrap();
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("radars.nav1.*")],
+        })
+        .unwrap();
+
+        assert!(!subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(subs.is_subscribed_path("radars.nav2.targets.5", false));
     }
 
     #[test]

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -602,6 +602,7 @@ impl ActiveSubscriptions {
                         list.push("*".to_string());
                     }
                 }
+                subscribe_targets(&mut self.target_subscriptions, "*", "*");
                 if !self.vessel_subscriptions.iter().any(|p| p == "*") {
                     self.vessel_subscriptions.push("*".to_string());
                     ais_subscribed = true;
@@ -625,13 +626,7 @@ impl ActiveSubscriptions {
                     radar_id,
                     target_pattern
                 );
-                let patterns = self
-                    .target_subscriptions
-                    .entry(radar_id.to_string())
-                    .or_default();
-                if !patterns.iter().any(|p| p == target_pattern) {
-                    patterns.push(target_pattern.to_string());
-                }
+                subscribe_targets(&mut self.target_subscriptions, radar_id, target_pattern);
                 continue;
             }
 
@@ -657,6 +652,14 @@ impl ActiveSubscriptions {
 
             // Handle control subscriptions (existing logic)
             let (radar_id, control_id) = extract_path(path);
+
+            // `radars.*` and `radars.<id>.*` ask for everything a radar has,
+            // which is more than its controls: without this, a client asking
+            // that way is quietly given controls alone, and the only way to
+            // reach targets is to name `.targets.` outright.
+            if control_id == "*" {
+                subscribe_targets(&mut self.target_subscriptions, radar_id, "*");
+            }
             let mut paths = self.paths.get_mut(radar_id);
             if paths.is_none() {
                 log::debug!("Creating radar '{}' self", radar_id);
@@ -1012,6 +1015,19 @@ impl ActiveSubscriptions {
     }
 }
 
+/// Record a target subscription, keyed by radar id, without duplicating a
+/// pattern the client already asked for.
+fn subscribe_targets(
+    subscriptions: &mut HashMap<String, Vec<String>>,
+    radar_id: &str,
+    pattern: &str,
+) {
+    let patterns = subscriptions.entry(radar_id.to_string()).or_default();
+    if !patterns.iter().any(|p| p == pattern) {
+        patterns.push(pattern.to_string());
+    }
+}
+
 fn extract_path(mut path: &str) -> (&str, &str) {
     if path.starts_with("radars.") {
         path = &path["radars.".len()..];
@@ -1227,6 +1243,53 @@ mod test {
         let patterns = subs.target_subscriptions.get("nav1").unwrap();
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0], "targets.*");
+    }
+
+    /// `radars.*` is how a client asks for everything a radar has, and it is
+    /// what the Signal K plugin subscribes with. It used to register controls
+    /// alone, so targets never reached the Signal K data model at all and the
+    /// only way to see one was to name `.targets.` outright.
+    #[test]
+    fn a_radar_wildcard_covers_targets_as_well_as_controls() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("radars.*")],
+        })
+        .unwrap();
+
+        assert!(subs.is_subscribed_path("radars.nav1.controls.gain", false));
+        assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
+    }
+
+    /// The same asked of one radar rather than all of them.
+    #[test]
+    fn a_single_radar_wildcard_covers_its_targets() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("radars.nav1.*")],
+        })
+        .unwrap();
+
+        assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(
+            !subs.is_subscribed_path("radars.nav2.targets.5", false),
+            "a wildcard under one radar must not reach another"
+        );
+    }
+
+    /// Subscribing to everything has to mean everything: the fan-out seeded
+    /// navigation, notifications and vessels but left targets out, so even `*`
+    /// delivered none.
+    #[test]
+    fn subscribing_to_everything_includes_targets() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("*")],
+        })
+        .unwrap();
+
+        assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(subs.is_subscribed_path("radars.nav1.controls.gain", false));
     }
 
     #[test]

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -1323,6 +1323,42 @@ mod test {
     /// A wildcard subscription has to be as easy to take back as it was to
     /// make: whatever asking for it added, unasking has to remove, or a client
     /// keeps receiving what it just said it no longer wants.
+    /// Overlapping wildcards share one entry rather than each owning their
+    /// own, so taking back the narrower one takes the shared entry with it
+    /// even though the wider one still wants it. Controls have always behaved
+    /// this way; targets match them, deliberately, rather than one half of the
+    /// model composing and the other half not.
+    ///
+    /// Pinned so the day someone makes overlap compose, this test fails and
+    /// says where to look — the fix belongs to controls and targets together.
+    #[test]
+    fn overlapping_wildcards_share_one_subscription() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(Subscription {
+            subscribe: vec![path("*")],
+        })
+        .unwrap();
+        subs.subscribe(Subscription {
+            subscribe: vec![path("radars.*")],
+        })
+        .unwrap();
+
+        subs.desubscribe(Desubscription {
+            desubscribe: vec![path("radars.*")],
+        })
+        .unwrap();
+
+        assert!(!subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(
+            !subs.is_subscribed_path("radars.nav1.controls.gain", false),
+            "controls share the same limitation; targets must not diverge from them"
+        );
+        assert!(
+            subs.is_subscribed_path("navigation.headingTrue", false),
+            "a category the narrower wildcard never named is untouched"
+        );
+    }
+
     #[test]
     fn a_radar_wildcard_can_be_taken_back() {
         let mut subs = ActiveSubscriptions::new(Subscribe::None);


### PR DESCRIPTION
No radar target has ever reached a Signal K server's data model. A client asking for `radars.*` — everything about the radars — was given their controls and nothing else, and a target only ever arrived if the client spelled out `.targets.` itself.

That is exactly how the Signal K plugin subscribes:

```js
subscriptions: [{ path: 'notifications.*' }, { path: 'radars.*' }],
pathPrefixes: ['notifications.', 'radars.'],
```

so it was never sent one to forward, and `radars.{id}.targets.*` simply did not exist on the host server. Reported from the OpenCPN plugin side as "there is no targets subtree in the SK data model", which turned out to be true and to start here.

`*` did not help either. The subscribe-everything fan-out seeded navigation, notifications and vessels, but not targets, so even asking for everything left them out.

## Measured against a HALO24 with targets tracking

| subscription | before | after |
| --- | --- | --- |
| `radars.*` | controls=84, **targets=0** | controls=84, **targets=34** |
| `*` | controls=84, **targets=0** | controls=84, **targets=40** |
| `radars.*.targets.*` | targets=85 | unchanged |

And on the Signal K server on the same box, with no plugin change:

```
before   nav1034A: ['controls']
after    nav1034A: ['controls', 'targets']
```

## Cause

`subscribe` only recorded a target subscription for a path containing `.targets.` (`stream.rs`). `radars.*` reduces to radar `*`, control `*`, which registered a control subscription alone. A radar-scoped wildcard now records the target subscription as well, and the `*` fan-out seeds targets alongside the other categories.

The duplicated insert in the explicit `.targets.` branch moved into the same small helper, so all three routes record a subscription the same way.

## Testing

Three unit tests: `radars.*` reaches controls and targets, `radars.{id}.*` reaches that radar's targets and not another's, and `*` reaches targets. Verified end to end on the radar as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Centralizes target subscription registration with a deduplication helper.
- Includes targets in `radars.*` and global `*` subscriptions.
- Preserves explicit target subscriptions.
- Adds tests for global, all-radar, and single-radar wildcard subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->