### PR TITLE
chore(release): 3.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "mayara"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mayara"
-version = "3.9.0"
+version = "3.10.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Marine radar server with REST API and WebSocket support"


### PR DESCRIPTION
## Summary

Shipping since v3.9.0:

- **Raymarine RD/HD control diagnosis** (#565) — an RD or HD radome painted a picture but ignored every control, with nothing in the log to say why. Those radars address themselves in `10/8` while the host is given `198.18.x`, so commands were routed away from the radar and silently lost. Mayara now detects the mismatch and says exactly what to do about it, and the setup guide documents the fix.
- **Quantum discovery no longer needs `--allow-wifi`** (#561) — a Quantum reaching its chartplotter over WiFi was invisible to a Mayara wired to RayNet unless the flag happened to be set. Both discovery groups are now joined unconditionally.
- **Choose which radar or radars to view** (#529) — with more than one radar the power lozenge opens a radar list, and combined views (consecutive pairs, or all at once) are offered from the overview.
- **Setup guides served by Mayara itself** (#562) — per-brand network setup, a shared radar-networking page, and an explanation of how a Quantum reaches the network, available on the boat with no internet.
- `refactor(api)`: the `dual` and `dualGroup` radar-list fields are gone (#530), replaced by the multi-radar view above.
- Dependency updates (#555, #556, #557, #558).

Version is 3.10.0 (minor, house style) despite the dropped API fields, matching the decision taken for 3.9.0.

## Tested

- `cargo fmt --check` clean
- `cargo clippy --no-deps --all-targets --features pcap-replay -- -D warnings` clean
- `cargo test --features pcap-replay` — 479 passed, 0 failed