### PR TITLE
fix(network): pin multicast sends to the intended interface

### DIFF
--- a/src/lib/brand/garmin/cdm_heartbeat.rs
+++ b/src/lib/brand/garmin/cdm_heartbeat.rs
@@ -163,7 +163,7 @@ pub(crate) async fn run(syc_group_id: Arc<AtomicU8>) {
 }
 
 async fn send_one(packet: &[u8], dest: &SocketAddrV4, nic: &Ipv4Addr) {
-    match network::create_multicast_send(dest, nic) {
+    match network::create_connected_send(dest, nic) {
         Ok(sock) => {
             // Suppress local loopback: otherwise the kernel delivers
             // our own packet right back to mayara's receive socket on

--- a/src/lib/brand/navico/command.rs
+++ b/src/lib/brand/navico/command.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use tokio::net::UdpSocket;
 
 use crate::brand::CommandSender;
-use crate::network::create_multicast_send;
+use crate::network::create_connected_send;
 use crate::radar::settings::{ControlId, ControlValue, SharedControls};
 use crate::radar::{Power, RadarError, RadarInfo};
 
@@ -47,7 +47,7 @@ impl Command {
     }
 
     async fn start_socket(&mut self) -> Result<(), RadarError> {
-        match create_multicast_send(&self.info.send_command_addr, &self.info.nic_addr) {
+        match create_connected_send(&self.info.send_command_addr, &self.info.nic_addr) {
             Ok(sock) => {
                 log::debug!(
                     "{} {} via {}: sending commands",

--- a/src/lib/brand/navico/command.rs
+++ b/src/lib/brand/navico/command.rs
@@ -61,7 +61,7 @@ impl Command {
             }
             Err(e) => {
                 log::debug!(
-                    "{} {} via {}: create multicast failed: {}",
+                    "{} {} via {}: send socket failed: {}",
                     self.key,
                     self.info.send_command_addr,
                     self.info.nic_addr,

--- a/src/lib/brand/navico/info.rs
+++ b/src/lib/brand/navico/info.rs
@@ -148,7 +148,7 @@ impl Information {
             }
             Err(e) => {
                 log::debug!(
-                    "{} {} via {}: create multicast failed: {}",
+                    "{} {} via {}: send socket failed: {}",
                     self.key,
                     SOCKET_ADDRESS[index],
                     self.nic_addr,

--- a/src/lib/brand/navico/info.rs
+++ b/src/lib/brand/navico/info.rs
@@ -7,7 +7,7 @@ use tokio::time::Instant;
 
 use crate::brand::navico::{HALO_HEADING_INFO_ADDRESS, HALO_SPEED_ADDRESS_A, HALO_SPEED_ADDRESS_B};
 use crate::navdata::{get_cog, get_heading_true, get_sog};
-use crate::network::create_multicast_send;
+use crate::network::create_connected_send;
 use crate::radar::{RadarError, RadarInfo};
 
 /// Heading is reported in the range [0..0xF800), with 0xF800 representing 360°.
@@ -135,7 +135,7 @@ impl Information {
         if self.sock[index].is_some() {
             return Ok(());
         }
-        match create_multicast_send(&SOCKET_ADDRESS[index], &self.nic_addr) {
+        match create_connected_send(&SOCKET_ADDRESS[index], &self.nic_addr) {
             Ok(sock) => {
                 log::debug!(
                     "{} {} via {}: sending info",

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -74,7 +74,7 @@ impl Command {
             }
             Err(e) => {
                 log::debug!(
-                    "{} {} via {}: create multicast failed: {}",
+                    "{} {} via {}: send socket failed: {}",
                     self.key,
                     self.info.send_command_addr,
                     self.info.nic_addr,

--- a/src/lib/brand/raymarine/command.rs
+++ b/src/lib/brand/raymarine/command.rs
@@ -4,7 +4,7 @@ use tokio::net::UdpSocket;
 
 use super::BaseModel;
 use crate::brand::CommandSender;
-use crate::network::create_multicast_send;
+use crate::network::create_connected_send;
 use crate::radar::range::Ranges;
 use crate::radar::settings::{ControlValue, SharedControls};
 use crate::radar::{RadarError, RadarInfo};
@@ -50,7 +50,7 @@ impl Command {
 
     async fn start_socket(&mut self) -> Result<(), RadarError> {
         assert!(!self.unicast_mode);
-        match create_multicast_send(&self.info.send_command_addr, &self.info.nic_addr) {
+        match create_connected_send(&self.info.send_command_addr, &self.info.nic_addr) {
             Ok(sock) => {
                 // The command address is often an Axiom that relays to a WiFi
                 // radar; like the wake burst, commands must carry TTL > 1 or
@@ -153,17 +153,17 @@ impl CommandSender for Command {
 mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
 
-    use crate::network::create_multicast_send;
+    use crate::network::create_connected_send;
 
     // The command socket (start_socket) relays through an Axiom to a WiFi
     // radar, so it must carry TTL > 1 or the relay drops it (issue #160).
     // start_socket needs a full RadarInfo to build, so exercise the socket
-    // configuration it performs directly: a create_multicast_send socket must
+    // configuration it performs directly: a create_connected_send socket must
     // accept both the multicast and unicast relay TTL and report them back.
     #[tokio::test]
     async fn command_socket_accepts_relay_ttl() {
         let dst = SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 5800);
-        let sock = create_multicast_send(&dst, &Ipv4Addr::UNSPECIFIED)
+        let sock = create_connected_send(&dst, &Ipv4Addr::UNSPECIFIED)
             .expect("command send socket should be creatable");
 
         sock.set_multicast_ttl_v4(super::super::RAYMARINE_RELAY_TTL)

--- a/src/lib/brand/raymarine/mod.rs
+++ b/src/lib/brand/raymarine/mod.rs
@@ -588,7 +588,7 @@ impl RaymarineLocator {
             let navdata_name = format!("{}-navdata", report_name);
             subsys.start(SubsystemBuilder::new(
                 navdata_name,
-                async move |s: &mut SubsystemHandle| match crate::network::create_multicast_send(
+                async move |s: &mut SubsystemHandle| match crate::network::create_connected_send(
                     &send_addr, &nic_addr,
                 ) {
                     Ok(sock) => navdata::run(s, sock).await.map_err(|e| e.into()),
@@ -747,7 +747,7 @@ async fn send_wake_burst(nic_addr: &Ipv4Addr) {
     let SocketAddr::V4(addr) = RAYMARINE_BEACON_ADDRESS else {
         return;
     };
-    match crate::network::create_multicast_send(&addr, nic_addr) {
+    match crate::network::create_connected_send(&addr, nic_addr) {
         Ok(sock) => {
             if let Err(e) = sock.set_multicast_ttl_v4(RAYMARINE_RELAY_TTL) {
                 log::warn!("via {}: wake burst TTL: {}", nic_addr, e);

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -683,7 +683,7 @@ async fn send_beacon_request(
             log::debug!("Sending beacon request to {} via all interfaces", addr);
 
             for nic_addr in interface_addresses {
-                match network::create_multicast_send(addr, nic_addr) {
+                match network::create_connected_send(addr, nic_addr) {
                     Ok(sock) => {
                         sock.set_broadcast(true)?;
                         if let Some(ttl) = multicast_ttl {

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -710,7 +710,7 @@ async fn send_beacon_request(
                     }
                     Err(e) => {
                         log::warn!(
-                            "{} via {}: Failed to create multicast socket: {}",
+                            "{} via {}: Failed to create send socket: {}",
                             addr,
                             nic_addr,
                             e

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -466,11 +466,17 @@ mod reachability_tests {
 #[cfg(test)]
 mod send_socket_tests {
     use super::{UdpSocket, create_connected_send};
+    use std::io;
     use std::net::{Ipv4Addr, SocketAddrV4};
 
     /// The all-hosts group. Any multicast destination proves the point; this
     /// one is guaranteed to exist wherever the tests run.
     const ALL_HOSTS_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
+
+    /// How many ports to try before giving up. Losing the race below once is
+    /// plausible; losing it this many times in a row means something other
+    /// than a collision is wrong.
+    const PORT_ATTEMPTS: usize = 16;
 
     /// The socket under test, on whichever local port we can get.
     ///
@@ -481,18 +487,23 @@ mod send_socket_tests {
     /// parallel processes under nextest, so losing the race is reachable rather
     /// than theoretical: on a collision, simply try another port.
     fn a_send_socket_on_some_free_port() -> UdpSocket {
-        for _ in 0..16 {
+        for _ in 0..PORT_ATTEMPTS {
             let port = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
                 .expect("a loopback port should be available")
                 .local_addr()
                 .expect("a bound socket has an address")
                 .port();
             let dst = SocketAddrV4::new(ALL_HOSTS_GROUP, port);
-            if let Ok(sock) = create_connected_send(&dst, &Ipv4Addr::LOCALHOST) {
-                return sock;
+            match create_connected_send(&dst, &Ipv4Addr::LOCALHOST) {
+                Ok(sock) => return sock,
+                // Somebody took the port between our look and our bind.
+                Err(e) if e.kind() == io::ErrorKind::AddrInUse => continue,
+                // Anything else is the failure the test exists to catch, so
+                // say what it was rather than blame the port.
+                Err(e) => panic!("send socket could not be created: {e}"),
             }
         }
-        panic!("no local port stayed free long enough to bind");
+        panic!("no local port stayed free after {PORT_ATTEMPTS} attempts");
     }
 
     /// Multicast commands must leave by the interface the radar was found on,

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -471,14 +471,23 @@ mod send_socket_tests {
     /// The all-hosts group. Any multicast destination proves the point; this
     /// one is guaranteed to exist wherever the tests run.
     const ALL_HOSTS_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
-    /// Arbitrary — nothing is ever sent, so the port only has to be bindable.
-    const ANY_PORT: u16 = 5800;
+
+    /// A loopback port nothing else holds. The socket binds locally to the
+    /// *destination's* port, so a fixed one here could collide with a real
+    /// service or with another test running alongside.
+    fn a_free_port() -> u16 {
+        std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .expect("a loopback port should be available")
+            .local_addr()
+            .expect("a bound socket has an address")
+            .port()
+    }
 
     /// Multicast commands must leave by the interface the radar was found on,
     /// not by whichever one happens to hold the default route.
     #[tokio::test]
     async fn a_send_socket_pins_multicast_to_the_given_interface() {
-        let dst = SocketAddrV4::new(ALL_HOSTS_GROUP, ANY_PORT);
+        let dst = SocketAddrV4::new(ALL_HOSTS_GROUP, a_free_port());
         let sock = create_connected_send(&dst, &Ipv4Addr::LOCALHOST)
             .expect("send socket should be creatable");
 

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -310,15 +310,23 @@ pub(crate) fn create_connected_unicast(
 /// ephemeral one: the radars expect commands to arrive from the port they are
 /// sent to, and reply there.
 ///
-/// Binding to `nic_addr` fixes the source address but not the outgoing
-/// interface — the kernel still routes by destination. For a unicast peer this
-/// host has no route to, `connect` fails here; for one reachable only by some
-/// other interface it succeeds and the datagrams quietly go the wrong way.
+/// Multicast is pinned to `nic_addr`'s interface. Unicast cannot be: binding to
+/// `nic_addr` fixes the source address but not the outgoing interface, and the
+/// kernel still routes by destination. For a unicast peer this host has no
+/// route to, `connect` fails here; for one reachable only by some other
+/// interface it succeeds and the datagrams quietly go the wrong way.
 pub(crate) fn create_connected_send(
     addr: &SocketAddrV4,
     nic_addr: &Ipv4Addr,
 ) -> io::Result<UdpSocket> {
     let socket: socket2::Socket = new_socket()?;
+
+    // Send multicast out of the radar's own interface. Without this the kernel
+    // chooses one by route, which on a boat with both WiFi and Ethernet — or a
+    // cellular dongle holding the default route — is usually not the radar's
+    // network, and the commands leave the wrong way. Unicast is unaffected by
+    // this option; it is set unconditionally because it costs nothing.
+    socket.set_multicast_if_v4(nic_addr)?;
 
     let socketaddr = SocketAddr::new(IpAddr::V4(*addr.ip()), addr.port());
     let socketaddr_nic = SocketAddr::new(IpAddr::V4(*nic_addr), addr.port());
@@ -449,6 +457,26 @@ mod reachability_tests {
                 &SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 2), 2573)
             ),
             None
+        );
+    }
+}
+
+#[cfg(test)]
+mod send_socket_tests {
+    use super::create_connected_send;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    /// Multicast commands must leave by the interface the radar was found on,
+    /// not by whichever one happens to hold the default route.
+    #[tokio::test]
+    async fn a_send_socket_pins_multicast_to_the_given_interface() {
+        let dst = SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 5800);
+        let sock = create_connected_send(&dst, &Ipv4Addr::LOCALHOST)
+            .expect("send socket should be creatable");
+
+        assert_eq!(
+            socket2::SockRef::from(&sock).multicast_if_v4().unwrap(),
+            Ipv4Addr::LOCALHOST
         );
     }
 }

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -301,10 +301,11 @@ pub(crate) fn create_connected_unicast(
     UdpSocket::from_std(socket.into())
 }
 
-/// A UDP socket for sending to `addr` out of the interface holding `nic_addr`.
+/// A UDP socket connected to `addr`, sourced from `nic_addr`.
 ///
 /// Works for a multicast group or a unicast peer alike — nothing here is
 /// multicast-specific, and half the callers send to a radar's own address.
+/// Only multicast is pinned to `nic_addr`'s interface; see below.
 ///
 /// Note that the local port is bound to the *destination's* port, not an
 /// ephemeral one: the radars expect commands to arrive from the port they are
@@ -467,11 +468,17 @@ mod send_socket_tests {
     use super::create_connected_send;
     use std::net::{Ipv4Addr, SocketAddrV4};
 
+    /// The all-hosts group. Any multicast destination proves the point; this
+    /// one is guaranteed to exist wherever the tests run.
+    const ALL_HOSTS_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
+    /// Arbitrary — nothing is ever sent, so the port only has to be bindable.
+    const ANY_PORT: u16 = 5800;
+
     /// Multicast commands must leave by the interface the radar was found on,
     /// not by whichever one happens to hold the default route.
     #[tokio::test]
     async fn a_send_socket_pins_multicast_to_the_given_interface() {
-        let dst = SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 5800);
+        let dst = SocketAddrV4::new(ALL_HOSTS_GROUP, ANY_PORT);
         let sock = create_connected_send(&dst, &Ipv4Addr::LOCALHOST)
             .expect("send socket should be creatable");
 

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -301,7 +301,20 @@ pub(crate) fn create_connected_unicast(
     UdpSocket::from_std(socket.into())
 }
 
-pub(crate) fn create_multicast_send(
+/// A UDP socket for sending to `addr` out of the interface holding `nic_addr`.
+///
+/// Works for a multicast group or a unicast peer alike — nothing here is
+/// multicast-specific, and half the callers send to a radar's own address.
+///
+/// Note that the local port is bound to the *destination's* port, not an
+/// ephemeral one: the radars expect commands to arrive from the port they are
+/// sent to, and reply there.
+///
+/// Binding to `nic_addr` fixes the source address but not the outgoing
+/// interface — the kernel still routes by destination. For a unicast peer this
+/// host has no route to, `connect` fails here; for one reachable only by some
+/// other interface it succeeds and the datagrams quietly go the wrong way.
+pub(crate) fn create_connected_send(
     addr: &SocketAddrV4,
     nic_addr: &Ipv4Addr,
 ) -> io::Result<UdpSocket> {

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -465,31 +465,41 @@ mod reachability_tests {
 
 #[cfg(test)]
 mod send_socket_tests {
-    use super::create_connected_send;
+    use super::{UdpSocket, create_connected_send};
     use std::net::{Ipv4Addr, SocketAddrV4};
 
     /// The all-hosts group. Any multicast destination proves the point; this
     /// one is guaranteed to exist wherever the tests run.
     const ALL_HOSTS_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
 
-    /// A loopback port nothing else holds. The socket binds locally to the
-    /// *destination's* port, so a fixed one here could collide with a real
-    /// service or with another test running alongside.
-    fn a_free_port() -> u16 {
-        std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
-            .expect("a loopback port should be available")
-            .local_addr()
-            .expect("a bound socket has an address")
-            .port()
+    /// The socket under test, on whichever local port we can get.
+    ///
+    /// [`create_connected_send`] binds locally to the *destination's* port, so
+    /// this needs a port to itself. A port cannot be reserved and handed over —
+    /// asking the OS for a free one releases it again the moment we look at it
+    /// — and a duplicate bind is refused even with `SO_REUSEADDR`. Tests run in
+    /// parallel processes under nextest, so losing the race is reachable rather
+    /// than theoretical: on a collision, simply try another port.
+    fn a_send_socket_on_some_free_port() -> UdpSocket {
+        for _ in 0..16 {
+            let port = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+                .expect("a loopback port should be available")
+                .local_addr()
+                .expect("a bound socket has an address")
+                .port();
+            let dst = SocketAddrV4::new(ALL_HOSTS_GROUP, port);
+            if let Ok(sock) = create_connected_send(&dst, &Ipv4Addr::LOCALHOST) {
+                return sock;
+            }
+        }
+        panic!("no local port stayed free long enough to bind");
     }
 
     /// Multicast commands must leave by the interface the radar was found on,
     /// not by whichever one happens to hold the default route.
     #[tokio::test]
     async fn a_send_socket_pins_multicast_to_the_given_interface() {
-        let dst = SocketAddrV4::new(ALL_HOSTS_GROUP, a_free_port());
-        let sock = create_connected_send(&dst, &Ipv4Addr::LOCALHOST)
-            .expect("send socket should be creatable");
+        let sock = a_send_socket_on_some_free_port();
 
         assert_eq!(
             socket2::SockRef::from(&sock).multicast_if_v4().unwrap(),

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -314,7 +314,8 @@ pub(crate) fn create_connected_unicast(
 /// `nic_addr` fixes the source address but not the outgoing interface, and the
 /// kernel still routes by destination. For a unicast peer this host has no
 /// route to, `connect` fails here; for one reachable only by some other
-/// interface it succeeds and the datagrams quietly go the wrong way.
+/// interface it succeeds and the datagrams quietly go the wrong way — see
+/// [`can_reach`].
 pub(crate) fn create_connected_send(
     addr: &SocketAddrV4,
     nic_addr: &Ipv4Addr,

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -303,9 +303,8 @@ pub(crate) fn create_connected_unicast(
 
 /// A UDP socket connected to `addr`, sourced from `nic_addr`.
 ///
-/// Works for a multicast group or a unicast peer alike — nothing here is
-/// multicast-specific, and half the callers send to a radar's own address.
-/// Only multicast is pinned to `nic_addr`'s interface; see below.
+/// Takes a multicast group or a unicast peer alike — half the callers send to
+/// a radar's own address — but only multicast is pinned to an interface.
 ///
 /// Note that the local port is bound to the *destination's* port, not an
 /// ephemeral one: the radars expect commands to arrive from the port they are


### PR DESCRIPTION
On a boat where the Mayara machine has more than one network — WiFi and Ethernet, or a cellular dongle holding the default route — Mayara could fail to find radars on the radar network, and fail to control the ones it did find. The symptom looks like a flaky cable or a switch problem: a radar that appears sometimes, or appears but ignores every command.

Multicast datagrams were leaving by whichever interface held the route, rather than the interface meant for them, because the send socket never set `IP_MULTICAST_IF`.

Worst affected is **discovery**, for every brand. The locator builds one socket per interface address and sends a beacon request through each, intending to probe them all — but all of them left by the same interface, so only one network was ever really probed.

Per brand:

- **Navico** and **Garmin** command their radars over multicast, so commands were lost the same way.
- **Raymarine** commands are unicast and were unaffected, but its beacons, wake burst and NavData are multicast — so a radar could go undiscovered, never wake, or never receive heading and position.

The fix is one `set_multicast_if_v4` call on the send socket. It needs no privileges and is available on every target we build, Windows included. Unicast is unaffected by the option — for unicast the outgoing interface still follows the routing table, which is what #569 is about.

Also renames `create_multicast_send` to `create_connected_send`. It does nothing multicast-specific — it binds to the given NIC address and connects — and half its callers pass a unicast radar address. The old name helped hide this bug, and made the unicast callers look like they were doing something they were not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Pins multicast UDP sends to the selected network interface with `IP_MULTICAST_IF`.

Renames `create_multicast_send` to `create_connected_send` for multicast and unicast destinations.

Updates Garmin, Navico, Raymarine, and locator senders to use the renamed helper.

Updates documentation and log messages to describe connected-send behavior.

Adds tests for multicast interface selection and reliable local-port allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->