### PR TITLE
fix(atomics): support platforms without native 64-bit atomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,12 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomic_float"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,7 +1603,6 @@ version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "atomic_float",
  "axum",
  "axum-core 0.5.6",
  "axum-embed",
@@ -1644,6 +1637,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
+ "portable-atomic",
  "protobuf",
  "protobuf-codegen",
  "reqwest",
@@ -2077,9 +2071,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ default = ["navico", "furuno", "garmin", "koden", "raymarine", "emulator"]
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.89"
-atomic_float = "1.1.0"
 axum = { version = "0.8.9", features = ["http2", "json", "macros", "tokio", "tower-log", "tracing", "ws"] }
 axum-core = "0.5.6"
 axum-embed = "0.1.0"
@@ -71,6 +70,7 @@ nmea-parser = { git = "https://github.com/keesverruijt/nmea-parser", "branch" = 
 num-derive = "0.5.1"
 num-traits = "0.2.19"
 once_cell = "1.21.4"
+portable-atomic = { version = "1.15.0", features = ["float"] }
 protobuf = "3.7.2"
 rust-embed = { version = "8.11.0", features = ["axum","interpolate-folder-path"] }
 serde = { version = "1.0.228", features = ["derive", "serde_derive"] }

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -1,7 +1,7 @@
-use atomic_float::AtomicF64;
 use futures_util::{SinkExt, StreamExt, future::select_ok};
 use mdns_sd::{Error, IfKind, ServiceDaemon, ServiceEvent};
 use nmea_parser::*;
+use portable_atomic::AtomicF64;
 use serde_json::Value;
 use std::{
     collections::HashSet,

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -2,6 +2,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use enum_primitive_derive::Primitive;
+use portable_atomic::AtomicU64;
 use protobuf::Message;
 use serde::Serialize;
 use serde::ser::Serializer;
@@ -14,7 +15,7 @@ use std::{
     net::{Ipv4Addr, SocketAddrV4},
     sync::{
         Arc, LazyLock, RwLock,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
 };
 use thiserror::Error;

--- a/src/lib/recording/player.rs
+++ b/src/lib/recording/player.rs
@@ -1,13 +1,14 @@
 //! Radar playback - reads .mrr files and emits frames as a virtual radar.
 
 use log::{debug, error, info, warn};
+use portable_atomic::AtomicU64;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::{RwLock, broadcast};
 

--- a/src/lib/recording/recorder.rs
+++ b/src/lib/recording/recorder.rs
@@ -1,11 +1,12 @@
 //! Radar recorder - subscribes to radar broadcast and writes to .mrr file.
 
 use log::{debug, error, info, warn};
+use portable_atomic::AtomicU64;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 


### PR DESCRIPTION
mayara currently fails to compile on 32-bit CPUs that lack native 64-bit atomic instructions (e.g. MIPS32, used by some embedded/router-class devices) — the build errors out with "no `AtomicU64` in `sync::atomic`". This fixes that so mayara can be built for those platforms.

## Root cause

`std::sync::atomic::AtomicU64` (used for a few internal timestamp/counter fields) and `atomic_float::AtomicF64` (used for shared heading/position/COG/SOG state in `navdata.rs`) both require native 64-bit atomic support, which doesn't exist on those architectures.

## Fix

Switch both to [`portable-atomic`](https://docs.rs/portable-atomic), a drop-in replacement with the same `load`/`store`/`Ordering` API. On every platform mayara currently ships for, it compiles to the exact same native instructions (zero behavior or performance change); on platforms without native 64-bit atomics it transparently falls back to a lock internally, so no call sites needed to change beyond the `use`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps --all-targets -- -D warnings`
- [x] `cargo test` (429 tests passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Replaces `AtomicU64` and `AtomicF64` with `portable-atomic` types. Native atomic instructions remain available where supported, with a lock-based fallback on platforms without native 64-bit atomic support. Preserves the existing `load`, `store`, and `Ordering` APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->