### PR TITLE
docs(raymarine): explain which addresses a Raymarine network uses

### DIFF
--- a/docs/raymarine-setup.md
+++ b/docs/raymarine-setup.md
@@ -8,7 +8,7 @@ The radar and the Mayara machine must be on the same wired Ethernet network.
 
 A **Quantum** needs a DHCP server on that network: it has no fallback address and stays silent until it gets a lease. An **RD or HD radome** never asks for one — it gives itself a fixed `10.x.x.x` address and keeps it forever, which is why it needs the Mayara machine to hold an address in that range too.
 
-Where a chartplotter is involved the network must be `198.18.0.0/21`. Give the Mayara machine an address between `198.18.4.0` and `198.18.7.254` — chartplotters claim addresses below that for themselves without checking.
+Where a chartplotter is involved the network must be `198.18.0.0/21` (netmask `255.255.248.0`). Let DHCP place the Mayara machine if you can; if you set its address by hand, use `198.18.0.2`–`198.18.0.19`. Never give it a fixed address in `198.18.0.32`–`198.18.3.255` — chartplotters claim those for themselves without checking whether anything already has one.
 
 ## Full guide
 

--- a/docs/raymarine-setup.md
+++ b/docs/raymarine-setup.md
@@ -4,7 +4,11 @@ Quantum and Quantum 2, Cyclone, the RD radome series, Magnum and the open arrays
 
 ## Network Requirements
 
-The radar and the Mayara machine must be on the same wired Ethernet network, and that network **must have a DHCP server**. A Raymarine radar has no fallback address: until it gets a lease it stays silent.
+The radar and the Mayara machine must be on the same wired Ethernet network.
+
+A **Quantum** needs a DHCP server on that network: it has no fallback address and stays silent until it gets a lease. An **RD or HD radome** never asks for one — it gives itself a fixed `10.x.x.x` address and keeps it forever, which is why it needs the Mayara machine to hold an address in that range too.
+
+Where a chartplotter is involved the network must be `198.18.0.0/21`. Give the Mayara machine an address between `198.18.4.0` and `198.18.7.254` — chartplotters claim addresses below that for themselves without checking.
 
 ## Full guide
 
@@ -16,7 +20,7 @@ http://<mayara-host>:6502/gui/help/raymarine.html
 
 It is also reachable from the "Network Configuration Help" panel on Mayara's radar list page. The source file is [`web/gui/help/raymarine.html`](../web/gui/help/raymarine.html) — edit that, not this file.
 
-It covers wired (RayNet) setup, the Quantum WiFi credentials trap, the multicast groups and ports, supported models, and troubleshooting.
+It covers wired (RayNet) setup, the Quantum WiFi credentials trap, the address ranges a Raymarine network uses, the multicast groups and ports, supported models, and troubleshooting.
 
 ## See also
 

--- a/web/gui/help/raymarine.html
+++ b/web/gui/help/raymarine.html
@@ -19,19 +19,29 @@
       <h2>What you need</h2>
       <ul class="myr_needs">
         <li>The radar and the Mayara machine on the same wired Ethernet network</li>
-        <li>A DHCP server on that network — this is the one hard requirement</li>
+        <li>A DHCP server on that network, if your radar is a Quantum</li>
         <li>A RayNet-to-RJ45 adapter cable, unless the radar already reaches a switch</li>
       </ul>
 
       <div class="myr_box myr_box_warn">
-        <span class="myr_box_title">DHCP is not optional</span>
+        <span class="myr_box_title">A Quantum needs DHCP; an RD radome does not</span>
         <p>
-          A Raymarine radar has no fallback address. It asks for one by DHCP,
-          and until it gets a lease it stays silent — no beacons, nothing for
-          Mayara to find. The DHCP server can be a Raymarine MFD, your router,
-          or a DHCP service on the Mayara machine itself. If the radar is not
-          detected, check your router's lease list first: if the radar is not in
-          it, nothing else you change will help.
+          A <strong>Quantum</strong> asks for its address by DHCP, and until it
+          gets a lease it stays silent — no beacons, nothing for Mayara to find.
+          The DHCP server can be a Raymarine chartplotter, your router, or a
+          DHCP service on the Mayara machine itself. If a Quantum is not
+          detected, check the lease list first: if the radar is not in it,
+          nothing else you change will help.
+        </p>
+        <p>
+          An <strong>RD or HD radome</strong> never asks. It gives itself a
+          fixed address in the <code>10.x.x.x</code> range and uses it forever.
+          That address is worked out from the radar's own hardware, so it never
+          changes — but it also means the radar takes no notice of your DHCP
+          server, and will not join the network your chartplotter set up. That
+          is the single most common reason an RD radar paints a picture but
+          ignores every control. See
+          <a href="#addresses">Addresses on a Raymarine network</a> below.
         </p>
       </div>
 
@@ -50,6 +60,53 @@
         <a href="quantum-networking.html">Quantum networking explained</a>.
       </p>
 
+      <h3 id="addresses">Addresses on a Raymarine network</h3>
+      <p>
+        Raymarine networks do not use the usual home-network numbers. If a
+        chartplotter is involved the network <strong>must</strong> be
+        <code>198.18.0.0</code> with netmask <code>255.255.248.0</code> — that
+        is everything from <code>198.18.0.0</code> to <code>198.18.7.255</code>.
+        Raymarine divides it up, and where you put the Mayara machine matters.
+      </p>
+      <div class="myr_scroll_x">
+        <table>
+          <thead>
+            <tr><th>Range</th><th>Who it belongs to</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>198.18.0.1</code></td>
+              <td>The DHCP server, if you run your own. It must be exactly this address.</td>
+            </tr>
+            <tr>
+              <td><code>198.18.0.32</code> – <code>198.18.3.255</code></td>
+              <td><strong>Chartplotters only.</strong> They pick their own address here without asking anyone. Never put anything else in this range.</td>
+            </tr>
+            <tr>
+              <td><code>198.18.4.0</code> – <code>198.18.7.254</code></td>
+              <td>Everything else, including the Mayara machine. A non-Raymarine DHCP server must hand out addresses only from here.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="myr_box myr_box_bad">
+        <span class="myr_box_title">Do not give Mayara an address below 198.18.4.0</span>
+        <p>
+          A chartplotter chooses its own address in the lower range and does not
+          check whether anything already has it. If you gave the Mayara machine
+          a fixed address there, a plotter can quietly claim the same one, and
+          from then on both behave erratically in ways that look like a failing
+          cable. Put Mayara at <code>198.18.4.x</code> through
+          <code>198.18.7.x</code>, or let the network's DHCP server place it.
+        </p>
+      </div>
+      <p>
+        RD and HD radomes sit outside all of this on <code>10.x.x.x</code>, so
+        on a mixed network the Mayara machine usually needs an address in both
+        ranges. That is covered under
+        <a href="#nocontrol">The picture works but no control does</a>.
+      </p>
+
       <h3>Traffic</h3>
       <div class="myr_scroll_x">
         <table>
@@ -65,7 +122,7 @@
             <tr>
               <td>Discovery, WiFi</td>
               <td><code>232.1.1.1:5800</code></td>
-              <td>Only joined when <code>--allow-wifi</code> is given</td>
+              <td>Always joined — a Quantum reports here even when Mayara is wired</td>
             </tr>
             <tr>
               <td>Reports and spokes</td>
@@ -243,7 +300,7 @@
 
       <h2>Troubleshooting</h2>
 
-      <h3>The picture works but no control does</h3>
+      <h3 id="nocontrol">The picture works but no control does</h3>
       <p>
         If the radar paints, the ranges are right and the status updates, but
         power, gain, sea and range do nothing at all, the radar is almost
@@ -273,6 +330,10 @@
 sudo ip addr add 10.0.0.2/8 dev eth0</code></pre>
       <p>
         Pick an address in <code>10.x.x.x</code> that nothing else is using.
+        This is an <em>extra</em> address — keep the
+        <code>198.18.x.x</code> one the network gave you, and if you are
+        setting that one by hand see
+        <a href="#addresses">Addresses on a Raymarine network</a>.
         Adding a route to the radar alone also works:
         <code>sudo ip route add 10.18.203.88/32 dev eth0</code>. Either way the
         change is not permanent — put it in your network configuration so it

--- a/web/gui/help/raymarine.html
+++ b/web/gui/help/raymarine.html
@@ -135,7 +135,7 @@
             <tr>
               <td>Discovery, WiFi</td>
               <td><code>232.1.1.1:5800</code></td>
-              <td>Always joined — a Quantum reports here even when Mayara is wired</td>
+              <td>Mayara always listens here. A Quantum reports to this group once it has an address, even if Mayara itself is wired.</td>
             </tr>
             <tr>
               <td>Reports and spokes</td>

--- a/web/gui/help/raymarine.html
+++ b/web/gui/help/raymarine.html
@@ -79,25 +79,38 @@
               <td>The DHCP server, if you run your own. It must be exactly this address.</td>
             </tr>
             <tr>
+              <td><code>198.18.0.2</code> – <code>198.18.0.19</code></td>
+              <td><strong>Fixed addresses for non-Raymarine equipment.</strong> This is where a hand-configured Mayara machine belongs.</td>
+            </tr>
+            <tr>
+              <td><code>198.18.0.20</code> – <code>198.18.0.31</code></td>
+              <td>Not spoken for, and not documented either. Leave it alone.</td>
+            </tr>
+            <tr>
               <td><code>198.18.0.32</code> – <code>198.18.3.255</code></td>
               <td><strong>Chartplotters only.</strong> They pick their own address here without asking anyone. Never put anything else in this range.</td>
             </tr>
             <tr>
               <td><code>198.18.4.0</code> – <code>198.18.7.254</code></td>
-              <td>Everything else, including the Mayara machine. A non-Raymarine DHCP server must hand out addresses only from here.</td>
+              <td>What a non-Raymarine DHCP server must hand out. Fine for Mayara if it gets its address automatically.</td>
             </tr>
           </tbody>
         </table>
       </div>
       <div class="myr_box myr_box_bad">
-        <span class="myr_box_title">Do not give Mayara an address below 198.18.4.0</span>
+        <span class="myr_box_title">Never give Mayara a fixed address in 198.18.0.32 – 198.18.3.255</span>
         <p>
-          A chartplotter chooses its own address in the lower range and does not
-          check whether anything already has it. If you gave the Mayara machine
-          a fixed address there, a plotter can quietly claim the same one, and
-          from then on both behave erratically in ways that look like a failing
-          cable. Put Mayara at <code>198.18.4.x</code> through
-          <code>198.18.7.x</code>, or let the network's DHCP server place it.
+          A chartplotter chooses its own address from that range and does not
+          check whether anything already has it. If the Mayara machine is
+          sitting on the address a plotter picks, both behave erratically
+          afterwards, in ways that look like a failing cable rather than an
+          address clash.
+        </p>
+        <p>
+          Best is to let the network's DHCP server give Mayara an address. If
+          you must set one by hand, use <code>198.18.0.2</code> through
+          <code>198.18.0.19</code> — the range Raymarine suggests for fixed
+          non-Raymarine equipment — with netmask <code>255.255.248.0</code>.
         </p>
       </div>
       <p>


### PR DESCRIPTION
The Raymarine help page told users that any Raymarine radar needs DHCP and has no fallback address. That is true of a Quantum, but wrong for an RD or HD radome — those give themselves a fixed `10.x.x.x` address, ignore DHCP entirely, and keep that address forever. It is the reason an RD radar paints a perfect picture while every control does nothing, so the page was steering affected users away from their actual problem.

Also adds the address ranges a Raymarine network uses, which were not documented anywhere. The network must be `198.18.0.0/21`; chartplotters claim `198.18.0.32`–`198.18.3.255` for themselves without checking whether anything already has it; `198.18.0.2`–`198.18.0.19` is where a hand-configured machine belongs; and `198.18.4.0`–`198.18.7.254` is what a third-party DHCP server may hand out. We have a user capture with the Mayara host sitting in the chartplotter range, which is a collision waiting to happen.

Ranges are per Raymarine's own [NETWORKING - IP / Netmask / DHCP](https://support.raymarine.com/s/article/NETWORKING---IP---Netmask---DHCP?language=en_US) FAQ, and every `198.18` address across our captures — 23 of 23 — falls inside the documented `/21`.

Separately, drops a stale line claiming `232.1.1.1:5800` is only joined when `--allow-wifi` is given; both beacon groups have been joined unconditionally since #563.

Docs only — no code changes.