### PR TITLE
chore(release): 3.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.8.1"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.8.1"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
## Summary

First release carrying the v3.4.0 Radar API (#467) — the current `:latest` image (v3.8.1) predates it, and `@marineyachtradar/signalk-plugin` 1.5.0 (which defaults to `:latest`) expects the new API shapes, so the pairing is broken until this ships.

Also shipping since v3.8.1: Signal K-conformant request handling and handshake (#537, #543), bulk PUT on /controls (#516), stream fixes (#539, #542, #545, #550), dual-range side-by-side GUI (#479), PPI tour (#531), protocol-based radar identity (#509, #510), HALO sea-clutter auto (#532), and mDNS rename/off (#524).

Version is 3.9.0 (minor, house style) despite the three BREAKING CHANGE footers — the radars list envelope, the lean RadarInfo, and the AIS context/path change — per maintainer decision.

## Tested

- `cargo fmt --check`, `cargo clippy --no-deps --all-targets --features pcap-replay -- -D warnings`, and `cargo test --features pcap-replay` (449 passed) green on the release commit