### PR TITLE
chore(deps): bump netlink-sys to 0.9 and rtnetlink to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,33 +1834,32 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
-dependencies = [
- "paste",
-]
+checksum = "2d6e2daf9a8c2e21302714706860a0e6be02e03d17294ecc66b354ea7d4059dd"
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "59d48ffc8b73a506e1ff0878528c72668f2bfbc3d875b6be890a96be5d0d5576"
 dependencies = [
  "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
+ "zerocopy",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "97e03ae6247c6cdb499e8f14e98c72b83954d85822b687056e3a21150b438f2b"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -1869,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+checksum = "c99d38e00b420df49e940fe0826e667c3dad82ac68eb4c2bbf754c1c14a83a10"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2057,12 +2056,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2454,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+checksum = "90f60a3ee149005c5819e03e3d73ba4a470bc18b52b0c8422cfe1bea2cae63c6"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2466,7 +2459,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix 0.30.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,8 @@ tokio-tungstenite = { git = "https://github.com/keesverruijt/tokio-tungstenite",
 system-configuration = "0.8.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-netlink-sys = { version = "0.8.8", features = ["tokio", "tokio_socket"] }
-rtnetlink = "0.21.0"
+netlink-sys = { version = "0.9.0", features = ["tokio", "tokio_socket"] }
+rtnetlink = "0.23.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 w32-error = "1.0.0"


### PR DESCRIPTION
No user-visible change — a dependency upgrade that has to happen in one step.

Dependabot raised these as two PRs, #572 (netlink-sys 0.8.8 → 0.9.0) and #573 (rtnetlink 0.21 → 0.23), and **both fail CI**. They are two halves of the same upgrade: rtnetlink 0.23 requires `netlink-sys ^0.9`, while `netlink-sys` is also a direct dependency of ours pinned at 0.8. Bumping either one alone leaves two versions of the crate in the graph, and the `AsyncSocket` trait in scope stops matching the socket rtnetlink hands back:

```
error[E0599]: no method named `socket_mut` found for mutable reference
              `&mut rtnetlink::netlink_sys::TokioSocket`
  --> src/lib/network/linux/mod.rs:42:10
note: there are multiple different versions of crate `netlink_sys` in the dependency graph
```

Bumping both together resolves to a single `netlink-sys 0.9.0`, and **no source changes are needed** — the netlink socket setup in `src/lib/network/linux/mod.rs` still compiles as written.

Verified by cross-compiling to `x86_64-unknown-linux-musl` (where that file is actually built) with `clippy --all-targets -D warnings` clean, plus the full test suite. Closes #572 and closes #573.