### PR TITLE
ci(release): add mipsel-unknown-linux-musl to release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
+        include:
+          - target: x86_64-unknown-linux-musl
+            channel: stable
+          - target: aarch64-unknown-linux-musl
+            channel: stable
+          # mipsel (e.g. OpenWrt/mt7621 devices) is a tier-3 target: rustup
+          # ships no prebuilt std for it, so std has to be built from source
+          # with `-Z build-std`, which requires nightly. See Cross.toml for
+          # the custom cross image this needs.
+          - target: mipsel-unknown-linux-musl
+            channel: nightly
 
     steps:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Install Rust
+    - name: Install Rust (stable)
+      if: matrix.channel == 'stable'
       uses: dtolnay/rust-toolchain@stable
+
+    - name: Install Rust (nightly)
+      if: matrix.channel == 'nightly'
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rust-src
 
     - uses: swatinem/rust-cache@v2
       with:
@@ -31,7 +48,12 @@ jobs:
       run: cargo install cross
 
     - name: Build
-      run: cross build --release --target ${{ matrix.target }}
+      run: |
+        if [ "${{ matrix.channel }}" = "nightly" ]; then
+          cross build -Z build-std=std,panic_abort --release --target ${{ matrix.target }}
+        else
+          cross build --release --target ${{ matrix.target }}
+        fi
 
     - name: Package
       run: |
@@ -154,6 +176,7 @@ jobs:
         files: |
           artifacts/mayara-server-x86_64-unknown-linux-musl/*.tar.gz
           artifacts/mayara-server-aarch64-unknown-linux-musl/*.tar.gz
+          artifacts/mayara-server-mipsel-unknown-linux-musl/*.tar.gz
           artifacts/mayara-server-macos/*.tar.gz
           artifacts/mayara-server-windows/*.zip
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+# mipsel-unknown-linux-musl (e.g. OpenWrt/mt7621 devices such as the
+# datahubpro) is a tier-3 target: rustup ships no prebuilt std for it, and
+# recent `cross` releases dropped their built-in image mapping for it even
+# though the cross-rs project still publishes one. Point at that image
+# explicitly and build std from source with `-Z build-std` on nightly (see
+# the `dhp`/`dhpd`/`dhpt` targets in Makefile.local).
+[target.mipsel-unknown-linux-musl]
+image = "ghcr.io/cross-rs/mipsel-unknown-linux-musl:main"


### PR DESCRIPTION
Release builds now include a `mipsel-unknown-linux-musl` binary, so mayara has a prebuilt download for OpenWrt/mt7621-class devices (e.g. the DataHub Pro) instead of requiring a from-source build.

## Details

mipsel is a tier-3 Rust target with no prebuilt std, so `cross` needs a nightly toolchain and `-Z build-std=std,panic_abort` to compile std from source. `Cross.toml` pins the docker image cross should use for this target, since recent `cross` releases dropped their built-in image mapping for it even though the image is still published. Builds on [#580](https://github.com/MarineYachtRadar/mayara-server/pull/580), which made mayara's own source portable to platforms without native 64-bit atomics.

The new matrix entry only changes toolchain/build-std for `mipsel-unknown-linux-musl`; the existing `x86_64`/`aarch64` release builds are unaffected.

## Test plan

- [x] Verified locally end-to-end: `cross build -Z build-std=std,panic_abort --target mipsel-unknown-linux-musl --release` with this `Cross.toml` produces a working `mipsel-sf` musl binary that runs on a real datahubpro device

Note: the release workflow itself only triggers on `v*` tags, so the matrix job can't be exercised in CI until the next tagged release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `mipsel-unknown-linux-musl` to Linux release builds.

- Uses nightly Rust and `-Z build-std=std,panic_abort` for the mipsel target.
- Pins the `cross` Docker image in `Cross.toml`.
- Includes the mipsel archive in release uploads.
- Keeps existing `x86_64` and `aarch64` builds unchanged.
- Verifies the binary on a DataHub Pro device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->