### PR TITLE
feat(telemetry): ask once, then report that this install works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ dependencies = [
  "unicase",
  "utoipa",
  "utoipa-swagger-ui",
+ "uuid",
  "w32-error",
  "wildmatch",
  "windows",
@@ -3552,6 +3553,17 @@ dependencies = [
  "url",
  "utoipa",
  "zip",
+]
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ tower = "0.5.3"
 tower-http = { version = "0.7", features = ["set-header", "trace"] }
 utoipa = { version = "5", features = ["macros", "axum_extras", "chrono", "time", "url", "repr" ] }
 serde_string_enum = "0.2.1"
+uuid = { version = "1", features = ["v4"] }
 unicase = "2.9.0"
 wildmatch = "2.6.1"
 utoipa-swagger-ui = { version = "9.0.2", features = ["url", "axum"] }

--- a/ENDUSER.md
+++ b/ENDUSER.md
@@ -97,6 +97,36 @@ This simulates a radar with moving targets so you can explore the interface.
 
 For the full list of options, run `mayara-server --help` or see [USAGE.md](USAGE.md).
 
+### Anonymous usage stats
+
+The first time you open Mayara's own page it asks one question:
+
+> **Inform developers of successful deploy?**
+
+Say yes and Mayara tells its developers, at most twice, that your radar works:
+once when it first delivers a picture, and once when it first accepts a setting
+you change. That is how we learn which radar models people actually get
+working, and on which computers -- there is no other way for us to find out
+that, say, a Garmin xHD on a Raspberry Pi stopped working in the latest
+release.
+
+A report holds the Mayara version, your operating system, how Mayara was
+installed (as a container, a Signal K plugin, an OpenCPN plugin, or on its
+own), the brand and model of your radar, and a random number that identifies
+this installation so repeat runs are not counted as new users. It never holds your position, your vessel,
+your radar's serial number or any network address.
+
+You are asked **once**; the answer is kept in your settings. Say no and nothing
+is ever sent. If Mayara cannot store its settings (see the warning above), it
+does not ask and does not report -- it could not remember your answer, so it
+does not pretend to.
+
+If you use Mayara through Signal K and never open Mayara's own page, you are
+never asked and nothing is sent. Whoever packages Mayara can answer for their
+users by setting `MAYARA_TELEMETRY=true` or `MAYARA_TELEMETRY=false`; with
+either set, the question is not asked. `--no-telemetry` on the command line
+also keeps Mayara quiet.
+
 ### Docker
 
 For more technically oriented users, Mayara is also available as a Docker image:

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,6 +137,34 @@ the server to accept IP-based SNI or point Mayara at an on-LAN instance.
 | `--output`      | Write RadarMessage protobuf data to stdout |
 | `--openapi`     | Output OpenAPI specification and exit      |
 
+### Anonymous Usage Stats
+
+The GUI asks once whether to report that this install works. On a yes, mayara
+sends at most two small reports per run: one when a radar first delivers data,
+one when a radar first accepts a control change. Each holds the mayara version,
+operating system, radar brand and model, and a random install id -- never a
+position, serial number or network address. Reports go to
+`https://telemetry.keversoft.com/mayara/v1/event`. See
+[ENDUSER.md](ENDUSER.md#anonymous-usage-stats).
+
+The answer lives in the settings file, so a run that cannot store its settings
+never asks and never reports.
+
+`MAYARA_DEPLOYMENT` tells us how mayara reached the boat, which is the
+difference between "nobody runs Garmin radars" and "nobody runs Garmin radars
+*in the container*". Whoever packages mayara sets it: `container` (set by the
+official image), `signalk-server-plugin`, or `mayara_pi`. Any other short label
+is passed through. Unset, mayara reports `embedded` when a parent process
+supervises it and `standalone` otherwise.
+
+| Option / variable            | Description                                        |
+| ---------------------------- | -------------------------------------------------- |
+| `--no-telemetry`             | Never ask, never send                              |
+| `MAYARA_TELEMETRY=false`     | Same, for containers and service units             |
+| `MAYARA_TELEMETRY=true`      | Answer yes for the user; the GUI does not ask      |
+| `MAYARA_TELEMETRY_URL=<url>` | Send to your own collector instead                 |
+| `MAYARA_DEPLOYMENT=<id>`     | How mayara was installed (see below)               |
+
 ## Examples
 
 ### Basic yacht installation

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,11 @@ LABEL org.opencontainers.image.license="Apache-2.0"
 RUN apk add --no-cache tini \
     && adduser -D -h /home/mayara mayara
 COPY --from=builder /usr/src/mayara-server/target/release/mayara-server /usr/local/bin/mayara-server
+# Names this deployment in the usage stats a user may agree to send, so a
+# container install is not counted as someone running the binary by hand.
+# A packager that builds on this image overrides it (the Signal K plugin
+# passes signalk-server-plugin).
+ENV MAYARA_DEPLOYMENT=container
 USER mayara
 EXPOSE 6502
 # Probe the always-served, unauthenticated discovery doc so the container

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -33,6 +33,8 @@ mayara-server --openapi
 | GET    | `/signalk/v2/api/vessels/self/radars`                        | List all detected radars                           |
 | GET    | `/signalk/v2/api/vessels/self/radars/interfaces`             | List network interfaces and radar discovery status |
 | GET    | `/signalk/v2/api/vessels/self/radars/diagnostics`            | Download a gzipped JSON network diagnostics snapshot |
+| GET    | `/signalk/v2/api/vessels/self/radars/telemetry`              | Whether to ask the user about anonymous usage reports |
+| PUT    | `/signalk/v2/api/vessels/self/radars/telemetry`              | Store the user's answer to that question |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/capabilities`      | Get radar capabilities and legend                  |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/controls`          | Get all control values                             |
 | PUT    | `/signalk/v2/api/vessels/self/radars/{id}/controls`          | Set several control values in one request          |

--- a/src/bin/mayara-server/web/mod.rs
+++ b/src/bin/mayara-server/web/mod.rs
@@ -129,6 +129,10 @@ impl Web {
         let tls = args.tls_cert.is_some() && args.tls_key.is_some();
         let (radars, tx_interface_request) = start_session(subsys, args.clone()).await;
 
+        // Needs the radars: the answer to the telemetry question lives in the
+        // settings file they own.
+        mayara::telemetry::init(&args, &radars);
+
         Web {
             radars,
             args,

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -28,6 +28,7 @@ use crate::web::{signalk::diagnostics, spokes_handler};
 use super::super::{Message, Web, WebSocket, WebSocketUpgrade};
 use mayara::{
     InterfaceApi,
+    config::Consent,
     config::SettingsStorage,
     navdata,
     radar::{
@@ -36,6 +37,7 @@ use mayara::{
         target::{ArpaTargetApi, MarpaRequest, TrackerCommand},
     },
     stream::{ActiveSubscriptions, Desubscription, SignalKDelta, Subscribe, Subscription},
+    telemetry::{self, RadarIdentity},
 };
 
 const PROVIDER: &str = mayara::PACKAGE;
@@ -48,6 +50,7 @@ const RADAR_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}";
 const RADAR_CAPABILITIES_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/capabilities";
 const INTERFACES_URI: &str = "/signalk/v2/api/vessels/self/radars/interfaces";
 const STATUS_URI: &str = "/signalk/v2/api/vessels/self/radars/status";
+const TELEMETRY_URI: &str = "/signalk/v2/api/vessels/self/radars/telemetry";
 const RADAR_CONTROLS_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/controls";
 const RADAR_CONTROL_URI: &str =
     "/signalk/v2/api/vessels/self/radars/{radar_id}/controls/{control_id}";
@@ -79,6 +82,8 @@ const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
         get_radar_info,
         get_interfaces,
         get_status,
+        get_telemetry,
+        set_telemetry,
         diagnostics::get_diagnostics,
         get_radar,
         get_control_values,
@@ -95,6 +100,8 @@ const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
         RadarApiV3,
         RadarsResponse,
         ServerStatus,
+        TelemetryState,
+        TelemetryConsentRequest,
         Capabilities,
         BareControlValue,
         // Target types
@@ -114,6 +121,7 @@ pub(crate) fn routes(axum: axum::Router<Web>) -> axum::Router<Web> {
     axum.route(BASE_URI, get(get_radars))
         .route(INTERFACES_URI, get(get_interfaces))
         .route(STATUS_URI, get(get_status))
+        .route(TELEMETRY_URI, get(get_telemetry).put(set_telemetry))
         .route(
             diagnostics::DIAGNOSTICS_URI,
             get(diagnostics::get_diagnostics),
@@ -387,6 +395,34 @@ impl From<SettingsStorage> for ServerStatus {
     }
 }
 
+/// Whether the GUI should ask the user about reporting that this install
+/// works, and what they answered.
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TelemetryState {
+    /// `unasked` -- put the question to the user, once. `granted` / `denied`
+    /// -- they have answered, or a packager answered for them. `unavailable`
+    /// -- this run may not report at all, so never ask.
+    #[schema(example = "unasked")]
+    consent: &'static str,
+}
+
+/// The user's answer.
+#[derive(Deserialize, ToSchema)]
+struct TelemetryConsentRequest {
+    /// True to report that this install works, false to keep quiet.
+    consent: bool,
+}
+
+fn consent_name(consent: Consent) -> &'static str {
+    match consent {
+        Consent::Unavailable => "unavailable",
+        Consent::Unasked => "unasked",
+        Consent::Granted => "granted",
+        Consent::Denied => "denied",
+    }
+}
+
 #[utoipa::path(
     get,
     path = "/signalk/v2/api/vessels/self/radars/status",
@@ -400,6 +436,45 @@ impl From<SettingsStorage> for ServerStatus {
 )]
 async fn get_status(State(state): State<Web>) -> Response {
     Json(ServerStatus::from(state.radars.settings_storage())).into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/signalk/v2/api/vessels/self/radars/telemetry",
+    summary = "Whether to ask about anonymous usage reports",
+    description = "Mayara can report, twice per run at most, that a radar delivered data and \
+                   accepted a control change -- version, OS, radar brand and model, and a \
+                   random install id. It asks first. `unasked` means the GUI should put the \
+                   question; `unavailable` means this run may not report and must not ask.",
+    responses((status = 200, body = TelemetryState, description = "Consent state")),
+    tag = "Radars"
+)]
+async fn get_telemetry() -> Response {
+    Json(TelemetryState {
+        consent: consent_name(telemetry::consent()),
+    })
+    .into_response()
+}
+
+#[utoipa::path(
+    put,
+    path = "/signalk/v2/api/vessels/self/radars/telemetry",
+    summary = "Answer the usage-report question",
+    description = "Stores the user's answer in the settings file, so they are asked once. \
+                   Ignored when this run may not report, or when the operator already \
+                   answered through the MAYARA_TELEMETRY environment variable.",
+    request_body(content = TelemetryConsentRequest, example = json!({"consent": true})),
+    responses((status = 200, body = TelemetryState, description = "Consent state after the answer")),
+    tag = "Radars"
+)]
+async fn set_telemetry(SignalKJson(request): SignalKJson<TelemetryConsentRequest>) -> Response {
+    let consent = telemetry::set_consent(request.consent);
+    log::info!("Usage stats consent set to {}", consent_name(consent));
+
+    Json(TelemetryState {
+        consent: consent_name(consent),
+    })
+    .into_response()
 }
 
 #[utoipa::path(
@@ -662,7 +737,7 @@ async fn set_control_value(
     );
 
     // Get the radar info and control without holding the lock across await
-    let (controls, control_value, radar_key) = {
+    let (controls, control_value, radar_key, radar_identity) = {
         match state.radars.get_by_key(&radar_id) {
             Some(radar) => {
                 // Any control PUT means someone is interacting with this
@@ -684,7 +759,12 @@ async fn set_control_value(
 
                 let control_value = ControlValue::from_request(control.item().control_id, request);
                 log::debug!("Map request to controlValue {:?}", control_value);
-                (radar.controls.clone(), control_value, radar.key())
+                (
+                    radar.controls.clone(),
+                    control_value,
+                    radar.key(),
+                    RadarIdentity::from(&radar),
+                )
             }
             None => {
                 return no_such_radar(&radar_id, &state.radars);
@@ -698,6 +778,7 @@ async fn set_control_value(
 
     // Check if this control should trigger persistence save
     let needs_persistence = control_needs_persistence(control_value.id);
+    let control_name = control_value.id.to_string();
 
     // Send the control request
     if let Err(e) = controls.process_client_request(control_value, reply_tx) {
@@ -724,6 +805,11 @@ async fn set_control_value(
             // No error reply within timeout, assume success
         }
     }
+
+    // The canonical control name, not the spelling the caller happened to
+    // use: the path match is case-insensitive, and every control path has to
+    // report the same name for the same control.
+    telemetry::note_control_ok(&control_name, radar_identity);
 
     SignalKResponse::ok()
 }
@@ -1164,7 +1250,7 @@ async fn set_control_values(
     log::info!("PUT {} controls for radar {}", request.len(), radar_id);
 
     // Resolve everything up front so the radar lock is not held across an await.
-    let (controls, resolved, radar_key) = {
+    let (controls, resolved, radar_key, radar_identity) = {
         match state.radars.get_by_key(&radar_id) {
             Some(radar) => {
                 // Any control PUT means someone is interacting with this radar
@@ -1206,7 +1292,12 @@ async fn set_control_values(
                         format!("Control(s) {:?} named more than once", duplicates),
                     );
                 }
-                (radar.controls.clone(), resolved, radar.key())
+                (
+                    radar.controls.clone(),
+                    resolved,
+                    radar.key(),
+                    RadarIdentity::from(&radar),
+                )
             }
             None => {
                 return no_such_radar(&radar_id, &state.radars);
@@ -1215,6 +1306,11 @@ async fn set_control_values(
     };
 
     let needs_persistence = resolved.iter().any(|cv| control_needs_persistence(cv.id));
+    // One name stands for the batch; the first is the one the caller led with.
+    let accepted = resolved
+        .first()
+        .map(|cv| cv.id.to_string())
+        .unwrap_or_default();
 
     let mut failures: Vec<String> = Vec::new();
     for control_value in resolved {
@@ -1245,6 +1341,7 @@ async fn set_control_values(
     }
 
     if failures.is_empty() {
+        telemetry::note_control_ok(&accepted, radar_identity);
         SignalKResponse::ok()
     } else {
         failures.sort();
@@ -1872,6 +1969,13 @@ async fn handle_control_request(
             let result = radar
                 .controls
                 .process_client_request(control_value.clone(), reply_tx);
+
+            if result.is_ok() {
+                telemetry::note_control_ok(
+                    &control_value.id.to_string(),
+                    RadarIdentity::from(&radar),
+                );
+            }
 
             // Save persistence for controls that need it
             if result.is_ok()

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -94,9 +94,39 @@ pub(crate) struct Radar {
     pub doppler_auto_track: bool,
 }
 
+/// Where the answer to the telemetry question lives, so the user is asked
+/// once and never again. A run that cannot store settings cannot remember an
+/// answer either, and so never asks and never reports.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub(crate) struct TelemetryConfig {
+    /// Random id for this install, created when consent is first given so
+    /// repeat runs are not counted as separate installs. Never derived from
+    /// anything about the boat, the radar or the network.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_id: Option<String>,
+    /// `None` until the user has answered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consent: Option<bool>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub(crate) struct Config {
     pub radars: HashMap<String, Radar>,
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
+}
+
+/// What the server may do about telemetry, and whether the GUI should put the
+/// question to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Consent {
+    /// Settings are not being stored, so an answer could not be remembered.
+    /// Never ask, never report.
+    Unavailable,
+    /// The user has not answered yet.
+    Unasked,
+    Granted,
+    Denied,
 }
 
 #[derive(Debug, Clone)]
@@ -107,6 +137,10 @@ pub(crate) struct Persistence {
     /// The settings file this run wanted but cannot write. `None` when
     /// settings are stored, and when a replay run wants none.
     unwritable: Option<PathBuf>,
+    /// Set when an answer to the telemetry question could not be written.
+    /// The stored answer no longer matches what the user asked for, so this
+    /// run neither reports nor asks again.
+    consent_unwritable: bool,
 }
 
 const SETTINGS_FILE: &str = "settings.json";
@@ -161,10 +195,12 @@ impl Persistence {
         Persistence {
             config: Config {
                 radars: HashMap::new(),
+                telemetry: TelemetryConfig::default(),
             },
             timestamp: SystemTime::UNIX_EPOCH,
             path: PathBuf::new(),
             unwritable,
+            consent_unwritable: false,
         }
     }
 
@@ -190,10 +226,12 @@ impl Persistence {
         let mut this = Persistence {
             config: Config {
                 radars: HashMap::new(),
+                telemetry: TelemetryConfig::default(),
             },
             timestamp: SystemTime::UNIX_EPOCH,
             path: settings_path,
             unwritable: None,
+            consent_unwritable: false,
         };
 
         match this.load() {
@@ -221,6 +259,7 @@ impl Persistence {
             timestamp: self.timestamp,
             unwritable: Some(self.path),
             path: PathBuf::new(),
+            consent_unwritable: self.consent_unwritable,
         }
     }
 
@@ -328,6 +367,70 @@ impl Persistence {
             }
             Ok(()) => true,
         }
+    }
+
+    /// Whether this run can remember anything at all.
+    fn is_storing(&self) -> bool {
+        matches!(self.storage(), SettingsStorage::Stored(_))
+    }
+
+    pub(crate) fn consent(&self) -> Consent {
+        if !self.is_storing() || self.consent_unwritable {
+            return Consent::Unavailable;
+        }
+        match self.config.telemetry.consent {
+            None => Consent::Unasked,
+            Some(true) => Consent::Granted,
+            Some(false) => Consent::Denied,
+        }
+    }
+
+    /// Record the user's answer. Withdrawing consent drops the install id, so
+    /// a later yes is a new install rather than the old one resurfacing.
+    ///
+    /// An answer that cannot be written is not an answer: the file still
+    /// holds the previous one, which a restart would restore -- turning a
+    /// withdrawn consent back into a granted one behind the user's back. So a
+    /// failed write puts this run in the same place as having no settings
+    /// file at all: nothing is reported, and nothing more is asked.
+    pub(crate) fn set_consent(&mut self, granted: bool) -> Consent {
+        if !self.is_storing() || self.consent_unwritable {
+            return Consent::Unavailable;
+        }
+
+        let previous = self.config.telemetry.clone();
+        self.config.telemetry.consent = Some(granted);
+        if !granted {
+            self.config.telemetry.install_id = None;
+        }
+
+        if !self.save() {
+            self.config.telemetry = previous;
+            self.consent_unwritable = true;
+            return Consent::Unavailable;
+        }
+
+        self.consent()
+    }
+
+    /// The id this install reports under, created on first use. Only ever
+    /// called once reporting is allowed, so creating one here is not a
+    /// decision about whether to report -- that has already been made.
+    pub(crate) fn ensure_install_id(&mut self) -> Option<String> {
+        if self.consent() == Consent::Unavailable {
+            return None;
+        }
+
+        if self.config.telemetry.install_id.is_none() {
+            self.config.telemetry.install_id = Some(uuid::Uuid::new_v4().to_string());
+            // An id that cannot be stored would be a fresh one on every
+            // start, counting one install many times over.
+            if !self.save() {
+                self.config.telemetry.install_id = None;
+                return None;
+            }
+        }
+        self.config.telemetry.install_id.clone()
     }
 
     pub(crate) fn store(&mut self, radar_info: &RadarInfo) {
@@ -567,7 +670,10 @@ mod tests {
             },
         );
         Persistence {
-            config: Config { radars },
+            config: Config {
+                radars,
+                ..Config::default()
+            },
             ..Persistence::disabled(None)
         }
     }
@@ -614,6 +720,78 @@ mod tests {
             p.config.radars.get("kod3456").map(|r| r.user_name.as_str()),
             Some("Current Name")
         );
+    }
+
+    /// The question is only ever put to a user whose answer can be kept.
+    #[test]
+    fn a_run_that_stores_nothing_is_never_asked() {
+        let mut p = Persistence::disabled(None);
+
+        assert_eq!(p.consent(), Consent::Unavailable);
+        assert_eq!(p.set_consent(true), Consent::Unavailable);
+        assert_eq!(p.ensure_install_id(), None);
+    }
+
+    /// The answer and the id outlive the run that produced them, which is the
+    /// whole reason the question is asked only once.
+    #[test]
+    fn consent_and_install_id_are_written_to_the_settings_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+
+        let mut p = persistence_at(path.clone());
+        assert_eq!(p.consent(), Consent::Unasked);
+        assert_eq!(p.set_consent(true), Consent::Granted);
+
+        let id = p.ensure_install_id().expect("consent means an id");
+        assert!(uuid::Uuid::parse_str(&id).is_ok());
+        assert_eq!(p.ensure_install_id(), Some(id.clone()), "id is stable");
+
+        let saved: Config = serde_json::from_reader(File::open(&path).unwrap()).unwrap();
+        assert_eq!(saved.telemetry.consent, Some(true));
+        assert_eq!(saved.telemetry.install_id, Some(id));
+    }
+
+    /// An answer that cannot be written is worse than no answer: the file
+    /// still holds the previous one, so a restart would restore it -- turning
+    /// a withdrawn consent back into a granted one. The run must then behave
+    /// as if it could store nothing at all.
+    #[test]
+    fn an_answer_that_cannot_be_written_is_not_acknowledged() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut p = persistence_at(dir.path().join("settings.json"));
+        p.set_consent(true);
+        assert_eq!(p.consent(), Consent::Granted);
+
+        // Take the file away from under it: the parent is now a plain file,
+        // which no user can write through.
+        let blocked = dir.path().join("blocker");
+        fs::write(&blocked, b"not a directory").unwrap();
+        p.path = blocked.join("settings.json");
+
+        assert_eq!(p.set_consent(false), Consent::Unavailable);
+        assert_eq!(
+            p.consent(),
+            Consent::Unavailable,
+            "a run that cannot record the answer must not keep reporting under the old one"
+        );
+        assert_eq!(p.ensure_install_id(), None);
+    }
+
+    /// Saying no drops the id, so a later yes counts as a new install rather
+    /// than resurrecting the old one.
+    #[test]
+    fn declining_forgets_the_install_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut p = persistence_at(dir.path().join("settings.json"));
+
+        p.set_consent(true);
+        let first = p.ensure_install_id().unwrap();
+        assert_eq!(p.set_consent(false), Consent::Denied);
+        assert_eq!(p.config.telemetry.install_id, None);
+
+        p.set_consent(true);
+        assert_ne!(p.ensure_install_id().unwrap(), first);
     }
 
     /// Brands that never had an identity key on their address as before,

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -31,6 +31,7 @@ pub mod recording;
 pub mod replay;
 pub mod signalk;
 pub mod stream;
+pub mod telemetry;
 pub mod util;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -205,6 +206,15 @@ pub struct Cli {
     /// the loser is renamed.
     #[arg(long, value_name = "NAME", conflicts_with = "no_mdns")]
     pub mdns_hostname: Option<String>,
+
+    /// Never ask about, or send, anonymous usage stats. Mayara otherwise asks
+    /// once in the GUI whether it may report that a radar delivered data and
+    /// accepted a control change -- the mayara version, operating system,
+    /// radar brand and model, and a random id for this install. Never a
+    /// position, serial number or network address. `MAYARA_TELEMETRY=false`
+    /// does the same; `MAYARA_TELEMETRY=true` answers yes without asking.
+    #[arg(long, default_value_t = false)]
+    pub no_telemetry: bool,
 
     /// Do not advertise on mDNS at all: no service and no host name, so
     /// `<name>.local` will not resolve to mayara and clients must be given its

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -33,7 +33,7 @@ pub mod trail;
 pub(crate) mod units;
 
 use crate::brand::CommandSender;
-use crate::config::{Persistence, SettingsStorage};
+use crate::config::{Consent, Persistence, SettingsStorage};
 use crate::protos::RadarMessage::RadarMessage;
 use crate::radar::settings::{
     ControlDestination, ControlError, ControlId, ControlUpdate, ControlValue, SharedControls,
@@ -757,6 +757,8 @@ impl RadarInfo {
     }
 
     pub(super) fn broadcast_radar_message(&self, message: RadarMessage) {
+        crate::telemetry::note_spokes(self);
+
         // write_to_bytes() pre-sizes the Vec via compute_size(), avoiding the
         // ~16 doublings a fresh Vec::new() would do for a ~40 KB serialized
         // batch of spokes (the dominant per-frame allocator churn).
@@ -915,6 +917,7 @@ impl SharedRadars {
                 new_info.ranges.len()
             );
             radars.info.insert(key, new_info.clone());
+            crate::telemetry::note_radar_found();
             Some(new_info)
         } else {
             None
@@ -925,6 +928,31 @@ impl SharedRadars {
     /// the warning a connecting client is sent.
     pub fn settings_storage(&self) -> SettingsStorage {
         self.radars.read().unwrap().persistent_data.storage()
+    }
+
+    /// Whether the user has agreed to report that this install works, and
+    /// whether the question can be put to them at all.
+    pub fn telemetry_consent(&self) -> Consent {
+        self.radars.read().unwrap().persistent_data.consent()
+    }
+
+    /// Record the user's answer to the telemetry question.
+    pub fn set_telemetry_consent(&self, granted: bool) -> Consent {
+        self.radars
+            .write()
+            .unwrap()
+            .persistent_data
+            .set_consent(granted)
+    }
+
+    /// The id this install reports under, created on first use. Called only
+    /// once reporting is already allowed.
+    pub(crate) fn telemetry_install_id(&self) -> Option<String> {
+        self.radars
+            .write()
+            .unwrap()
+            .persistent_data
+            .ensure_install_id()
     }
 
     ///

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -1,0 +1,566 @@
+//! Anonymous "it works" reports.
+//!
+//! Mayara sends at most two small reports per run: one when a radar first
+//! delivers spoke data, and one when the first control change the user made is
+//! accepted. Together they answer the only question the reports exist for --
+//! "does this build, on this platform, actually drive this radar?"
+//!
+//! Nothing is sent until the user says yes. The GUI asks once, and the answer
+//! is kept in the settings file -- which means a run that cannot store its
+//! settings never asks and never reports, because it could not remember the
+//! answer and would ask again on every start. `--no-telemetry` and
+//! `MAYARA_TELEMETRY=false` keep the question from being asked at all;
+//! `MAYARA_TELEMETRY=true` answers it, so a packager that owns the
+//! deployment can decide for its users.
+//!
+//! No position, no serial number, no network address and no vessel data is
+//! ever included: the only identifier is a random UUID created when consent is
+//! given, so repeat runs of one install are not counted as many.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use log::{debug, info};
+use serde::Serialize;
+
+use crate::config::Consent;
+use crate::radar::{RadarInfo, SharedRadars};
+use crate::{Brand, Cli, VERSION};
+
+/// Collector that receives the reports. Set `MAYARA_TELEMETRY_URL` to send a
+/// run's reports somewhere else; setting it empty stops them entirely.
+const DEFAULT_ENDPOINT: &str = "https://telemetry.keversoft.com/mayara/v1/event";
+
+const ENV_URL: &str = "MAYARA_TELEMETRY_URL";
+/// `false` keeps reporting off and the question unasked; `true` answers the
+/// question on the user's behalf, so the GUI never puts it to them. Unset
+/// leaves it to the user. This is how a packager that owns the deployment --
+/// the Signal K plugin, a container image -- decides for its users.
+const ENV_TELEMETRY: &str = "MAYARA_TELEMETRY";
+/// How mayara was installed, set by whoever packaged it. The values mayara
+/// itself ships with are `container`, `signalk-server-plugin` and
+/// `mayara_pi`; anything else is passed through, so a packager can label
+/// itself without waiting for a mayara release.
+const ENV_DEPLOYMENT: &str = "MAYARA_DEPLOYMENT";
+
+/// A report is a courtesy, never a reason to keep a socket open; one attempt,
+/// then give up until the next run.
+const SEND_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Longest accepted `MAYARA_DEPLOYMENT` value, so a stray environment
+/// variable cannot turn a report into a payload of arbitrary size.
+const MAX_DEPLOYMENT_LEN: usize = 32;
+
+const EVENT_SPOKES: &str = "spokes";
+const EVENT_CONTROL: &str = "control";
+
+/// What kind of radar the report is about. Cheap to build, so a caller can
+/// snapshot it while it holds a `RadarInfo` and report later.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RadarIdentity {
+    brand: Brand,
+    model: Option<String>,
+    dual_range: bool,
+}
+
+impl From<&RadarInfo> for RadarIdentity {
+    fn from(info: &RadarInfo) -> Self {
+        RadarIdentity {
+            brand: info.brand,
+            model: info.controls.model_name(),
+            dual_range: info.dual_range,
+        }
+    }
+}
+
+/// Emulated and recorded radars say nothing about real hardware working.
+fn is_real_radar(brand: Brand) -> bool {
+    !matches!(brand, Brand::Emulator | Brand::Playback)
+}
+
+/// Whether this caller gets to send the milestone `flag` stands for. Consent
+/// is checked before the flag is spent, so a milestone that passes while the
+/// user has not answered yet still reports once they say yes.
+fn claim_with(consent: Consent, flag: &AtomicBool, brand: Brand) -> bool {
+    consent == Consent::Granted && claim_once(flag, brand)
+}
+
+/// Claim a milestone for the one caller that gets to report it.
+fn claim_once(flag: &AtomicBool, brand: Brand) -> bool {
+    !flag.load(Ordering::Relaxed) && is_real_radar(brand) && !flag.swap(true, Ordering::Relaxed)
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+struct Report<'a> {
+    install: &'a str,
+    version: &'static str,
+    os: &'static str,
+    arch: &'static str,
+    deployment: &'a str,
+    event: &'static str,
+    brand: Brand,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<&'a str>,
+    radars: usize,
+    dual_range: bool,
+    features: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    secs_to_first_spoke: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    control: Option<&'a str>,
+}
+
+struct Telemetry {
+    endpoint: String,
+    /// Cheap to clone (an `Arc` inside), and the only route to the settings
+    /// file where the user's answer and the install id live.
+    radars: SharedRadars,
+    deployment: String,
+    /// A packager answered through the environment: report, and never ask.
+    forced: bool,
+    start: Instant,
+    radar_count: AtomicUsize,
+    spokes_reported: AtomicBool,
+    control_reported: AtomicBool,
+}
+
+static TELEMETRY: OnceLock<Telemetry> = OnceLock::new();
+
+fn active() -> Option<&'static Telemetry> {
+    TELEMETRY.get()
+}
+
+/// Decide whether this run may report at all, and whether the user still has
+/// to be asked. Everything else in this module is inert until this has run.
+pub fn init(args: &Cli, radars: &SharedRadars) {
+    let forced = match env_telemetry() {
+        Some(false) => {
+            info!("Usage stats are off ({ENV_TELEMETRY}=false); the GUI will not ask");
+            return;
+        }
+        Some(true) => true,
+        None => false,
+    };
+    if args.no_telemetry {
+        info!("Usage stats are off (--no-telemetry); the GUI will not ask");
+        return;
+    }
+    if args.is_replay() {
+        debug!("Usage stats are off in replay mode");
+        return;
+    }
+
+    let endpoint = std::env::var(ENV_URL).unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string());
+    if endpoint.is_empty() {
+        debug!("Usage stats have no collector configured");
+        return;
+    }
+
+    // Without a settings file there is nowhere to keep the answer, so the
+    // question would come back on every start and the install would be
+    // counted afresh every time. Say nothing and report nothing.
+    if radars.telemetry_consent() == Consent::Unavailable {
+        info!("Usage stats are off: this run cannot store an answer to the question");
+        return;
+    }
+
+    let _ = TELEMETRY.set(Telemetry {
+        endpoint,
+        radars: radars.clone(),
+        deployment: deployment(args),
+        forced,
+        start: Instant::now(),
+        radar_count: AtomicUsize::new(0),
+        spokes_reported: AtomicBool::new(false),
+        control_reported: AtomicBool::new(false),
+    });
+
+    match consent() {
+        Consent::Granted if forced => {
+            info!("Usage stats are on ({ENV_TELEMETRY}=true); the GUI will not ask")
+        }
+        Consent::Granted => info!("Usage stats are on; the user agreed"),
+        Consent::Denied => info!("Usage stats are off; the user declined"),
+        _ => info!("Usage stats: the GUI will ask once whether to report that this works"),
+    }
+}
+
+/// `MAYARA_TELEMETRY` as a decision, ignoring anything that is not a plain
+/// yes or no.
+fn env_telemetry() -> Option<bool> {
+    parse_telemetry_setting(&std::env::var(ENV_TELEMETRY).ok()?)
+}
+
+fn parse_telemetry_setting(value: &str) -> Option<bool> {
+    match value.trim().to_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        other => {
+            info!("Ignoring {ENV_TELEMETRY}='{other}': expected true or false");
+            None
+        }
+    }
+}
+
+/// What the GUI should do about the question. `Unavailable` when this run may
+/// not report at all, in which case the question is never put to the user.
+pub fn consent() -> Consent {
+    match active() {
+        None => Consent::Unavailable,
+        Some(t) if t.forced => Consent::Granted,
+        Some(t) => t.radars.telemetry_consent(),
+    }
+}
+
+/// Record the user's answer. Refused when this run may not report, or when a
+/// packager already answered through the environment.
+pub fn set_consent(granted: bool) -> Consent {
+    match active() {
+        None => Consent::Unavailable,
+        Some(t) if t.forced => Consent::Granted,
+        Some(t) => t.radars.set_telemetry_consent(granted),
+    }
+}
+
+/// A radar was discovered. Only the count is reported.
+pub fn note_radar_found() {
+    if let Some(t) = active() {
+        t.radar_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// A radar delivered spoke data. Called per broadcast frame, so the common
+/// path is a single relaxed load.
+pub fn note_spokes(info: &RadarInfo) {
+    if let Some(t) = active()
+        && t.claim(&t.spokes_reported, info.brand)
+    {
+        let secs = t.start.elapsed().as_secs();
+        t.send(EVENT_SPOKES, RadarIdentity::from(info), Some(secs), None);
+    }
+}
+
+/// A radar accepted a control change made by the user.
+pub fn note_control_ok(control_id: &str, identity: RadarIdentity) {
+    if let Some(t) = active()
+        && t.claim(&t.control_reported, identity.brand)
+    {
+        t.send(EVENT_CONTROL, identity, None, Some(control_id.to_owned()));
+    }
+}
+
+impl Telemetry {
+    /// Whether this caller is the one that gets to send `flag`'s report.
+    /// Consent is checked first, so a milestone that passes while the user
+    /// has not answered yet is not spent: it reports on the next one after
+    /// they say yes.
+    fn claim(&self, flag: &AtomicBool, brand: Brand) -> bool {
+        claim_with(consent(), flag, brand)
+    }
+
+    fn report<'a>(
+        &'a self,
+        install: &'a str,
+        event: &'static str,
+        identity: &'a RadarIdentity,
+        secs_to_first_spoke: Option<u64>,
+        control: Option<&'a str>,
+    ) -> Report<'a> {
+        Report {
+            install,
+            version: VERSION,
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            deployment: &self.deployment,
+            event,
+            brand: identity.brand,
+            model: identity.model.as_deref(),
+            radars: self.radar_count.load(Ordering::Relaxed).max(1),
+            dual_range: identity.dual_range,
+            features: features(),
+            secs_to_first_spoke,
+            control,
+        }
+    }
+
+    fn send(
+        &'static self,
+        event: &'static str,
+        identity: RadarIdentity,
+        secs_to_first_spoke: Option<u64>,
+        control: Option<String>,
+    ) {
+        let Some(install) = self.radars.telemetry_install_id() else {
+            return;
+        };
+        let body = serde_json::to_string(&self.report(
+            &install,
+            event,
+            &identity,
+            secs_to_first_spoke,
+            control.as_deref(),
+        ))
+        .expect("Cannot serialize telemetry report");
+        let endpoint = self.endpoint.clone();
+
+        tokio::spawn(async move {
+            let result = reqwest::Client::new()
+                .post(&endpoint)
+                .timeout(SEND_TIMEOUT)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(body)
+                .send()
+                .await;
+            match result {
+                Ok(response) => debug!("Usage stats '{}' sent: {}", event, response.status()),
+                Err(e) => debug!("Usage stats '{}' not sent: {}", event, e),
+            }
+        });
+    }
+}
+
+/// Which radar brands this binary was built with -- a report from a build
+/// without a brand compiled in says nothing about that brand.
+fn features() -> Vec<&'static str> {
+    let mut features = Vec::new();
+    for (name, enabled) in [
+        ("navico", cfg!(feature = "navico")),
+        ("furuno", cfg!(feature = "furuno")),
+        ("garmin", cfg!(feature = "garmin")),
+        ("koden", cfg!(feature = "koden")),
+        ("raymarine", cfg!(feature = "raymarine")),
+    ] {
+        if enabled {
+            features.push(name);
+        }
+    }
+    features
+}
+
+/// How mayara was installed, for telling a container apart from a Signal K
+/// plugin or an OpenCPN one. Only the packager really knows, so it says so
+/// through `MAYARA_DEPLOYMENT`; failing that, all mayara can tell is whether
+/// some parent process is supervising it.
+fn deployment(args: &Cli) -> String {
+    deployment_from(std::env::var(ENV_DEPLOYMENT).ok().as_deref(), args)
+}
+
+fn deployment_from(label: Option<&str>, args: &Cli) -> String {
+    // A label that sanitizes away to nothing -- `!!!` -- is no label, and
+    // must not be reported as an empty deployment.
+    match label.map(sanitized_deployment).filter(|l| !l.is_empty()) {
+        Some(label) => label,
+        None if args.parent.is_some() => "embedded".to_string(),
+        None => "standalone".to_string(),
+    }
+}
+
+/// Keep the reported value to something that groups cleanly in the
+/// collector: one short word, no whitespace or punctuation to normalise
+/// away later.
+fn sanitized_deployment(value: &str) -> String {
+    value
+        .trim()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(MAX_DEPLOYMENT_LEN)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cli(args: &[&str]) -> Cli {
+        use clap::Parser;
+        Cli::parse_from(std::iter::once("mayara").chain(args.iter().copied()))
+    }
+
+    fn identity() -> RadarIdentity {
+        RadarIdentity {
+            brand: Brand::Navico,
+            model: Some("HALO".to_string()),
+            dual_range: true,
+        }
+    }
+
+    /// The report builder, without the `SharedRadars` a live `Telemetry`
+    /// carries -- these are the fields that go on the wire.
+    fn report<'a>(
+        install: &'a str,
+        identity: &'a RadarIdentity,
+        event: &'static str,
+        secs_to_first_spoke: Option<u64>,
+        control: Option<&'a str>,
+    ) -> Report<'a> {
+        Report {
+            install,
+            version: VERSION,
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            deployment: "standalone",
+            event,
+            brand: identity.brand,
+            model: identity.model.as_deref(),
+            radars: 2,
+            dual_range: identity.dual_range,
+            features: features(),
+            secs_to_first_spoke,
+            control,
+        }
+    }
+
+    const INSTALL: &str = "11111111-2222-3333-4444-555555555555";
+
+    #[test]
+    fn report_holds_only_the_announced_fields() {
+        let identity = identity();
+        let json =
+            serde_json::to_value(report(INSTALL, &identity, EVENT_SPOKES, Some(12), None)).unwrap();
+
+        assert_eq!(json["install"], INSTALL);
+        assert_eq!(json["version"], VERSION);
+        assert_eq!(json["brand"], "Navico");
+        assert_eq!(json["model"], "HALO");
+        assert_eq!(json["dual_range"], true);
+        assert_eq!(json["event"], "spokes");
+        assert_eq!(json["secs_to_first_spoke"], 12);
+
+        // Nothing beyond the fields the question promises.
+        let fields: Vec<&str> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            fields,
+            vec![
+                "arch",
+                "brand",
+                "deployment",
+                "dual_range",
+                "event",
+                "features",
+                "install",
+                "model",
+                "os",
+                "radars",
+                "secs_to_first_spoke",
+                "version"
+            ]
+        );
+    }
+
+    #[test]
+    fn control_report_names_the_control_and_omits_spoke_timing() {
+        let identity = identity();
+        let json = serde_json::to_value(report(
+            INSTALL,
+            &identity,
+            EVENT_CONTROL,
+            None,
+            Some("range"),
+        ))
+        .unwrap();
+
+        assert_eq!(json["event"], "control");
+        assert_eq!(json["control"], "range");
+        assert!(json.get("secs_to_first_spoke").is_none());
+    }
+
+    #[test]
+    fn model_is_omitted_while_the_radar_has_not_reported_one() {
+        let identity = RadarIdentity {
+            brand: Brand::Furuno,
+            model: None,
+            dual_range: false,
+        };
+        let json =
+            serde_json::to_value(report(INSTALL, &identity, EVENT_SPOKES, Some(3), None)).unwrap();
+
+        assert!(json.get("model").is_none());
+    }
+
+    /// Regression: a milestone reached before the user answers must not be
+    /// spent, or a yes would be followed by silence for the rest of the run --
+    /// and nothing may be sent while the question is still open.
+    #[test]
+    fn a_milestone_reached_before_the_answer_is_not_spent() {
+        let spokes = AtomicBool::new(false);
+
+        assert!(!claim_with(Consent::Unasked, &spokes, Brand::Navico));
+        assert!(!claim_with(Consent::Denied, &spokes, Brand::Navico));
+        assert!(!claim_with(Consent::Unavailable, &spokes, Brand::Navico));
+
+        assert!(
+            claim_with(Consent::Granted, &spokes, Brand::Navico),
+            "saying yes must still report the milestone that already passed"
+        );
+        assert!(!claim_with(Consent::Granted, &spokes, Brand::Navico));
+    }
+
+    #[test]
+    fn each_milestone_is_claimed_once() {
+        let spokes = AtomicBool::new(false);
+
+        assert!(claim_once(&spokes, Brand::Navico));
+        assert!(!claim_once(&spokes, Brand::Navico));
+    }
+
+    #[test]
+    fn emulated_and_recorded_radars_are_never_reported() {
+        let spokes = AtomicBool::new(false);
+
+        assert!(!claim_once(&spokes, Brand::Emulator));
+        assert!(!claim_once(&spokes, Brand::Playback));
+        // A real radar in the same run can still report.
+        assert!(claim_once(&spokes, Brand::Navico));
+    }
+
+    /// A packager answers for its users through the environment; anything
+    /// that is not a plain yes or no leaves the question to the user.
+    #[test]
+    fn the_environment_answers_only_when_it_says_so_plainly() {
+        assert_eq!(parse_telemetry_setting("true"), Some(true));
+        assert_eq!(parse_telemetry_setting(" TRUE "), Some(true));
+        assert_eq!(parse_telemetry_setting("false"), Some(false));
+        assert_eq!(parse_telemetry_setting("0"), Some(false));
+        assert_eq!(parse_telemetry_setting("maybe"), None);
+        assert_eq!(parse_telemetry_setting(""), None);
+    }
+
+    /// Without a packager saying so, all mayara knows is whether something
+    /// is supervising it.
+    #[test]
+    fn deployment_falls_back_to_what_mayara_can_see_for_itself() {
+        assert_eq!(deployment_from(None, &cli(&[])), "standalone");
+        assert_eq!(deployment_from(None, &cli(&["--parent", "42"])), "embedded");
+    }
+
+    /// A label that survives nothing of itself must not be reported as an
+    /// empty deployment.
+    #[test]
+    fn a_label_that_sanitizes_away_is_no_label() {
+        assert_eq!(deployment_from(Some("!!!"), &cli(&[])), "standalone");
+        assert_eq!(
+            deployment_from(Some("  "), &cli(&["--parent", "42"])),
+            "embedded"
+        );
+        assert_eq!(deployment_from(Some("container"), &cli(&[])), "container");
+    }
+
+    #[test]
+    fn a_deployment_label_is_reduced_to_one_groupable_word() {
+        assert_eq!(sanitized_deployment("container"), "container");
+        assert_eq!(
+            sanitized_deployment(" signalk-server-plugin\n"),
+            "signalk-server-plugin"
+        );
+        assert_eq!(sanitized_deployment("mayara_pi"), "mayara_pi");
+        assert_eq!(sanitized_deployment("home brew!"), "homebrew");
+        assert_eq!(sanitized_deployment("!!!"), "");
+        assert_eq!(sanitized_deployment(&"x".repeat(64)).len(), 32);
+    }
+}

--- a/tests/replay_furuno.rs
+++ b/tests/replay_furuno.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_furuno_drs2d.rs
+++ b/tests/replay_furuno_drs2d.rs
@@ -43,6 +43,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_furuno_nnd.rs
+++ b/tests/replay_furuno_nnd.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_garmin.rs
+++ b/tests/replay_garmin.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_navico_4g.rs
+++ b/tests/replay_navico_4g.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_navico_br24.rs
+++ b/tests/replay_navico_br24.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_navico_halo20plus.rs
+++ b/tests/replay_navico_halo20plus.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_navico_halo24.rs
+++ b/tests/replay_navico_halo24.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_navico_halo3006.rs
+++ b/tests/replay_navico_halo3006.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_raymarine.rs
+++ b/tests/replay_raymarine.rs
@@ -40,6 +40,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_raymarine_rd418d.rs
+++ b/tests/replay_raymarine_rd418d.rs
@@ -44,6 +44,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/tests/replay_raymarine_rd418hd.rs
+++ b/tests/replay_raymarine_rd418hd.rs
@@ -47,6 +47,7 @@ fn test_args() -> Cli {
         merge_targets: false,
         no_websocket_compression: false,
         mdns_hostname: None,
+        no_telemetry: false,
         no_mdns: true,
         pcap_max_time: None,
     }

--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -212,6 +212,7 @@ export async function fetchRadars() {
 }
 
 /**
+/**
  * Ask the server whether it can store radar settings.
  *
  * Returns null when the answer cannot be had — an older mayara has no such
@@ -230,6 +231,49 @@ export async function fetchServerStatus() {
   } catch (err) {
     console.log("Server status unavailable:", err);
     return null;
+  }
+}
+
+/**
+ * Ask the server whether the usage-report question should be put to the user.
+ *
+ * Returns null when the answer cannot be had — an older mayara has no such
+ * endpoint, and a proxy in front of it may not route one. Either way the
+ * question is simply not asked.
+ *
+ * @returns {Promise<{consent: string}|null>}
+ */
+export async function fetchTelemetryConsent() {
+  await detectMode();
+
+  try {
+    const response = await apiFetch(`${getRadarsPath()}/telemetry`);
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (err) {
+    console.log("Telemetry consent state unavailable:", err);
+    return null;
+  }
+}
+
+/**
+ * Record the user's answer to the usage-report question.
+ * @param {boolean} consent - True to report, false to keep quiet.
+ * @returns {Promise<boolean>} Whether the answer was stored.
+ */
+export async function setTelemetryConsent(consent) {
+  await detectMode();
+
+  try {
+    const response = await apiFetch(`${getRadarsPath()}/telemetry`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ consent }),
+    });
+    return response.ok;
+  } catch (err) {
+    console.error("Failed to store telemetry answer:", err);
+    return false;
   }
 }
 

--- a/web/gui/discovery.css
+++ b/web/gui/discovery.css
@@ -300,6 +300,56 @@
 }
 
 /* ============================================
+   One-time question: report that this works?
+   ============================================ */
+
+.myr_telemetry_ask {
+  display: none;
+  background: linear-gradient(135deg, rgba(40, 90, 140, 0.9), rgba(30, 65, 105, 0.9));
+  border: 1px solid rgba(120, 180, 240, 0.5);
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 25px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.myr_ask_title {
+  font-size: 20px;
+  font-weight: bold;
+  color: #fff;
+  margin-bottom: 12px;
+}
+
+.myr_ask_content {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.myr_ask_buttons {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.myr_ask_buttons button {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  font-size: 15px;
+  cursor: pointer;
+}
+
+.myr_ask_yes {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1e4169;
+  font-weight: bold;
+}
+
+.myr_ask_no {
+  background: rgba(0, 0, 0, 0.25);
+  color: #fff;
+}
+
+/* ============================================
    WebGPU Warning & Error Pages
    ============================================ */
 

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -31,6 +31,9 @@
         <div id="settings_warning" class="myr_settings_warning">
         </div>
 
+        <div id="telemetry_ask" class="myr_telemetry_ask">
+        </div>
+
         <div id="radars" class="myr_discovery_section">
             <div class="myr_detecting">
                 <span class="myr_pulse"></span>

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -6,7 +6,12 @@ import {
   isStandaloneMode,
   detectMode,
   apiFetch,
+<<<<<<< HEAD
   fetchServerStatus,
+=======
+  fetchTelemetryConsent,
+  setTelemetryConsent,
+>>>>>>> b9607de (feat(telemetry): ask once, then report that this install works)
 } from "./api.js";
 import { radarCombinations, multiViewUrl } from "./radar-list.js";
 
@@ -941,6 +946,49 @@ async function showSettingsWarning() {
   );
 }
 
+// Put the usage-report question to the user, once. The server answers
+// "unasked" only while it is able to remember what they say, so a yes or no
+// here is the last time they see this.
+async function askAboutTelemetry() {
+  const state = await fetchTelemetryConsent();
+  if (!state || state.consent !== "unasked") return;
+
+  const box = document.getElementById("telemetry_ask");
+  if (!box) return;
+
+  const answer = async (consent) => {
+    box.style.display = "none";
+    await setTelemetryConsent(consent);
+  };
+
+  box.style.display = "block";
+  box.replaceChildren();
+  van.add(box, div({ class: "myr_ask_title" }, "Inform developers of successful deploy?"));
+  van.add(
+    box,
+    div(
+      { class: "myr_ask_content" },
+      p(
+        "Mayara can tell its developers, at most twice, that your radar works: ",
+        "once when it first delivers a picture and once when it first accepts a ",
+        "setting you change. That is how we learn which radars and which computers ",
+        "people actually get working."
+      ),
+      p(
+        "A report holds the mayara version, your operating system, the brand and ",
+        "model of your radar, and a random number for this installation. ",
+        strong("Never"),
+        " your position, your vessel, your radar's serial number or any network address."
+      ),
+      div(
+        { class: "myr_ask_buttons" },
+        button({ class: "myr_ask_yes", onclick: () => answer(true) }, "Yes, report it"),
+        button({ class: "myr_ask_no", onclick: () => answer(false) }, "No thanks")
+      )
+    )
+  );
+}
+
 async function loadRadars() {
   try {
     const radars = await fetchRadars();
@@ -970,7 +1018,11 @@ window.onload = async function () {
 
   // Load data
   loadRadars();
+<<<<<<< HEAD
   showSettingsWarning();
+=======
+  askAboutTelemetry();
+>>>>>>> b9607de (feat(telemetry): ask once, then report that this install works)
 
   // Hide the interfaces section (now shown via popup)
   const interfacesSection = document.getElementById("interfaces");


### PR DESCRIPTION
## Summary

Nothing currently tells us which radars people actually get working, on what
hardware, or when a release breaks one of them — so a Garmin xHD on a Pi can
stop working for months without us hearing about it.

The first time someone opens mayara's own page it now asks one question:

> **Inform developers of successful deploy?**

On a yes, mayara sends at most two small reports per run: one when a radar
first delivers a picture, one when a radar first accepts a setting the user
changed. A report carries the mayara version, OS/arch, how mayara was
installed, the radar brand and model, the brands compiled in, and a random
install id. Never a position, a vessel, a serial number or a network address.
Emulated and replayed radars are never reported — they say nothing about
hardware. Reports go to `https://telemetry.keversoft.com/mayara/v1/event`.

The answer is kept in `settings.json`, so the question is asked once. That is
also why **a run that cannot store its settings never asks and never reports**:
it could not remember the answer, so it would ask again on every start and
count one install many times.

A packager that owns the deployment decides for its users with
`MAYARA_TELEMETRY=true` / `=false`; either way the question is not asked. That
is how mayara behind Signal K — where the GUI may never be opened — stays
silent unless the plugin says otherwise. `--no-telemetry` also keeps it quiet.

Only the packager knows how mayara reached the boat, so it says so through
`MAYARA_DEPLOYMENT` (`container`, `signalk-server-plugin`, `mayara_pi`, or its
own short label). The image sets `container` for itself. That is the difference
between "nobody runs Garmin radars" and "nobody runs Garmin radars *in the
container*".

## Tested

Against a live server and a stub collector, covering every branch of the
contract: unanswered (silent), yes (both events, one install id), no,
`MAYARA_TELEMETRY=true` (reports, never asks), `MAYARA_TELEMETRY=false`
(overrides a stored yes), an unwritable config dir (silent even with
`MAYARA_TELEMETRY=true`), and a restart under a stored yes (reports without
asking again, same install id). Confirmed `deployment` reaches the wire.

Unit tests cover the report's exact field set, the once-per-run claim, brand
exclusion, the environment parsing, the deployment fallback and sanitiser, and
consent persistence in `settings.json`. One is a regression test for a bug
found during this work: a milestone reached *before* the user answers must not
be spent, or a yes would be followed by silence for the rest of the run.

`cargo test`, `cargo clippy --no-deps --all-targets -- -D warnings`,
`cargo fmt --check`.

## Follow-ups (other repos)

- plugin: pass `MAYARA_DEPLOYMENT=signalk-server-plugin` in its container env.
- `mayara_pi`: set its own label where it spawns mayara.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds opt-in anonymous telemetry for successful radar deployments.

- Prompts users once for consent and persists the choice in `settings.json`.
- Supports `MAYARA_TELEMETRY`, `--no-telemetry`, `MAYARA_DEPLOYMENT`, and deployment labels in Docker.
- Sends at most two reports per run:
  - When a physical radar first delivers picture data.
  - When a physical radar first accepts a user control change.
- Reports version, platform, deployment method, radar identity, compiled radar brands, and a random install ID.
- Excludes positions, vessel data, serial numbers, and network addresses.
- Excludes emulated and replayed radars.
- Adds GUI consent controls, API endpoints, persistence logic, telemetry hooks, documentation, and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->