### PR TITLE
feat(config): warn when radar settings are not being saved

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -27,7 +27,9 @@ use crate::web::{signalk::diagnostics, spokes_handler};
 
 use super::super::{Message, Web, WebSocket, WebSocketUpgrade};
 use mayara::{
-    InterfaceApi, navdata,
+    InterfaceApi,
+    config::SettingsStorage,
+    navdata,
     radar::{
         GeoPosition, Legend, RadarError, RadarInfo, SharedRadars,
         settings::{BareControlValue, Control, ControlId, ControlValue, RadarControlValue},
@@ -45,6 +47,7 @@ const OPENAPI_URI: &str = "/signalk/v2/api/vessels/self/radars/resources/openapi
 const RADAR_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}";
 const RADAR_CAPABILITIES_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/capabilities";
 const INTERFACES_URI: &str = "/signalk/v2/api/vessels/self/radars/interfaces";
+const STATUS_URI: &str = "/signalk/v2/api/vessels/self/radars/status";
 const RADAR_CONTROLS_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/controls";
 const RADAR_CONTROL_URI: &str =
     "/signalk/v2/api/vessels/self/radars/{radar_id}/controls/{control_id}";
@@ -75,6 +78,7 @@ const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
         get_radars,
         get_radar_info,
         get_interfaces,
+        get_status,
         diagnostics::get_diagnostics,
         get_radar,
         get_control_values,
@@ -90,6 +94,7 @@ const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
         RadarControlIdParam,
         RadarApiV3,
         RadarsResponse,
+        ServerStatus,
         Capabilities,
         BareControlValue,
         // Target types
@@ -108,6 +113,7 @@ struct ApiDoc;
 pub(crate) fn routes(axum: axum::Router<Web>) -> axum::Router<Web> {
     axum.route(BASE_URI, get(get_radars))
         .route(INTERFACES_URI, get(get_interfaces))
+        .route(STATUS_URI, get(get_status))
         .route(
             diagnostics::DIAGNOSTICS_URI,
             get(diagnostics::get_diagnostics),
@@ -343,6 +349,57 @@ async fn get_radars(State(state): State<Web>) -> Response {
         radars,
     })
     .into_response()
+}
+
+/// Whether this run keeps what the user sets up.
+///
+/// mayara runs fine without a settings file -- an unwritable config directory
+/// costs the user their radar names and zones, never their radar -- so the
+/// GUI needs to be able to say so on a page that has no WebSocket open.
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct ServerStatus {
+    /// False when radar names, guard zones and exclusion zones set now are
+    /// gone after a restart.
+    settings_stored: bool,
+    /// The settings file in use, or the one that cannot be written. Absent
+    /// on a replay run, which wants none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    settings_path: Option<String>,
+}
+
+impl From<SettingsStorage> for ServerStatus {
+    fn from(storage: SettingsStorage) -> Self {
+        match storage {
+            SettingsStorage::Stored(path) => ServerStatus {
+                settings_stored: true,
+                settings_path: Some(path.display().to_string()),
+            },
+            SettingsStorage::Unwritable(path) => ServerStatus {
+                settings_stored: false,
+                settings_path: Some(path.display().to_string()),
+            },
+            SettingsStorage::NotWanted => ServerStatus {
+                settings_stored: false,
+                settings_path: None,
+            },
+        }
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/signalk/v2/api/vessels/self/radars/status",
+    summary = "Get server status",
+    description = "Reports whether this mayara run can store radar settings. When it cannot, \
+                   radar names, guard zones and exclusion zones are lost on restart, and the \
+                   same condition is sent to connecting clients as a \
+                   `notifications.mayara.settingsNotStored` Signal K notification.",
+    responses((status = 200, body = ServerStatus, description = "Server status")),
+    tag = "Radars"
+)]
+async fn get_status(State(state): State<Web>) -> Response {
+    Json(ServerStatus::from(state.radars.settings_storage())).into_response()
 }
 
 #[utoipa::path(
@@ -1473,6 +1530,8 @@ async fn ws_signalk_delta(
         // AIS vessels are NOT sent on initial connection.
         // They are sent when the client subscribes to "vessels.*"
     }
+
+    sk_delta.add_settings_warning(&radars.settings_storage());
 
     if let Some(sk_delta) = sk_delta.build() {
         send_message(socket, sk_delta).await?;

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -104,9 +104,37 @@ pub(crate) struct Persistence {
     pub config: Config,
     timestamp: SystemTime,
     path: PathBuf,
+    /// The settings file this run wanted but cannot write. `None` when
+    /// settings are stored, and when a replay run wants none.
+    unwritable: Option<PathBuf>,
 }
 
 const SETTINGS_FILE: &str = "settings.json";
+
+/// What this run does with radar settings. Reported by the status endpoint
+/// and, when settings are going nowhere, sent to every connecting client as
+/// a Signal K notification.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SettingsStorage {
+    /// Settings are read from and written to this file.
+    Stored(PathBuf),
+    /// This file cannot be written, so nothing the user sets up is
+    /// remembered. Named, so they know which permissions to fix.
+    Unwritable(PathBuf),
+    /// A replay run keeps nothing on purpose.
+    NotWanted,
+}
+
+/// What a run can do with the settings file it found.
+enum Loaded {
+    /// Settings are read and written normally.
+    Writable,
+    /// Existing settings were read but cannot be changed -- a file that
+    /// belongs to someone else.
+    ReadOnly,
+    /// Nothing could be read and nothing can be written.
+    Unusable,
+}
 
 /// The settings file to read and write, or `None` when the config directory
 /// cannot be created. A radar works fine without one, so an unwritable
@@ -126,26 +154,37 @@ fn settings_path(config_dir: &std::path::Path) -> Option<PathBuf> {
 }
 
 impl Persistence {
-    /// A persistence that remembers nothing, for a run that has nowhere to
-    /// write. An empty path is the marker every write path already checks.
-    fn disabled() -> Self {
+    /// A persistence that remembers nothing. An empty path is the marker
+    /// every write path already checks; `unwritable` names the file this run
+    /// failed to write, and stays `None` when it never wanted one.
+    fn disabled(unwritable: Option<PathBuf>) -> Self {
         Persistence {
             config: Config {
                 radars: HashMap::new(),
             },
             timestamp: SystemTime::UNIX_EPOCH,
             path: PathBuf::new(),
+            unwritable,
+        }
+    }
+
+    pub(crate) fn storage(&self) -> SettingsStorage {
+        match &self.unwritable {
+            Some(path) => SettingsStorage::Unwritable(path.clone()),
+            None if self.path.as_os_str().is_empty() => SettingsStorage::NotWanted,
+            None => SettingsStorage::Stored(self.path.clone()),
         }
     }
 
     pub(crate) fn new() -> Self {
         if crate::replay::is_active() {
             debug!("persistence disabled in pcap replay mode");
-            return Self::disabled();
+            return Self::disabled(None);
         }
 
-        let Some(settings_path) = settings_path(get_project_dirs().config_dir()) else {
-            return Self::disabled();
+        let config_dir = get_project_dirs().config_dir().to_owned();
+        let Some(settings_path) = settings_path(&config_dir) else {
+            return Self::disabled(Some(config_dir.join(SETTINGS_FILE)));
         };
 
         let mut this = Persistence {
@@ -154,15 +193,49 @@ impl Persistence {
             },
             timestamp: SystemTime::UNIX_EPOCH,
             path: settings_path,
+            unwritable: None,
         };
 
-        if !this.load() {
-            warn!("Radar names, guard zones and other settings will not be remembered");
-            return Self::disabled();
+        match this.load() {
+            Loaded::Writable => {
+                debug!("persistence loaded: {:?}", this);
+                this
+            }
+            Loaded::ReadOnly => {
+                warn!("Radar names, guard zones and other settings will not be remembered");
+                this.read_only()
+            }
+            Loaded::Unusable => {
+                warn!("Radar names, guard zones and other settings will not be remembered");
+                Self::disabled(Some(this.path))
+            }
         }
-        debug!("persistence loaded: {:?}", this);
+    }
 
-        this
+    /// Keep the settings that were read, write no more of them. A file owned
+    /// by another user still describes this radar correctly -- the user keeps
+    /// their zones and names for this run -- it just cannot take changes.
+    fn read_only(self) -> Self {
+        Persistence {
+            config: self.config,
+            timestamp: self.timestamp,
+            unwritable: Some(self.path),
+            path: PathBuf::new(),
+        }
+    }
+
+    /// Whether the settings file will take a change. Existing settings can be
+    /// readable and still belong to another user, which is what a container
+    /// mount produces after the uid it runs as changes; opening for writing
+    /// is the only way to find out, and it leaves the contents alone.
+    fn is_writable(&self) -> bool {
+        match fs::OpenOptions::new().write(true).open(&self.path) {
+            Ok(_) => true,
+            Err(e) => {
+                warn!("cannot write config '{}': {}", self.path.display(), e);
+                false
+            }
+        }
     }
 
     fn get_file_time(&self) -> SystemTime {
@@ -185,11 +258,12 @@ impl Persistence {
         );
     }
 
-    /// Returns whether the settings file can be used. A first run writes an
+    /// What this run can do with the settings file. A first run writes an
     /// empty one, which doubles as the check that this run can write at all:
     /// `create_dir_all` succeeds on a directory that already exists but
-    /// belongs to another user, so the write is what finds that out.
-    fn load(&mut self) -> bool {
+    /// belongs to another user, so the write is what finds that out. An
+    /// existing file gets the same question asked of it directly.
+    fn load(&mut self) -> Loaded {
         let file = match File::open(&self.path) {
             Err(e) => {
                 warn!(
@@ -198,7 +272,11 @@ impl Persistence {
                     e
                 );
 
-                return self.save();
+                return if self.save() {
+                    Loaded::Writable
+                } else {
+                    Loaded::Unusable
+                };
             }
             Ok(f) => f,
         };
@@ -220,7 +298,12 @@ impl Persistence {
         };
 
         self.timestamp = self.get_file_time();
-        true
+
+        if self.is_writable() {
+            Loaded::Writable
+        } else {
+            Loaded::ReadOnly
+        }
     }
 
     fn saver(&mut self) -> Result<(), Box<dyn Error>> {
@@ -485,7 +568,7 @@ mod tests {
         );
         Persistence {
             config: Config { radars },
-            ..Persistence::disabled()
+            ..Persistence::disabled(None)
         }
     }
 
@@ -567,10 +650,31 @@ mod tests {
         assert!(settings_path(&blocker.join("mayara")).is_none());
     }
 
+    /// The status endpoint and the connect-time warning both read this, and
+    /// they must tell apart "cannot write" from "a replay run wants none" --
+    /// only the first is worth warning a user about.
+    #[test]
+    fn storage_tells_a_failed_run_from_one_that_wants_nothing() {
+        let path = PathBuf::from("/config/mayara/settings.json");
+
+        assert_eq!(
+            persistence_at(path.clone()).storage(),
+            SettingsStorage::Stored(path.clone())
+        );
+        assert_eq!(
+            Persistence::disabled(Some(path.clone())).storage(),
+            SettingsStorage::Unwritable(path)
+        );
+        assert_eq!(
+            Persistence::disabled(None).storage(),
+            SettingsStorage::NotWanted
+        );
+    }
+
     fn persistence_at(path: PathBuf) -> Persistence {
         Persistence {
             path,
-            ..Persistence::disabled()
+            ..Persistence::disabled(None)
         }
     }
 
@@ -580,8 +684,51 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(SETTINGS_FILE);
 
-        assert!(persistence_at(path.clone()).load());
+        assert!(matches!(
+            persistence_at(path.clone()).load(),
+            Loaded::Writable
+        ));
         assert!(path.is_file());
+    }
+
+    /// A settings file that opens for reading may still belong to another
+    /// user -- exactly what a container mount produces once the uid it runs
+    /// as changes. Opening it for writing is the only way to find out.
+    /// A directory standing in for the file is refused by every user, root
+    /// included, which no chmod can claim.
+    #[test]
+    fn a_settings_file_that_rejects_writes_is_not_storage() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let writable = dir.path().join("settings.json");
+        fs::write(&writable, b"{}").unwrap();
+        assert!(persistence_at(writable).is_writable());
+
+        let refuses_writes = dir.path().join("unwritable.json");
+        fs::create_dir(&refuses_writes).unwrap();
+        assert!(!persistence_at(refuses_writes).is_writable());
+    }
+
+    /// Settings that cannot be updated are still worth having: the user keeps
+    /// their radar names and zones for this run, and is told they will not
+    /// survive it.
+    #[test]
+    fn settings_that_cannot_be_updated_are_still_read() {
+        let path = PathBuf::from("/config/mayara/settings.json");
+        let mut p = persistence_with("nav1034A", "Bow Radar");
+        p.path = path.clone();
+
+        let p = p.read_only();
+
+        assert_eq!(
+            p.config
+                .radars
+                .get("nav1034A")
+                .map(|r| r.user_name.as_str()),
+            Some("Bow Radar"),
+            "what was read stays available for this run"
+        );
+        assert_eq!(p.storage(), SettingsStorage::Unwritable(path));
     }
 
     /// An existing directory says nothing about being able to write in it --
@@ -594,6 +741,9 @@ mod tests {
         let blocker = dir.path().join("blocker");
         fs::write(&blocker, b"not a directory").unwrap();
 
-        assert!(!persistence_at(blocker.join(SETTINGS_FILE)).load());
+        assert!(matches!(
+            persistence_at(blocker.join(SETTINGS_FILE)).load(),
+            Loaded::Unusable
+        ));
     }
 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -33,7 +33,7 @@ pub mod trail;
 pub(crate) mod units;
 
 use crate::brand::CommandSender;
-use crate::config::Persistence;
+use crate::config::{Persistence, SettingsStorage};
 use crate::protos::RadarMessage::RadarMessage;
 use crate::radar::settings::{
     ControlDestination, ControlError, ControlId, ControlUpdate, ControlValue, SharedControls,
@@ -919,6 +919,12 @@ impl SharedRadars {
         } else {
             None
         }
+    }
+
+    /// What this run does with radar settings, for the status endpoint and
+    /// the warning a connecting client is sent.
+    pub fn settings_storage(&self) -> SettingsStorage {
+        self.radars.read().unwrap().persistent_data.storage()
     }
 
     ///

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -13,6 +13,7 @@ use wildmatch::WildMatch;
 
 use crate::{
     PACKAGE,
+    config::SettingsStorage,
     navdata::get_own_ship_context,
     radar::settings::{BareControlValue, Control, ControlDefinition, ControlId, RadarControlValue},
     radar::target::ArpaTargetApi,
@@ -22,6 +23,11 @@ use crate::{
 /// Signal K's self-reference context, used until a concrete own-ship URN
 /// (e.g. `vessels.urn:mrn:signalk:uuid:…`) is detected from the upstream.
 const SELF_CONTEXT: &str = "vessels.self";
+
+/// Notification path for "this run is not saving radar settings". Under
+/// `mayara.` rather than `radar.<id>.`: the condition belongs to the server,
+/// not to any one radar.
+const SETTINGS_NOTIFICATION_PATH: &str = "notifications.mayara.settingsNotStored";
 
 /// The Signal K context for an AIS target, keyed by MMSI the way Signal K
 /// itself keys it (`vessels.urn:mrn:imo:mmsi:431004411`) rather than by bare
@@ -181,6 +187,32 @@ impl SignalKDelta {
             }],
         };
         self.updates.push(delta_update);
+    }
+
+    /// Tell a connecting client that this run is not saving radar settings.
+    ///
+    /// Sent on connect rather than once at startup, because it describes a
+    /// state that holds for the whole run and a client that joins an hour in
+    /// has to learn about it too. Sent whatever the client subscribed to: it
+    /// says something about the server, not about vessel data, and mayara's
+    /// own GUI connects with `subscribe=none`.
+    pub fn add_settings_warning(&mut self, storage: &SettingsStorage) {
+        let SettingsStorage::Unwritable(path) = storage else {
+            return;
+        };
+
+        self.add_notification_update(
+            SETTINGS_NOTIFICATION_PATH,
+            NotificationValue {
+                state: NotificationState::Warn,
+                method: vec![NotificationMethod::Visual],
+                message: format!(
+                    "Radar settings cannot be saved to '{}'. Radar names, guard zones and exclusion zones are forgotten when mayara restarts.",
+                    path.display()
+                ),
+            },
+            "mayara",
+        );
     }
 
     /// Add a Signal K `notifications.*` alarm update.
@@ -1292,6 +1324,43 @@ mod test {
         // The wildcard scope is `notifications.radar.*`, so other
         // notification subtrees stay outside.
         assert!(!subs.is_subscribed_path("notifications.security.accessRequest.x", false));
+    }
+
+    #[test]
+    fn a_run_that_cannot_save_settings_warns_every_client_that_connects() {
+        use std::path::PathBuf;
+
+        let mut delta = SignalKDelta::new();
+        delta.add_settings_warning(&SettingsStorage::Unwritable(PathBuf::from(
+            "/skdata/mayara-config/mayara/settings.json",
+        )));
+
+        let json = serde_json::to_value(delta.build().expect("a warning is a delta")).unwrap();
+        let value = &json["updates"][0]["values"][0];
+
+        assert_eq!(value["path"], "notifications.mayara.settingsNotStored");
+        assert_eq!(value["value"]["state"], "warn");
+        assert_eq!(value["value"]["method"][0], "visual");
+        assert!(
+            value["value"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("/skdata/mayara-config/mayara/settings.json"),
+            "the message has to name the file the user must fix"
+        );
+    }
+
+    /// A run that stores settings, and a replay run that wants none, are both
+    /// working as intended -- neither is worth a notification.
+    #[test]
+    fn a_run_that_saves_settings_warns_nobody() {
+        use std::path::PathBuf;
+
+        let mut delta = SignalKDelta::new();
+        delta.add_settings_warning(&SettingsStorage::Stored(PathBuf::from("/config/s.json")));
+        delta.add_settings_warning(&SettingsStorage::NotWanted);
+
+        assert!(delta.build().is_none());
     }
 
     #[test]

--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -212,6 +212,28 @@ export async function fetchRadars() {
 }
 
 /**
+ * Ask the server whether it can store radar settings.
+ *
+ * Returns null when the answer cannot be had — an older mayara has no such
+ * endpoint, and a proxy in front of it may not route one. A landing page that
+ * cannot reach it simply shows no warning, rather than failing to load.
+ *
+ * @returns {Promise<{settingsStored: boolean, settingsPath?: string}|null>}
+ */
+export async function fetchServerStatus() {
+  await detectMode();
+
+  try {
+    const response = await apiFetch(`${getRadarsPath()}/status`);
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (err) {
+    console.log("Server status unavailable:", err);
+    return null;
+  }
+}
+
+/**
  * Unwrap the radar list to a plain `{ id: radar }` map. The Radar API response
  * is the `{ version, radars }` envelope (both mayara and signalk-server return
  * this); older/bare responses that are already a keyed map are passed through.

--- a/web/gui/discovery.css
+++ b/web/gui/discovery.css
@@ -303,7 +303,8 @@
    WebGPU Warning & Error Pages
    ============================================ */
 
-.myr_webgpu_warning {
+.myr_webgpu_warning,
+.myr_settings_warning {
   display: none;
   background: linear-gradient(135deg, rgba(180, 80, 40, 0.9), rgba(140, 60, 30, 0.9));
   border: 1px solid rgba(255, 150, 100, 0.5);

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -28,6 +28,9 @@
         <div id="action_buttons" class="myr_discovery_section">
         </div>
         
+        <div id="settings_warning" class="myr_settings_warning">
+        </div>
+
         <div id="radars" class="myr_discovery_section">
             <div class="myr_detecting">
                 <span class="myr_pulse"></span>

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -6,6 +6,7 @@ import {
   isStandaloneMode,
   detectMode,
   apiFetch,
+  fetchServerStatus,
 } from "./api.js";
 import { radarCombinations, multiViewUrl } from "./radar-list.js";
 
@@ -907,6 +908,39 @@ function showActionButtons() {
   van.add(container, div({ class: "myr_action_buttons" }, ...buttons));
 }
 
+// Warn that nothing the user sets up on this server survives a restart.
+// Shown on the discovery page because that is where someone lands, and the
+// page holds no WebSocket to carry the matching Signal K notification.
+async function showSettingsWarning() {
+  const status = await fetchServerStatus();
+  if (!status || status.settingsStored || !status.settingsPath) return;
+
+  const warningDiv = document.getElementById("settings_warning");
+  if (!warningDiv) return;
+
+  warningDiv.style.display = "block";
+  warningDiv.replaceChildren();
+
+  van.add(warningDiv, div({ class: "myr_warning_title" }, "Settings are not being saved"));
+  van.add(
+    warningDiv,
+    div(
+      { class: "myr_warning_content" },
+      p(
+        "Mayara cannot write to ",
+        code(status.settingsPath),
+        ", so radar names, guard zones and exclusion zones you set up now are ",
+        strong("forgotten when mayara restarts"),
+        "."
+      ),
+      p(
+        "The radars themselves work normally. To keep your settings, give mayara " +
+          "permission to write that file, or point it at a folder it owns."
+      )
+    )
+  );
+}
+
 async function loadRadars() {
   try {
     const radars = await fetchRadars();
@@ -936,6 +970,7 @@ window.onload = async function () {
 
   // Load data
   loadRadars();
+  showSettingsWarning();
 
   // Hide the interfaces section (now shown via popup)
   const interfacesSection = document.getElementById("interfaces");

--- a/web/gui/viewer.js
+++ b/web/gui/viewer.js
@@ -1333,11 +1333,17 @@ function createNotificationBanner() {
   container.appendChild(banner);
 }
 
-// Drop every active notification and hide the banner. Called on disconnect
-// and on radar (re)selection so stale alarms from a prior context never
-// leak into a fresh one.
+// Drop the radar's notifications and redraw the banner. Called on disconnect
+// and on radar (re)selection so stale alarms from a prior context never leak
+// into a fresh one. Notifications about the server itself are left standing:
+// they hold for as long as the connection does, and nothing re-sends them
+// when the user switches radar.
 function clearNotifications() {
-  activeNotifications.clear();
+  for (const path of activeNotifications.keys()) {
+    if (path.startsWith("notifications.radar.")) {
+      activeNotifications.delete(path);
+    }
+  }
   updateNotificationBanner();
 }
 


### PR DESCRIPTION
## Summary

#585 stopped mayara from refusing to start when it cannot write its settings —
but the only sign anything is wrong is a line in a log the user never reads.
Meanwhile everything they set up (radar names, guard zones, exclusion zones) is
quietly gone after the next restart. The Signal K plugin's host mount makes
this reachable in normal use, not just in a broken install.

The condition is now server state, the way Signal K reports security being off,
rather than a one-off event:

- `GET .../radars/status` → `{"settingsStored": false, "settingsPath": "…"}`,
  which the discovery page reads to show a persistent warning card. That page
  holds no WebSocket, so it could not learn this any other way.
- Every client connecting to the delta stream is told through a
  `notifications.mayara.settingsNotStored` warning naming the file, so the
  viewer's banner, other Signal K clients and the plugin all see it without
  asking. It is asserted on connect, not fired once at startup, so a client
  joining an hour in still learns about it.

The status endpoint is a mayara-only sibling of `interfaces` and `diagnostics`,
deliberately *not* a field on the `{version, radars}` envelope: signalk-server
rebuilds that when aggregating providers, so an extra field there would vanish
behind the plugin proxy.

`SettingsStorage` tells "cannot write" apart from "a replay run wants none", so
replay warns nobody.

## Tested

Live, against a config directory that exists but is mode 555: the status
endpoint reports `settingsStored: false` with the path, and a client connecting
with `subscribe=none` receives the notification (`state: "warn"`,
`method: ["visual"]`, message naming the file). A writable run reports
`settingsStored: true` and sends nothing.

Unit tests cover the three storage states and the notification delta, including
that a healthy or replay run produces no delta at all. `cargo test`,
`cargo clippy --no-deps --all-targets -- -D warnings`, `cargo fmt --check`.

## Note

mayara's GUI connects with `subscribe=none`, so the warning is sent outside the
subscription gate — it describes the server, not vessel data. Without that the
viewer would never see it.

Also fixes a GUI bug found on the way: `clearNotifications()` wiped *every*
notification on a radar switch, which would have dropped this one permanently
since nothing re-sends it. It now clears only `notifications.radar.*`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Exposes settings persistence through `GET .../radars/status`, including `settingsStored` and `settingsPath`.
- Adds `notifications.mayara.settingsNotStored` warnings for connected delta-stream clients when settings are unwritable, including `subscribe=none` clients.
- Suppresses warnings for replay runs and writable configurations.
- Displays a discovery-page warning when settings cannot persist.
- Preserves server-level notifications when clearing radar-specific notifications during radar changes.
- Adds tests for storage states, status responses, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->