### PR TITLE
feat(radar): mark a radar read-only when it cannot be commanded

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -170,7 +170,13 @@ condition holds and `normal` when it clears, and `message` is human-readable.
 has no address on. The radar's picture and status still arrive, because those
 are multicast, but commands are unicast and would be routed away, so mayara
 refuses them and marks the radar's controls `isReadOnly` until the addressing is
-fixed. The message carries the two addresses and the command that resolves it.
+fixed. The message names both addresses and the interface, and suggests how to
+reach the radar — give this host an address in the radar's subnet, or add a host
+route to it.
+
+When this state changes, mayara pushes the affected control definitions again as
+`meta` deltas, so a client that renders controls from `meta` must be prepared for
+those to arrive at any time, not only on connection.
 
 ### Client → Server: Set Control Value
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -138,14 +138,39 @@ The stream opens with a hello carrying `name`, `version`, `roles`, and `self`
 (the own-ship context). On first connection (when `sendCachedValues=true`),
 metadata describing each control is sent in a `meta` array.
 
+**A `meta` array can arrive at any time, not only on connection.** A control's
+definition is not fixed for the life of the stream: mayara marks controls
+`isReadOnly` when it discovers the radar cannot be commanded, and settable
+again when it can, and range and value limits are narrowed once a radar's model
+is known. Clients must apply meta updates as they arrive and re-render
+accordingly — a client that reads the definitions once at connect time will
+show controls that no longer match the radar.
+
 **Subscribable path prefixes:**
 
 | Prefix           | Data                                    | Context   |
 | ---------------- | --------------------------------------- | --------- |
 | `radars.*`       | radar controls and ARPA targets         | own-ship  |
 | `navigation.*`   | own-ship heading, position, COG/SOG     | own-ship  |
-| `notifications.*`| radar alarms (e.g. guard zones)         | own-ship  |
+| `notifications.*`| radar alarms and reachability           | own-ship  |
 | `vessels.*`      | AIS vessels                             | other     |
+
+### Notifications
+
+Notifications follow Signal K conventions: `state` is `alarm` while the
+condition holds and `normal` when it clears, and `message` is human-readable.
+
+| Path                                          | Meaning                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------ |
+| `notifications.radar.{id}.error.{code}`        | A fault **the radar reported about itself**; `code` is the vendor's code  |
+| `notifications.radar.{id}.unreachable`         | The radar cannot be commanded from this host — see below                  |
+| `notifications.radar.{id}.guardZone.{n}`       | A guard zone alarm                                                        |
+
+`unreachable` is raised when a radar's command address is on a subnet this host
+has no address on. The radar's picture and status still arrive, because those
+are multicast, but commands are unicast and would be routed away, so mayara
+refuses them and marks the radar's controls `isReadOnly` until the addressing is
+fixed. The message carries the two addresses and the command that resolves it.
 
 ### Client → Server: Set Control Value
 

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -4,7 +4,7 @@ use tokio::net::UdpSocket;
 
 use super::BaseModel;
 use crate::brand::CommandSender;
-use crate::network::{self, create_multicast_send};
+use crate::network::create_multicast_send;
 use crate::radar::range::Ranges;
 use crate::radar::settings::{ControlValue, SharedControls};
 use crate::radar::{RadarError, RadarInfo};
@@ -68,7 +68,6 @@ impl Command {
                     self.info.send_command_addr,
                     self.info.nic_addr
                 );
-                self.warn_if_command_addr_offlink();
                 self.sock = Some(Arc::new(sock));
 
                 Ok(())
@@ -84,44 +83,6 @@ impl Command {
                 Err(RadarError::Io(e))
             }
         }
-    }
-
-    /// Warn when the radar's command address cannot be reached from the
-    /// interface it was discovered on.
-    ///
-    /// Reports arrive by multicast and are delivered whatever the addressing,
-    /// so the radar looks perfectly healthy — ranges, status and spokes all
-    /// work — while every command silently disappears. RD radomes make this
-    /// routine: they are addressed in 10/8 while a host on the RayNet network
-    /// is given 198.18.x, so the two share a wire but not a subnet, and the
-    /// unicast command leaves via whatever the routing table prefers.
-    ///
-    /// Nothing can be done about it from inside the process — the host needs
-    /// an address or a route on the radar's subnet — so say so plainly rather
-    /// than failing silently.
-    fn warn_if_command_addr_offlink(&self) {
-        let dst = *self.info.send_command_addr.ip();
-        let Some((ifname, netmask)) = network::interface_for(&self.info.nic_addr) else {
-            return;
-        };
-        if !network::is_offlink(&self.info.nic_addr, &netmask, &dst) {
-            return;
-        }
-        log::warn!(
-            "{}: radar command address {} is not on the same subnet as {} on interface '{}'. \
-             Spokes and status will work, but every control will be routed away from the radar \
-             and silently ignored. Give this host an address on the radar's subnet, for example \
-             `ip addr add {}/8 dev {}` with an unused address, or add a route to the radar: \
-             `ip route add {}/32 dev {}`.",
-            self.key,
-            dst,
-            self.info.nic_addr,
-            ifname,
-            dst,
-            ifname,
-            dst,
-            ifname,
-        );
     }
 
     pub async fn send(&mut self, message: &[u8]) -> Result<(), RadarError> {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -664,10 +664,18 @@ pub async fn start_session(
         },
     ));
 
+    let (tx_ip_change, _rx_ip_change) = broadcast::channel(1);
+
     // Decay a radar's power state to Off once it stops sending (issue #432): a
     // powered-off radar goes silent, so without this its GUI icon would hold the
     // last state it reported (standby/transmit) forever.
+    //
+    // The same loop re-checks whether each radar can still be commanded. That
+    // depends on this host's addressing, so it is driven by address changes as
+    // well as by the tick — the tick alone would still catch it, but only after
+    // a delay, and a radar discovered between ticks needs evaluating too.
     let watchdog_radars = radars.clone();
+    let mut watchdog_rx_ip_change = tx_ip_change.subscribe();
     subsystem.start(SubsystemBuilder::new(
         "Radar Watchdog",
         async move |subsys: &mut SubsystemHandle| {
@@ -678,8 +686,13 @@ pub async fn start_session(
                         log::debug!("Radar watchdog shutdown");
                         break;
                     },
+                    _ = watchdog_rx_ip_change.recv() => {
+                        log::debug!("Radar watchdog: address change, re-checking reachability");
+                        watchdog_radars.refresh_command_reachability();
+                    },
                     _ = interval.tick() => {
                         watchdog_radars.mark_silent_radars_off();
+                        watchdog_radars.refresh_command_reachability();
                     }
                 }
             }
@@ -688,8 +701,6 @@ pub async fn start_session(
     ));
 
     let locator = Locator::new(args.clone(), radars.clone());
-
-    let (tx_ip_change, _rx_ip_change) = broadcast::channel(1);
     let mut navdata = navdata::NavigationData::new(args.clone());
 
     let rx_ip_change_clone = tx_ip_change.subscribe();

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -399,7 +399,6 @@ mod reachability_tests {
     use super::can_reach;
     use std::net::{Ipv4Addr, SocketAddrV4};
 
-    /// A destination on the same interface as the source is reachable.
     /// Loopback is the only pair guaranteed to exist wherever the tests run.
     #[test]
     fn a_destination_on_our_own_interface_is_reachable() {

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -322,16 +322,42 @@ pub(crate) fn match_ipv4(addr: &Ipv4Addr, bcast: &Ipv4Addr, netmask: &Ipv4Addr) 
     r == b
 }
 
-/// True when a unicast destination cannot be reached directly on the wire the
-/// interface `nic`/`netmask` sits on.
+/// Whether a unicast command sent to `dst` would actually leave by the
+/// interface the radar was discovered on.
 ///
 /// Binding a socket to a source address does not pin the outgoing interface:
-/// the kernel routes by destination, so an off-link destination silently
-/// leaves via whichever interface the routing table prefers — usually the
-/// default route, and never the radar. Multicast and broadcast are exempt;
-/// they are delivered on the wire regardless of subnet.
-pub(crate) fn is_offlink(nic: &Ipv4Addr, netmask: &Ipv4Addr, dst: &Ipv4Addr) -> bool {
-    !dst.is_multicast() && !dst.is_broadcast() && !match_ipv4(dst, nic, netmask)
+/// the kernel routes by destination, so a destination the routing table does
+/// not send that way leaves via whichever interface it prefers — usually the
+/// default route, and never the radar.
+///
+/// The kernel is asked rather than the netmask compared, because the two
+/// answers differ exactly where it matters. A user who fixes this by adding an
+/// address in the radar's range, or a host route to the radar, changes the
+/// routing table but not the address mayara discovered the radar on; comparing
+/// subnets would keep calling the radar unreachable after the problem is
+/// solved. Connecting a UDP socket performs the route lookup and sends
+/// nothing.
+///
+/// `None` when nothing can be concluded — the interface went away, or the
+/// source address the kernel picked belongs to no interface we can see.
+pub(crate) fn can_reach(nic_addr: &Ipv4Addr, dst: &SocketAddrV4) -> Option<bool> {
+    let (ifname, _) = interface_for(nic_addr)?;
+
+    let probe = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+    if probe.connect(*dst).is_err() {
+        // No route at all to that destination.
+        return Some(false);
+    }
+    let SocketAddr::V4(local) = probe.local_addr().ok()? else {
+        return None;
+    };
+
+    // The source address the kernel chose identifies the interface it would
+    // send from. If that is not the radar's interface, the command would go
+    // out of the wrong one and be lost.
+    let (chosen, _) = interface_for(local.ip())?;
+
+    Some(chosen == ifname)
 }
 
 /// Find the name and netmask of the interface carrying `nic_addr`.
@@ -370,37 +396,47 @@ pub(crate) use windows::spawn_wait_for_ip_addr_change;
 
 #[cfg(test)]
 mod reachability_tests {
-    use super::is_offlink;
-    use std::net::Ipv4Addr;
+    use super::can_reach;
+    use std::net::{Ipv4Addr, SocketAddrV4};
 
+    /// A destination on the same interface as the source is reachable.
+    /// Loopback is the only pair guaranteed to exist wherever the tests run.
     #[test]
-    fn rd_radar_on_another_subnet_is_offlink() {
-        // Wire-observed: RD radomes are addressed in 10/8 while a host on the
-        // RayNet network gets 198.18.x from the MFD's DHCP server. Commands
-        // are unicast, so they never reach the radar.
-        assert!(is_offlink(
-            &Ipv4Addr::new(198, 18, 1, 200),
-            &Ipv4Addr::new(255, 255, 0, 0),
-            &Ipv4Addr::new(10, 18, 203, 88)
-        ));
+    fn a_destination_on_our_own_interface_is_reachable() {
+        assert_eq!(
+            can_reach(
+                &Ipv4Addr::LOCALHOST,
+                &SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2573)
+            ),
+            Some(true)
+        );
     }
 
+    /// The case this exists for: the radar is not on the interface it was
+    /// discovered on, so the command would leave by the default route (or by
+    /// nothing at all) and never arrive. Either way it is not reachable
+    /// *from loopback*, which is what is being asked.
     #[test]
-    fn quantum_on_the_same_subnet_is_reachable() {
-        // A Quantum is addressed in 198.18.x like the host, which is why
-        // Quantum control has always worked.
-        assert!(!is_offlink(
-            &Ipv4Addr::new(198, 18, 7, 45),
-            &Ipv4Addr::new(255, 255, 0, 0),
-            &Ipv4Addr::new(198, 18, 0, 158)
-        ));
+    fn a_destination_reached_by_another_interface_is_not() {
+        assert_eq!(
+            can_reach(
+                &Ipv4Addr::LOCALHOST,
+                &SocketAddrV4::new(Ipv4Addr::new(198, 18, 1, 200), 2573)
+            ),
+            Some(false)
+        );
     }
 
+    /// Nothing can be said when we do not hold the address the radar was
+    /// found on, so the caller must not act.
     #[test]
-    fn multicast_and_broadcast_are_never_offlink() {
-        let nic = Ipv4Addr::new(198, 18, 1, 200);
-        let mask = Ipv4Addr::new(255, 255, 0, 0);
-        assert!(!is_offlink(&nic, &mask, &Ipv4Addr::new(232, 1, 1, 1)));
-        assert!(!is_offlink(&nic, &mask, &Ipv4Addr::new(255, 255, 255, 255)));
+    fn an_address_we_do_not_hold_concludes_nothing() {
+        assert_eq!(
+            can_reach(
+                &Ipv4Addr::new(192, 0, 2, 1),
+                &SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 2), 2573)
+            ),
+            None
+        );
     }
 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -85,6 +85,11 @@ pub enum RadarError {
     Timeout,
     #[error("Shutdown")]
     Shutdown,
+    #[error(
+        "Radar at {0} cannot be reached from {1}: it is on a different subnet, so controls are unavailable. \
+         Give this host an address on the radar's subnet."
+    )]
+    CannotReachRadar(std::net::Ipv4Addr, std::net::Ipv4Addr),
     #[error("No such control '{0}'")]
     InvalidControlId(String),
     #[error("{0}")]
@@ -951,6 +956,56 @@ impl SharedRadars {
             > 0
     }
 
+    /// Re-evaluate, for every known radar, whether its command address can be
+    /// reached from the interface it was discovered on.
+    ///
+    /// Binding a socket to a source address does not pin the outgoing
+    /// interface — the kernel routes by destination — so a radar addressed on
+    /// a subnet this host has no address on receives none of our commands
+    /// while its multicast picture and status arrive perfectly. Raymarine RD
+    /// and HD radomes make this routine: they address themselves in 10/8 while
+    /// a host on the RayNet network is given 198.18.x by the chartplotter.
+    ///
+    /// Cheap to call repeatedly: [`SharedControls::set_command_reachable`]
+    /// only acts on a change of state, so this is driven both by the radar
+    /// watchdog and by address-change events.
+    pub(crate) fn refresh_command_reachability(&self) {
+        let infos: Vec<RadarInfo> = {
+            let radars = self.radars.read().unwrap();
+            radars.info.values().cloned().collect()
+        };
+
+        for info in infos {
+            let dst = *info.send_command_addr.ip();
+            // Multicast and broadcast reach the wire whatever the addressing.
+            if dst.is_multicast() || dst.is_broadcast() {
+                continue;
+            }
+            let Some((ifname, netmask)) = crate::network::interface_for(&info.nic_addr) else {
+                // The interface went away; say nothing rather than guess.
+                continue;
+            };
+            let offlink = crate::network::is_offlink(&info.nic_addr, &netmask, &dst);
+            let reason = format!(
+                "radar address {} is not on the same subnet as {} on interface '{}'. \
+                 Give this host an address on the radar's subnet, for example \
+                 `ip addr add {}/8 dev {}` with an unused address, or add a route: \
+                 `ip route add {}/32 dev {}`",
+                dst, info.nic_addr, ifname, dst, ifname, dst, ifname
+            );
+            if info.controls.set_command_reachable(!offlink, &reason) {
+                if offlink {
+                    log::warn!("{}: controls disabled: {}", info.key(), reason);
+                } else {
+                    log::info!(
+                        "{}: radar is reachable again; controls restored",
+                        info.key()
+                    );
+                }
+            }
+        }
+    }
+
     /// A radar is considered powered off once no packet has been received from
     /// it for this long. A standby radar still emits periodic status reports, so
     /// only a genuinely silent (powered-off or disconnected) radar decays to
@@ -1788,6 +1843,21 @@ impl CommonRadar {
                 };
             }
             ControlDestination::Command => {
+                // A radar we cannot reach swallows commands silently: the
+                // datagram is routed away and both connect() and send()
+                // succeed. Refuse the set instead, so the client is told why
+                // rather than watching the control snap back.
+                if !self.info.controls.command_reachable() {
+                    let e = RadarError::CannotReachRadar(
+                        *self.info.send_command_addr.ip(),
+                        self.info.nic_addr,
+                    );
+                    return self
+                        .info
+                        .controls
+                        .send_error_to_client(reply_tx, &cv, &e)
+                        .await;
+                }
                 if let Some(command_sender) = command_sender {
                     if let Err(e) = command_sender.set_control(&cv, &self.info.controls).await {
                         return self

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -986,12 +986,16 @@ impl SharedRadars {
                 continue;
             };
             let offlink = crate::network::is_offlink(&info.nic_addr, &netmask, &dst);
+            // Never name a concrete address to configure: the only address
+            // known here is the radar's own, and telling the user to assign
+            // that to the host would collide with the radar. The prefix length
+            // is unknown too. A host route to the radar is safe to suggest
+            // because it names the radar as a destination, not as our address.
             let reason = format!(
                 "radar address {} is not on the same subnet as {} on interface '{}'. \
-                 Give this host an address on the radar's subnet, for example \
-                 `ip addr add {}/8 dev {}` with an unused address, or add a route: \
-                 `ip route add {}/32 dev {}`",
-                dst, info.nic_addr, ifname, dst, ifname, dst, ifname
+                 Give this host an unused address in the radar's subnet, or add a \
+                 route to it: `ip route add {}/32 dev {}`",
+                dst, info.nic_addr, ifname, dst, ifname
             );
             if info.controls.set_command_reachable(!offlink, &reason) {
                 if offlink {
@@ -1777,8 +1781,14 @@ impl CommonRadar {
                 match cv.id {
                     ControlId::GuardZone1 | ControlId::GuardZone2 => {
                         self.update();
-                        // Send to hardware if the brand supports it (e.g. Furuno)
-                        if let Some(command_sender) = command_sender {
+                        // Send to hardware if the brand supports it (e.g. Furuno).
+                        // Mayara evaluates the zone itself either way, so an
+                        // unreachable radar keeps a working guard zone; only the
+                        // optional hardware copy is skipped.
+                        if let Some(command_sender) = command_sender
+                            .as_mut()
+                            .filter(|_| self.info.controls.command_reachable())
+                        {
                             match command_sender.set_control(&cv, &self.info.controls).await {
                                 Ok(()) => {}
                                 Err(RadarError::CannotSetControlId(_)) => {}

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -981,24 +981,29 @@ impl SharedRadars {
             if dst.is_multicast() || dst.is_broadcast() {
                 continue;
             }
-            let Some((ifname, netmask)) = crate::network::interface_for(&info.nic_addr) else {
-                // The interface went away; say nothing rather than guess.
+            let Some(reachable) =
+                crate::network::can_reach(&info.nic_addr, &info.send_command_addr)
+            else {
+                // The interface went away, or the route leads somewhere we
+                // cannot identify; say nothing rather than guess.
                 continue;
             };
-            let offlink = crate::network::is_offlink(&info.nic_addr, &netmask, &dst);
+            let ifname = crate::network::interface_for(&info.nic_addr)
+                .map(|(name, _)| name)
+                .unwrap_or_else(|| "the radar interface".to_string());
             // Never name a concrete address to configure: the only address
             // known here is the radar's own, and telling the user to assign
             // that to the host would collide with the radar. The prefix length
             // is unknown too. A host route to the radar is safe to suggest
             // because it names the radar as a destination, not as our address.
             let reason = format!(
-                "radar address {} is not on the same subnet as {} on interface '{}'. \
+                "radar address {} cannot be reached from {} on interface '{}'. \
                  Give this host an unused address in the radar's subnet, or add a \
                  route to it: `ip route add {}/32 dev {}`",
                 dst, info.nic_addr, ifname, dst, ifname
             );
-            if info.controls.set_command_reachable(!offlink, &reason) {
-                if offlink {
+            if info.controls.set_command_reachable(reachable, &reason) {
+                if !reachable {
                     log::warn!("{}: controls disabled: {}", info.key(), reason);
                 } else {
                     log::info!(

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -3688,7 +3688,7 @@ pub struct ControlDefinition {
     /// Read-only for a reason that will not change while mayara runs: the
     /// control is informational, or this is a replay. A radar that cannot
     /// currently be commanded also reads as read-only to clients, but that is
-    /// derived at egress rather than stored here — see `effective_read_only`.
+    /// derived at egress rather than stored here — see [`effective`].
     #[serde(skip_serializing_if = "is_false")]
     is_read_only: bool,
     #[serde(skip)]

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -615,38 +615,25 @@ pub struct Controls {
     command_reachable: bool,
 }
 
-/// Whether a control must appear read-only to clients: because it always is,
-/// because this is a replay, or because the radar cannot currently be commanded
-/// and this control would be sent to it.
+/// A copy of `control` as clients should see it: read-only if it is stored that
+/// way, or if it would be sent to a radar that cannot currently be commanded.
 ///
-/// The single place that decides, so insertion, redefinition and reachability
-/// transitions cannot drift apart.
-fn effective_read_only(
-    replay: bool,
-    command_reachable: bool,
-    control_id: ControlId,
-    item: &ControlDefinition,
-) -> bool {
-    item.intrinsic_read_only
-        || replay
-        || (!command_reachable && control_id.get_destination() == ControlDestination::Command)
+/// Derived on the way out rather than written into the control, so a radar
+/// going unreachable and coming back cannot leave a stale flag behind.
+fn effective(command_reachable: bool, control: &Control) -> Control {
+    let mut control = control.clone();
+    control.item.is_read_only |= !command_reachable
+        && control.item.control_id.get_destination() == ControlDestination::Command;
+
+    control
 }
 
 impl Controls {
     fn insert(&mut self, control_id: ControlId, value: Control) {
-        let item = ControlDefinition {
-            intrinsic_read_only: value.item.intrinsic_read_only || value.item.is_read_only,
-            ..value.item
-        };
         let v = Control {
             item: ControlDefinition {
-                is_read_only: effective_read_only(
-                    self.replay,
-                    self.command_reachable,
-                    control_id,
-                    &item,
-                ),
-                ..item
+                is_read_only: self.replay || value.item.is_read_only,
+                ..value.item
             },
             ..value
         };
@@ -847,9 +834,8 @@ impl SharedControls {
 
     pub(crate) fn add(&mut self, control_builder: ControlBuilder) {
         let (id, control) = control_builder.take();
-        // Via Controls::insert, so a control added while the radar is in
-        // replay or cannot be commanded is born read-only rather than
-        // appearing settable until the next transition.
+        // Via Controls::insert, so a control added after startup is subject to
+        // the same read-only rules as one added during it.
         self.controls.write().unwrap().insert(id, control);
     }
 
@@ -860,15 +846,10 @@ impl SharedControls {
     pub(crate) fn update_definition(&mut self, control_builder: ControlBuilder) {
         let (id, new_control) = control_builder.take();
         let mut locked = self.controls.write().unwrap();
-        let (replay, reachable) = (locked.replay, locked.command_reachable);
         if let Some(existing) = locked.controls.get_mut(&id) {
-            let was_intrinsic = existing.item.intrinsic_read_only;
+            let was_read_only = existing.item.is_read_only;
             existing.item = new_control.item;
-            // Carry the intrinsic flag across a redefinition, but recompute
-            // what clients see — ORing the old *effective* flag would make
-            // "unreachable" stick forever once a brand redefines a control.
-            existing.item.intrinsic_read_only |= was_intrinsic;
-            existing.item.is_read_only = effective_read_only(replay, reachable, id, &existing.item);
+            existing.item.is_read_only |= was_read_only;
         } else {
             locked.insert(id, new_control);
         }
@@ -882,8 +863,13 @@ impl SharedControls {
 
     pub fn get_controls(&self) -> HashMap<ControlId, Control> {
         let locked = self.controls.read().unwrap();
+        let reachable = locked.command_reachable;
 
-        locked.controls.clone()
+        locked
+            .controls
+            .iter()
+            .map(|(id, control)| (*id, effective(reachable, control)))
+            .collect()
     }
 
     pub(crate) fn new_client_subscription(&self) -> tokio::sync::broadcast::Receiver<ControlValue> {
@@ -1209,7 +1195,10 @@ impl SharedControls {
                 .controls
                 .get(&ControlId::Range)
                 .expect("Range should always be set");
-            sk_delta.add_meta_for_control(&locked.radar_id, range_control);
+            sk_delta.add_meta_for_control(
+                &locked.radar_id,
+                &effective(locked.command_reachable, range_control),
+            );
             log::debug!("meta: {:?}", sk_delta);
         }
         sk_delta.add_updates(vec![radar_control_value]);
@@ -1296,22 +1285,12 @@ impl SharedControls {
 
             // Controls handled inside mayara (trails, targets, guard zones)
             // keep working and stay settable; only those that end up as a
-            // datagram to the radar become read-only.
-            let ids: Vec<ControlId> = locked
-                .controls
-                .keys()
-                .copied()
-                .filter(|id| id.get_destination() == ControlDestination::Command)
-                .collect();
-            let replay = locked.replay;
-            for id in ids {
-                if let Some(control) = locked.controls.get_mut(&id) {
-                    let want = effective_read_only(replay, reachable, id, &control.item);
-                    if control.item.is_read_only == want {
-                        continue;
-                    }
-                    control.item.is_read_only = want;
-                    delta.add_meta_for_control(&radar_id, &control.clone());
+            // datagram to the radar read differently now. Ones that are stored
+            // read-only anyway did not change, so clients need not hear of them.
+            for (id, control) in locked.controls.iter() {
+                if id.get_destination() == ControlDestination::Command && !control.item.is_read_only
+                {
+                    delta.add_meta_for_control(&radar_id, &effective(reachable, control));
                 }
             }
         }
@@ -2586,7 +2565,6 @@ pub(crate) struct ControlBuilder {
 impl ControlBuilder {
     pub(crate) fn read_only(mut self, is_read_only: bool) -> Self {
         self.control.item.is_read_only = is_read_only;
-        self.control.item.intrinsic_read_only = is_read_only;
 
         self
     }
@@ -3707,15 +3685,12 @@ pub struct ControlDefinition {
     pub(crate) descriptions: Option<HashMap<i32, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) valid_values: Option<Vec<i32>>,
-    /// What clients see: the control cannot be set right now.
+    /// Read-only for a reason that will not change while mayara runs: the
+    /// control is informational, or this is a replay. A radar that cannot
+    /// currently be commanded also reads as read-only to clients, but that is
+    /// derived at egress rather than stored here — see `effective_read_only`.
     #[serde(skip_serializing_if = "is_false")]
     is_read_only: bool,
-    /// Whether the control is read-only by its own nature, as opposed to
-    /// because of a condition that can lift — replay, or a radar that cannot
-    /// currently be commanded. Kept separately so recovering from such a
-    /// condition cannot make an intrinsically read-only control settable.
-    #[serde(skip)]
-    intrinsic_read_only: bool,
     #[serde(skip)]
     is_send_always: bool, // Whether the controlvalue is sent out to client in all state messages
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3774,7 +3749,6 @@ impl ControlDefinition {
             descriptions,
             valid_values,
             is_read_only,
-            intrinsic_read_only: is_read_only,
             is_send_always,
             max_distance: None,
         }

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -3967,6 +3967,7 @@ mod test {
         assert!(controls.set_command_reachable(false, "on another subnet"));
         let delta = sent_delta(&mut sk_rx);
         assert!(delta.contains("notifications.radar.test.unreachable"));
+        assert!(delta.contains(r#""state":"alarm""#));
         assert!(delta.contains("on another subnet"));
         assert!(delta.contains(&format!("radars.test.controls.{}", ControlId::Range)));
         assert!(
@@ -3978,9 +3979,12 @@ mod test {
         assert!(!controls.set_command_reachable(false, "on another subnet"));
         assert!(sk_rx.try_recv().is_err());
 
+        // Clearing is the same path at state `normal` — that is how Signal K
+        // retracts a notification, so the path alone proves nothing here.
         assert!(controls.set_command_reachable(true, ""));
         let delta = sent_delta(&mut sk_rx);
         assert!(delta.contains("notifications.radar.test.unreachable"));
+        assert!(delta.contains(r#""state":"normal""#));
         assert!(delta.contains(&format!("radars.test.controls.{}", ControlId::Range)));
         assert!(sk_rx.try_recv().is_err());
 

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -21,7 +21,7 @@ use super::range::Range;
 use super::units::Units;
 use crate::Cli;
 use crate::config::GuardZone;
-use crate::stream::SignalKDelta;
+use crate::stream::{NotificationMethod, NotificationState, NotificationValue, SignalKDelta};
 use crate::{
     TargetMode,
     radar::{Power, RadarError, range::Ranges},
@@ -607,6 +607,12 @@ pub struct Controls {
     sk_client_tx: tokio::sync::broadcast::Sender<SignalKDelta>,
     #[serde(skip)]
     control_update_tx: tokio::sync::broadcast::Sender<ControlUpdate>,
+
+    /// False when this radar's command address cannot be reached from the
+    /// interface it was discovered on. Its controls are then marked read-only
+    /// and sets are refused rather than sent into the void.
+    #[serde(skip)]
+    command_reachable: bool,
 }
 
 impl Controls {
@@ -711,6 +717,7 @@ impl Controls {
             all_clients_tx,
             sk_client_tx,
             control_update_tx,
+            command_reachable: true,
         }
     }
 }
@@ -1194,8 +1201,6 @@ impl SharedControls {
         name: Option<&str>,
         active: bool,
     ) {
-        use crate::stream::{NotificationMethod, NotificationState, NotificationValue};
-
         let locked = self.controls.read().unwrap();
         let path = format!("notifications.radar.{}.error.{:#x}", locked.radar_id, code);
         let (state, method, message) = if active {
@@ -1225,6 +1230,85 @@ impl SharedControls {
         if let Err(e) = locked.sk_client_tx.send(delta) {
             log::trace!("Failed to broadcast radar error notification: {}", e);
         }
+    }
+
+    /// True while this radar's command address is reachable from the interface
+    /// it was discovered on.
+    pub(crate) fn command_reachable(&self) -> bool {
+        self.controls.read().unwrap().command_reachable
+    }
+
+    /// Record whether the radar can be commanded, and make that visible.
+    ///
+    /// A radar on a subnet this host has no address on still delivers its
+    /// picture and status, because those are multicast — only the unicast
+    /// commands are lost, silently, which makes the radar look healthy and
+    /// broken at the same time. When that is detected every control that would
+    /// be sent to the radar is marked read-only, updated definitions are
+    /// pushed as Signal K meta deltas, and a notification carries the reason.
+    /// All of it is undone when the radar becomes reachable again.
+    ///
+    /// Returns true when the state changed.
+    pub(crate) fn set_command_reachable(&self, reachable: bool, reason: &str) -> bool {
+        let mut delta = SignalKDelta::new();
+        let radar_id;
+        {
+            let mut locked = self.controls.write().unwrap();
+            if locked.command_reachable == reachable {
+                return false;
+            }
+            locked.command_reachable = reachable;
+            radar_id = locked.radar_id.clone();
+
+            // Controls handled inside mayara (trails, targets, guard zones)
+            // keep working and stay settable; only those that end up as a
+            // datagram to the radar become read-only.
+            let ids: Vec<ControlId> = locked
+                .controls
+                .keys()
+                .copied()
+                .filter(|id| id.get_destination() == ControlDestination::Command)
+                .collect();
+            for id in ids {
+                if let Some(control) = locked.controls.get_mut(&id) {
+                    if control.item.is_read_only == !reachable {
+                        continue;
+                    }
+                    control.item.is_read_only = !reachable;
+                    delta.add_meta_for_control(&radar_id, &control.clone());
+                }
+            }
+        }
+
+        let path = format!("notifications.radar.{}.unreachable", radar_id);
+        let (state, method, message) = if reachable {
+            (
+                NotificationState::Normal,
+                Vec::new(),
+                "Radar is reachable again; controls restored".to_string(),
+            )
+        } else {
+            (
+                NotificationState::Alarm,
+                vec![NotificationMethod::Visual],
+                format!("Radar cannot be controlled: {}", reason),
+            )
+        };
+        delta.add_notification_update(
+            &path,
+            NotificationValue {
+                state,
+                method,
+                message,
+            },
+            "mayara",
+        );
+
+        let locked = self.controls.read().unwrap();
+        if let Err(e) = locked.sk_client_tx.send(delta) {
+            log::trace!("Failed to broadcast reachability change: {}", e);
+        }
+        true
     }
 
     pub async fn send_reply_to_client(
@@ -3804,6 +3888,44 @@ mod test {
         // A control with no automatic mode reports no flag at all.
         let (_, range) = new_numeric(ControlId::Range, 0., 100_000.).take();
         assert_eq!(range.reported_auto(), None);
+    }
+
+    /// A radar that cannot be commanded must say so rather than accept sets
+    /// that go nowhere: the controls it would send to the radar become
+    /// read-only, and the ones mayara handles itself keep working.
+    #[test]
+    fn unreachable_radar_marks_only_command_controls_read_only() {
+        let controls = test_controls();
+        assert!(controls.command_reachable());
+
+        assert!(controls.set_command_reachable(false, "on another subnet"));
+        assert!(!controls.command_reachable());
+
+        let all = controls.get_controls();
+        let read_only = |id: &ControlId| all.get(id).map(|c| c.item().is_read_only);
+        // Range is sent to the radar; a guard zone is evaluated inside mayara.
+        assert_eq!(read_only(&ControlId::Range), Some(true));
+        assert_eq!(read_only(&ControlId::GuardZone1), Some(false));
+    }
+
+    /// The sweep that drives this runs on every watchdog tick, so repeating a
+    /// state must be free of side effects — no meta storm, no notification
+    /// storm.
+    #[test]
+    fn reachability_only_reports_transitions() {
+        let controls = test_controls();
+        assert!(!controls.set_command_reachable(true, ""));
+        assert!(controls.set_command_reachable(false, "gone"));
+        assert!(!controls.set_command_reachable(false, "gone"));
+        assert!(controls.set_command_reachable(true, ""));
+        assert_eq!(
+            controls
+                .get_controls()
+                .get(&ControlId::Range)
+                .map(|c| c.item().is_read_only),
+            Some(false),
+            "controls must become settable again when the radar comes back"
+        );
     }
 
     fn test_controls() -> SharedControls {

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -615,12 +615,38 @@ pub struct Controls {
     command_reachable: bool,
 }
 
+/// Whether a control must appear read-only to clients: because it always is,
+/// because this is a replay, or because the radar cannot currently be commanded
+/// and this control would be sent to it.
+///
+/// The single place that decides, so insertion, redefinition and reachability
+/// transitions cannot drift apart.
+fn effective_read_only(
+    replay: bool,
+    command_reachable: bool,
+    control_id: ControlId,
+    item: &ControlDefinition,
+) -> bool {
+    item.intrinsic_read_only
+        || replay
+        || (!command_reachable && control_id.get_destination() == ControlDestination::Command)
+}
+
 impl Controls {
     fn insert(&mut self, control_id: ControlId, value: Control) {
+        let item = ControlDefinition {
+            intrinsic_read_only: value.item.intrinsic_read_only || value.item.is_read_only,
+            ..value.item
+        };
         let v = Control {
             item: ControlDefinition {
-                is_read_only: self.replay || value.item.is_read_only,
-                ..value.item
+                is_read_only: effective_read_only(
+                    self.replay,
+                    self.command_reachable,
+                    control_id,
+                    &item,
+                ),
+                ..item
             },
             ..value
         };
@@ -821,7 +847,10 @@ impl SharedControls {
 
     pub(crate) fn add(&mut self, control_builder: ControlBuilder) {
         let (id, control) = control_builder.take();
-        self.controls.write().unwrap().controls.insert(id, control);
+        // Via Controls::insert, so a control added while the radar is in
+        // replay or cannot be commanded is born read-only rather than
+        // appearing settable until the next transition.
+        self.controls.write().unwrap().insert(id, control);
     }
 
     /// Replace a control's definition (auto flags, min/max, etc.) while
@@ -831,12 +860,17 @@ impl SharedControls {
     pub(crate) fn update_definition(&mut self, control_builder: ControlBuilder) {
         let (id, new_control) = control_builder.take();
         let mut locked = self.controls.write().unwrap();
+        let (replay, reachable) = (locked.replay, locked.command_reachable);
         if let Some(existing) = locked.controls.get_mut(&id) {
-            let was_read_only = existing.item.is_read_only;
+            let was_intrinsic = existing.item.intrinsic_read_only;
             existing.item = new_control.item;
-            existing.item.is_read_only |= was_read_only;
+            // Carry the intrinsic flag across a redefinition, but recompute
+            // what clients see — ORing the old *effective* flag would make
+            // "unreachable" stick forever once a brand redefines a control.
+            existing.item.intrinsic_read_only |= was_intrinsic;
+            existing.item.is_read_only = effective_read_only(replay, reachable, id, &existing.item);
         } else {
-            locked.controls.insert(id, new_control);
+            locked.insert(id, new_control);
         }
     }
 
@@ -1269,12 +1303,14 @@ impl SharedControls {
                 .copied()
                 .filter(|id| id.get_destination() == ControlDestination::Command)
                 .collect();
+            let replay = locked.replay;
             for id in ids {
                 if let Some(control) = locked.controls.get_mut(&id) {
-                    if control.item.is_read_only == !reachable {
+                    let want = effective_read_only(replay, reachable, id, &control.item);
+                    if control.item.is_read_only == want {
                         continue;
                     }
-                    control.item.is_read_only = !reachable;
+                    control.item.is_read_only = want;
                     delta.add_meta_for_control(&radar_id, &control.clone());
                 }
             }
@@ -2550,6 +2586,7 @@ pub(crate) struct ControlBuilder {
 impl ControlBuilder {
     pub(crate) fn read_only(mut self, is_read_only: bool) -> Self {
         self.control.item.is_read_only = is_read_only;
+        self.control.item.intrinsic_read_only = is_read_only;
 
         self
     }
@@ -3670,8 +3707,15 @@ pub struct ControlDefinition {
     pub(crate) descriptions: Option<HashMap<i32, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) valid_values: Option<Vec<i32>>,
+    /// What clients see: the control cannot be set right now.
     #[serde(skip_serializing_if = "is_false")]
     is_read_only: bool,
+    /// Whether the control is read-only by its own nature, as opposed to
+    /// because of a condition that can lift — replay, or a radar that cannot
+    /// currently be commanded. Kept separately so recovering from such a
+    /// condition cannot make an intrinsically read-only control settable.
+    #[serde(skip)]
+    intrinsic_read_only: bool,
     #[serde(skip)]
     is_send_always: bool, // Whether the controlvalue is sent out to client in all state messages
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3730,6 +3774,7 @@ impl ControlDefinition {
             descriptions,
             valid_values,
             is_read_only,
+            intrinsic_read_only: is_read_only,
             is_send_always,
             max_distance: None,
         }
@@ -3910,14 +3955,35 @@ mod test {
 
     /// The sweep that drives this runs on every watchdog tick, so repeating a
     /// state must be free of side effects — no meta storm, no notification
-    /// storm.
+    /// storm — while every real transition must reach clients exactly once.
     #[test]
     fn reachability_only_reports_transitions() {
-        let controls = test_controls();
+        let (controls, mut sk_rx) = test_controls_with_deltas();
+
+        // Already reachable: nothing changed, nothing sent.
         assert!(!controls.set_command_reachable(true, ""));
-        assert!(controls.set_command_reachable(false, "gone"));
-        assert!(!controls.set_command_reachable(false, "gone"));
+        assert!(sk_rx.try_recv().is_err());
+
+        assert!(controls.set_command_reachable(false, "on another subnet"));
+        let delta = sent_delta(&mut sk_rx);
+        assert!(delta.contains("notifications.radar.test.unreachable"));
+        assert!(delta.contains("on another subnet"));
+        assert!(delta.contains(&format!("radars.test.controls.{}", ControlId::Range)));
+        assert!(
+            sk_rx.try_recv().is_err(),
+            "a transition is a single delta, not one per control"
+        );
+
+        // Repeating the state says nothing at all.
+        assert!(!controls.set_command_reachable(false, "on another subnet"));
+        assert!(sk_rx.try_recv().is_err());
+
         assert!(controls.set_command_reachable(true, ""));
+        let delta = sent_delta(&mut sk_rx);
+        assert!(delta.contains("notifications.radar.test.unreachable"));
+        assert!(delta.contains(&format!("radars.test.controls.{}", ControlId::Range)));
+        assert!(sk_rx.try_recv().is_err());
+
         assert_eq!(
             controls
                 .get_controls()
@@ -3928,14 +3994,66 @@ mod test {
         );
     }
 
+    /// A control that is read-only by its own nature must stay read-only when
+    /// the radar comes back: recovery lifts only what unreachability imposed.
+    #[test]
+    fn recovery_keeps_intrinsically_read_only_controls_read_only() {
+        let (mut controls, _sk_rx) = test_controls_with_deltas();
+        controls.update_definition(new_numeric(ControlId::Range, 0., 100_000.).read_only(true));
+
+        let read_only = |controls: &SharedControls| {
+            controls
+                .get_controls()
+                .get(&ControlId::Range)
+                .map(|c| c.item().is_read_only)
+        };
+        assert_eq!(read_only(&controls), Some(true));
+
+        controls.set_command_reachable(false, "on another subnet");
+        assert_eq!(read_only(&controls), Some(true));
+        controls.set_command_reachable(true, "");
+        assert_eq!(read_only(&controls), Some(true));
+    }
+
+    /// A control that turns up while the radar cannot be commanded must be
+    /// born read-only, rather than looking settable until the next transition.
+    #[test]
+    fn controls_added_while_unreachable_are_read_only() {
+        let (mut controls, _sk_rx) = test_controls_with_deltas();
+        controls.set_command_reachable(false, "on another subnet");
+
+        controls.add(new_numeric(ControlId::Rain, 0., 100.));
+        assert_eq!(
+            controls
+                .get_controls()
+                .get(&ControlId::Rain)
+                .map(|c| c.item().is_read_only),
+            Some(true)
+        );
+    }
+
+    /// What a client would have received, as JSON — the delta's own fields are
+    /// private, and the wire form is what these tests are about anyway.
+    fn sent_delta(sk_rx: &mut tokio::sync::broadcast::Receiver<SignalKDelta>) -> String {
+        serde_json::to_string(&sk_rx.try_recv().expect("a delta was sent")).unwrap()
+    }
+
     fn test_controls() -> SharedControls {
-        let (sk_tx, _sk_rx) = tokio::sync::broadcast::channel(16);
-        SharedControls::new(
+        test_controls_with_deltas().0
+    }
+
+    fn test_controls_with_deltas() -> (
+        SharedControls,
+        tokio::sync::broadcast::Receiver<SignalKDelta>,
+    ) {
+        let (sk_tx, sk_rx) = tokio::sync::broadcast::channel(16);
+        let controls = SharedControls::new(
             "test".to_string(),
             sk_tx,
             &Cli::parse_from(["mayara-server"]),
             HashMap::new(),
-        )
+        );
+        (controls, sk_rx)
     }
 
     /// A client asking for a range the radar does not offer gets the

--- a/web/gui/control.js
+++ b/web/gui/control.js
@@ -1789,6 +1789,11 @@ function connectStateStream(streamUrl, radarIdParam) {
       const message = JSON.parse(event.data);
 
       if (message.updates) {
+        // A control's definition can change while we are connected — the
+        // server marks controls read-only when it discovers the radar cannot
+        // be commanded, and settable again when it can. Rebuild the panel when
+        // that happens rather than leaving stale widgets on screen.
+        let metaChanged = false;
         for (const update of message.updates) {
           if (update.meta) {
             for (const item of update.meta) {
@@ -1809,6 +1814,7 @@ function connectStateStream(streamUrl, radarIdParam) {
                     `meta data changed: ${controlId} from ${oldc} to ${newc}`
                   );
                   myr_capabilities.controls[controlId] = control;
+                  metaChanged = true;
                 } else {
                   console.log(`No change to meta data for ${controlId}`);
                 }
@@ -1842,6 +1848,12 @@ function connectStateStream(streamUrl, radarIdParam) {
               });
             }
           }
+        }
+        if (metaChanged) {
+          // Rebuilding empties the panel, so put the values we already know
+          // straight back; the stream only re-sends them when they change.
+          buildControls();
+          Object.values(myr_control_values).forEach(setControlValue);
         }
       } else if (message.name && message.version) {
         console.log("Connected to " + message.name + " v" + message.version);


### PR DESCRIPTION
A radar on a subnet this host has no address on looks perfectly healthy — picture, ranges and status all arrive — while every control silently does nothing. Turning the radar on, changing range, adjusting gain: the widget moves, then snaps back, and nothing in the log says why.

Raymarine RD and HD radomes make this routine: they address themselves in `10/8` while a host on the RayNet network is given `198.18.x` by the chartplotter's DHCP server. The commands are unicast and the kernel routes them away. Two users have reported it.

## What changes

Discovery is untouched — the picture is worth having, and hiding the radar would leave the user with nothing and no explanation. What changes is that the radar stops pretending to be controllable:

- **Controls that would be sent to the radar are marked `isReadOnly`**, and the updated definitions go out as Signal K **meta deltas**, so connected clients re-render instead of showing widgets that no longer work.
- **`notifications.radar.<id>.unreachable`** names both addresses and the interface, and suggests how to reach the radar. A separate kind from `error.<code>`, which is reserved for faults a radar reports about *itself* — this one is about the network, and no radar could ever report it.
- **A set against an unreachable radar is refused** with an explanatory error rather than sent into the void.
- **Controls mayara evaluates itself** — trails, targets, guard zones — keep working and stay settable.

All of it reverses when the radar becomes reachable again.

## Reachability is asked of the kernel, not guessed

`can_reach` connects a UDP socket (which sends nothing) and checks which interface the kernel would send from. Comparing subnets instead would have been a trap: both remedies — adding an address in the radar's range, or a host route to it — change the routing table without changing the address the radar was discovered on, so a subnet comparison would keep reporting the radar unreachable after the user had already fixed it.

The read-only flag is **derived where controls leave the server** rather than written into each control and undone later, so there is no second copy of the state to fall out of sync, and a radar going away and coming back cannot leave a stale flag behind. Controls that are read-only by their own nature stay that way through both transitions.

## Generic, and self-healing

The sweep lives in `SharedRadars` and is brand-agnostic: any radar with a unicast command address is evaluated. It runs on the radar watchdog tick and on **address-change events** (`tx_ip_change`, the same signal navdata and signalk already consume), so adding the missing address while mayara is running restores the controls without a restart.

This replaces the Raymarine-specific warning from #565, which is removed.

## Client-visible contract

`docs/api/README.md` now states that a `meta` array can arrive at any time, not only on connection — a client that reads definitions once at connect will show controls that no longer match the radar. The notification kinds are documented in a table.

The GUI rebuilds its control panel when a definition changes, re-applying the values it already holds so the rebuild is invisible apart from the controls becoming read-only.

## Tests

Unreachability marks command controls read-only while leaving guard zones settable; intrinsically read-only controls survive both transitions; a control added while unreachable is born read-only; each transition emits exactly one delta carrying the meta and the notification at the right state, and a repeated state emits nothing. Plus three behavioural tests for `can_reach`.