### PR TITLE
fix(config): keep running when settings cannot be stored

### DIFF
--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -106,23 +106,48 @@ pub(crate) struct Persistence {
     path: PathBuf,
 }
 
+/// Name of the settings file inside the config directory.
+const SETTINGS_FILE: &str = "settings.json";
+
+/// The settings file to read and write, or `None` when the config directory
+/// cannot be created. A radar works fine without one, so an unwritable
+/// config directory -- a read-only mount, a host directory owned by another
+/// user -- costs the user their remembered settings, never their radar.
+fn settings_path(config_dir: &std::path::Path) -> Option<PathBuf> {
+    if let Err(e) = fs::create_dir_all(config_dir) {
+        warn!(
+            "Cannot create settings directory '{}': {}",
+            config_dir.display(),
+            e
+        );
+        warn!("Radar names, guard zones and other settings will not be remembered");
+        return None;
+    }
+    Some(config_dir.join(SETTINGS_FILE))
+}
+
 impl Persistence {
+    /// A persistence that remembers nothing, for a run that has nowhere to
+    /// write. An empty path is the marker every write path already checks.
+    fn disabled() -> Self {
+        Persistence {
+            config: Config {
+                radars: HashMap::new(),
+            },
+            timestamp: SystemTime::UNIX_EPOCH,
+            path: PathBuf::new(),
+        }
+    }
+
     pub(crate) fn new() -> Self {
         if crate::replay::is_active() {
             debug!("persistence disabled in pcap replay mode");
-            return Persistence {
-                config: Config {
-                    radars: HashMap::new(),
-                },
-                timestamp: SystemTime::UNIX_EPOCH,
-                path: PathBuf::new(),
-            };
+            return Self::disabled();
         }
 
-        let project_dirs = get_project_dirs();
-        let mut settings_path = project_dirs.config_dir().to_owned();
-        fs::create_dir_all(&settings_path).expect("Cannot create settings directory");
-        settings_path.push("settings.json");
+        let Some(settings_path) = settings_path(get_project_dirs().config_dir()) else {
+            return Self::disabled();
+        };
 
         let mut this = Persistence {
             config: Config {
@@ -450,8 +475,7 @@ mod tests {
         );
         Persistence {
             config: Config { radars },
-            timestamp: SystemTime::UNIX_EPOCH,
-            path: PathBuf::new(),
+            ..Persistence::disabled()
         }
     }
 
@@ -506,5 +530,30 @@ mod tests {
         let mut p = persistence_with("gar0102", "Radar");
         assert!(!p.take_legacy_entry("gar0102", "gar0102"));
         assert!(p.config.radars.contains_key("gar0102"));
+    }
+
+    /// The usual case: the config directory does not exist yet on first run.
+    #[test]
+    fn a_missing_config_directory_is_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("mayara");
+
+        let path = settings_path(&config_dir).expect("first run must get a settings file");
+
+        assert_eq!(path, config_dir.join(SETTINGS_FILE));
+        assert!(config_dir.is_dir());
+    }
+
+    /// A radar must keep working when its settings cannot be stored: the
+    /// config directory may be a read-only mount, or a host directory owned
+    /// by another user. Blocked by a plain file standing where the directory
+    /// should be, which no user -- root included -- can create through.
+    #[test]
+    fn an_unusable_config_directory_disables_persistence_instead_of_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocker");
+        fs::write(&blocker, b"not a directory").unwrap();
+
+        assert!(settings_path(&blocker.join("mayara")).is_none());
     }
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -106,7 +106,6 @@ pub(crate) struct Persistence {
     path: PathBuf,
 }
 
-/// Name of the settings file inside the config directory.
 const SETTINGS_FILE: &str = "settings.json";
 
 /// The settings file to read and write, or `None` when the config directory
@@ -157,7 +156,10 @@ impl Persistence {
             path: settings_path,
         };
 
-        this.load();
+        if !this.load() {
+            warn!("Radar names, guard zones and other settings will not be remembered");
+            return Self::disabled();
+        }
         debug!("persistence loaded: {:?}", this);
 
         this
@@ -183,7 +185,11 @@ impl Persistence {
         );
     }
 
-    fn load(&mut self) {
+    /// Returns whether the settings file can be used. A first run writes an
+    /// empty one, which doubles as the check that this run can write at all:
+    /// `create_dir_all` succeeds on a directory that already exists but
+    /// belongs to another user, so the write is what finds that out.
+    fn load(&mut self) -> bool {
         let file = match File::open(&self.path) {
             Err(e) => {
                 warn!(
@@ -192,8 +198,7 @@ impl Persistence {
                     e
                 );
 
-                self.save();
-                return;
+                return self.save();
             }
             Ok(f) => f,
         };
@@ -215,6 +220,7 @@ impl Persistence {
         };
 
         self.timestamp = self.get_file_time();
+        true
     }
 
     fn saver(&mut self) -> Result<(), Box<dyn Error>> {
@@ -231,9 +237,13 @@ impl Persistence {
         Ok(())
     }
 
-    fn save(&mut self) {
-        if let Err(e) = self.saver() {
-            warn!("cannot store config '{}': {}", self.path.display(), e);
+    fn save(&mut self) -> bool {
+        match self.saver() {
+            Err(e) => {
+                warn!("cannot store config '{}': {}", self.path.display(), e);
+                false
+            }
+            Ok(()) => true,
         }
     }
 
@@ -371,7 +381,7 @@ impl Persistence {
         }
 
         if modified {
-            self.save();
+            let _ = self.save();
         }
     }
 
@@ -396,7 +406,7 @@ impl Persistence {
         );
         self.config.radars.insert(key.to_string(), entry);
         if !self.path.as_os_str().is_empty() {
-            self.save();
+            let _ = self.save();
         }
         true
     }
@@ -555,5 +565,35 @@ mod tests {
         fs::write(&blocker, b"not a directory").unwrap();
 
         assert!(settings_path(&blocker.join("mayara")).is_none());
+    }
+
+    fn persistence_at(path: PathBuf) -> Persistence {
+        Persistence {
+            path,
+            ..Persistence::disabled()
+        }
+    }
+
+    /// First run: no settings file yet, so one is written and kept.
+    #[test]
+    fn a_first_run_writes_the_settings_file_it_found_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(SETTINGS_FILE);
+
+        assert!(persistence_at(path.clone()).load());
+        assert!(path.is_file());
+    }
+
+    /// An existing directory says nothing about being able to write in it --
+    /// it may belong to another user -- so a settings file that cannot be
+    /// created has to disable persistence too, or every later save retries a
+    /// write that cannot succeed.
+    #[test]
+    fn a_settings_file_that_cannot_be_written_disables_persistence() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocker");
+        fs::write(&blocker, b"not a directory").unwrap();
+
+        assert!(!persistence_at(blocker.join(SETTINGS_FILE)).load());
     }
 }


### PR DESCRIPTION
## Summary

Mayara refused to start when it could not create the directory it keeps
radar settings in — the server exited instead of running the radar. A radar
needs no settings file to work, so that failure now costs the user only
their remembered names and guard zones; the picture still comes up:

```
WARN Cannot create settings directory '…/net.verruijt.mayara': Permission denied (os error 13)
WARN Radar names, guard zones and other settings will not be remembered
```

`Persistence::new()` followed `create_dir_all` with `expect()`. Directory
creation moves into `settings_path()`, which warns and returns `None`, and
`new()` falls back to the existing remembers-nothing state that pcap replay
mode already uses — an empty path, which every write path already checks.

This matters now because the Signal K plugin is about to mount mayara's
config directory from the host
(MarineYachtRadar/mayara-server-signalk-plugin#111), where the directory's
owner can differ from the in-container user. Without this, that mount would
turn a lost-settings annoyance into a server that will not boot.

## Tested

- Ran the binary with `HOME` pointed at a read-only `Application Support`:
  warns as above, starts, serves `/signalk`, radar runs.
- New unit tests: a missing config directory is created on first run; an
  unusable one disables persistence rather than failing. The second blocks
  the path with a plain file instead of chmod, so it holds as root in CI.
- `cargo test`, `cargo clippy --no-deps --all-targets -- -D warnings`,
  `cargo fmt --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates configuration persistence to keep the server running when the settings directory cannot be created or written.

- Warns and disables persistence when the configuration path is unusable.
- Continues radar operation without remembering radar names, guard zones, or other settings.
- Adds tests for missing directory creation and blocked configuration paths.
- Validates with `cargo test`, Clippy with warnings denied, and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->