### PR TITLE
fix(raymarine): warn when the radar is on an unreachable subnet

### DIFF
--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -4,7 +4,7 @@ use tokio::net::UdpSocket;
 
 use super::BaseModel;
 use crate::brand::CommandSender;
-use crate::network::create_multicast_send;
+use crate::network::{self, create_multicast_send};
 use crate::radar::range::Ranges;
 use crate::radar::settings::{ControlValue, SharedControls};
 use crate::radar::{RadarError, RadarInfo};
@@ -68,6 +68,7 @@ impl Command {
                     self.info.send_command_addr,
                     self.info.nic_addr
                 );
+                self.warn_if_command_addr_offlink();
                 self.sock = Some(Arc::new(sock));
 
                 Ok(())
@@ -83,6 +84,44 @@ impl Command {
                 Err(RadarError::Io(e))
             }
         }
+    }
+
+    /// Warn when the radar's command address cannot be reached from the
+    /// interface it was discovered on.
+    ///
+    /// Reports arrive by multicast and are delivered whatever the addressing,
+    /// so the radar looks perfectly healthy — ranges, status and spokes all
+    /// work — while every command silently disappears. RD radomes make this
+    /// routine: they are addressed in 10/8 while a host on the RayNet network
+    /// is given 198.18.x, so the two share a wire but not a subnet, and the
+    /// unicast command leaves via whatever the routing table prefers.
+    ///
+    /// Nothing can be done about it from inside the process — the host needs
+    /// an address or a route on the radar's subnet — so say so plainly rather
+    /// than failing silently.
+    fn warn_if_command_addr_offlink(&self) {
+        let dst = *self.info.send_command_addr.ip();
+        let Some((ifname, netmask)) = network::interface_for(&self.info.nic_addr) else {
+            return;
+        };
+        if !network::is_offlink(&self.info.nic_addr, &netmask, &dst) {
+            return;
+        }
+        log::warn!(
+            "{}: radar command address {} is not on the same subnet as {} on interface '{}'. \
+             Spokes and status will work, but every control will be routed away from the radar \
+             and silently ignored. Give this host an address on the radar's subnet, for example \
+             `ip addr add {}/8 dev {}` with an unused address, or add a route to the radar: \
+             `ip route add {}/32 dev {}`.",
+            self.key,
+            dst,
+            self.info.nic_addr,
+            ifname,
+            dst,
+            ifname,
+            dst,
+            ifname,
+        );
     }
 
     pub async fn send(&mut self, message: &[u8]) -> Result<(), RadarError> {

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -322,6 +322,37 @@ pub(crate) fn match_ipv4(addr: &Ipv4Addr, bcast: &Ipv4Addr, netmask: &Ipv4Addr) 
     r == b
 }
 
+/// True when a unicast destination cannot be reached directly on the wire the
+/// interface `nic`/`netmask` sits on.
+///
+/// Binding a socket to a source address does not pin the outgoing interface:
+/// the kernel routes by destination, so an off-link destination silently
+/// leaves via whichever interface the routing table prefers — usually the
+/// default route, and never the radar. Multicast and broadcast are exempt;
+/// they are delivered on the wire regardless of subnet.
+pub(crate) fn is_offlink(nic: &Ipv4Addr, netmask: &Ipv4Addr, dst: &Ipv4Addr) -> bool {
+    !dst.is_multicast() && !dst.is_broadcast() && !match_ipv4(dst, nic, netmask)
+}
+
+/// Find the name and netmask of the interface carrying `nic_addr`.
+///
+/// `None` when no interface has that address, in which case nothing can be
+/// concluded about reachability.
+pub(crate) fn interface_for(nic_addr: &Ipv4Addr) -> Option<(String, Ipv4Addr)> {
+    use network_interface::{NetworkInterface, NetworkInterfaceConfig};
+
+    for itf in NetworkInterface::show().ok()? {
+        for addr in &itf.addr {
+            if let (IpAddr::V4(ip), Some(IpAddr::V4(mask))) = (addr.ip(), addr.netmask())
+                && ip == *nic_addr
+            {
+                return Some((itf.name.clone(), mask));
+            }
+        }
+    }
+    None
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) use macos::is_wireless_interface;
 #[cfg(target_os = "macos")]
@@ -336,3 +367,40 @@ pub(crate) use linux::spawn_wait_for_ip_addr_change;
 pub(crate) use windows::is_wireless_interface;
 #[cfg(target_os = "windows")]
 pub(crate) use windows::spawn_wait_for_ip_addr_change;
+
+#[cfg(test)]
+mod reachability_tests {
+    use super::is_offlink;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn rd_radar_on_another_subnet_is_offlink() {
+        // Wire-observed: RD radomes are addressed in 10/8 while a host on the
+        // RayNet network gets 198.18.x from the MFD's DHCP server. Commands
+        // are unicast, so they never reach the radar.
+        assert!(is_offlink(
+            &Ipv4Addr::new(198, 18, 1, 200),
+            &Ipv4Addr::new(255, 255, 0, 0),
+            &Ipv4Addr::new(10, 18, 203, 88)
+        ));
+    }
+
+    #[test]
+    fn quantum_on_the_same_subnet_is_reachable() {
+        // A Quantum is addressed in 198.18.x like the host, which is why
+        // Quantum control has always worked.
+        assert!(!is_offlink(
+            &Ipv4Addr::new(198, 18, 7, 45),
+            &Ipv4Addr::new(255, 255, 0, 0),
+            &Ipv4Addr::new(198, 18, 0, 158)
+        ));
+    }
+
+    #[test]
+    fn multicast_and_broadcast_are_never_offlink() {
+        let nic = Ipv4Addr::new(198, 18, 1, 200);
+        let mask = Ipv4Addr::new(255, 255, 0, 0);
+        assert!(!is_offlink(&nic, &mask, &Ipv4Addr::new(232, 1, 1, 1)));
+        assert!(!is_offlink(&nic, &mask, &Ipv4Addr::new(255, 255, 255, 255)));
+    }
+}

--- a/web/gui/help/raymarine.html
+++ b/web/gui/help/raymarine.html
@@ -243,6 +243,42 @@
 
       <h2>Troubleshooting</h2>
 
+      <h3>The picture works but no control does</h3>
+      <p>
+        If the radar paints, the ranges are right and the status updates, but
+        power, gain, sea and range do nothing at all, the radar is almost
+        certainly on a different IP subnet from the machine running Mayara.
+      </p>
+      <p>
+        This is normal on Raymarine networks and it particularly affects the
+        <strong>RD and HD radomes</strong>. Those radars address themselves in
+        the <code>10.x.x.x</code> range, while a chartplotter's DHCP server
+        hands your Mayara machine an address in <code>198.18.x.x</code>. The two
+        share one cable but not one subnet. The chartplotters cope because they
+        give themselves an address in <em>both</em> ranges; an ordinary computer
+        has only the one it was given.
+      </p>
+      <p>
+        The radar's picture and status still arrive, because those are
+        multicast and are delivered whatever the addressing. Controls are sent
+        straight to the radar's own address, so they leave by whichever network
+        connection the machine thinks is the way out — never the radar. Mayara
+        logs a warning naming the two addresses when it spots this.
+      </p>
+      <p>
+        The fix is to give the Mayara machine an address on the radar's subnet
+        as well. Find the radar's address in Mayara's log, then, on Linux:
+      </p>
+      <pre><code># the radar is, say, 10.18.203.88 and your radar network card is eth0
+sudo ip addr add 10.0.0.2/8 dev eth0</code></pre>
+      <p>
+        Pick an address in <code>10.x.x.x</code> that nothing else is using.
+        Adding a route to the radar alone also works:
+        <code>sudo ip route add 10.18.203.88/32 dev eth0</code>. Either way the
+        change is not permanent — put it in your network configuration so it
+        survives a reboot.
+      </p>
+
       <h3>Radar not detected</h3>
       <ul>
         <li>Check the DHCP lease list and confirm the radar actually has an address.</li>


### PR DESCRIPTION
An RD or HD radome paints a picture, reports its ranges and updates its status — but no control does anything at all. Power, gain, sea and range are silently ignored. Two users have now reported exactly this, and nothing in the log said why.

## Cause

RD and HD radomes address themselves in `10/8`, while a host on the RayNet network is given `198.18.x` by the chartplotter's DHCP server. They share a cable but not a subnet. The chartplotters cope because they hold an address in *both* ranges; an ordinary computer holds only the one it was given.

Reports arrive anyway because they are multicast. Commands are unicast to the radar's own address, and binding a socket to a source address does not pin the outgoing interface — the kernel routes by destination, so the datagram leaves via the default route and never reaches the radar. Both `connect()` and `send()` succeed, which is why the failure was completely invisible.

Confirmed across four captures:

| Radar | Address | Host / MFD |
|---|---|---|
| RD418HD (user report) | `10.18.203.88` | `198.18.1.200` |
| RD418HD (`raymarine-rd418hd.pcap.gz`) | `10.3.82.210` | `198.18.3.38` |
| RD418D (`raymarine-rd418d.pcap.gz`) | `10.18.106.155` | — |
| Quantum (`raymarine-quantum.pcap.gz`) | `198.18.0.158` | same subnet |

The Quantum sharing the host's subnet is why Quantum control has always worked and only the magnetron radomes are affected.

## Change

Mayara cannot fix the addressing from inside the process — the host needs an address or a route on the radar's subnet — so it now says so instead of failing silently. On opening the command socket it compares the radar's command address against the netmask of the interface it was discovered on, and for an off-link unicast destination logs a warning naming both addresses, the interface, and the `ip addr add` that resolves it.

The Raymarine setup guide gains a matching **"The picture works but no control does"** troubleshooting section.

Multicast and broadcast destinations are exempt, since those are delivered whatever the addressing. Three unit tests cover the predicate using the real wire addresses above.