### PR TITLE
fix(controls): broadcast an auto change the radar reports on its own

### DIFF
--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -1534,13 +1534,36 @@ impl SharedControls {
         }
     }
 
+    /// Record an auto state the radar just reported, and tell clients.
+    ///
+    /// The broadcast has to happen here. `set_auto` only raises
+    /// `needs_refresh`, which is flushed by the next `Control::set` -- and for
+    /// a control whose auto flag arrives in a status report without a value
+    /// beside it (HALO's Sea), no such call is guaranteed to follow. The
+    /// pending refresh could then sit unsent indefinitely, leaving every
+    /// client that renders from the delta stream showing the old auto state
+    /// while REST and the radar itself have moved on.
     pub fn set_auto_state(&self, control_id: &ControlId, auto: bool) -> Result<(), ControlError> {
-        let mut locked = self.controls.write().unwrap();
-        if let Some(control) = locked.controls.get_mut(control_id) {
+        let changed = {
+            let mut locked = self.controls.write().unwrap();
+            let Some(control) = locked.controls.get_mut(control_id) else {
+                return Err(ControlError::NotSupported(*control_id));
+            };
             control.set_auto(auto);
-        } else {
-            return Err(ControlError::NotSupported(*control_id));
+
+            if control.needs_refresh {
+                // Flushed here, so a later value-bearing set does not
+                // re-broadcast the same news.
+                control.needs_refresh = false;
+                Some(control.clone())
+            } else {
+                None
+            }
         };
+
+        if let Some(control) = changed {
+            self.send_to_all_clients(&control);
+        }
         Ok(())
     }
 
@@ -4409,6 +4432,94 @@ mod test {
         let json = r#"{"id":"-1","value":"49"}"#;
 
         assert!(serde_json::from_str::<ControlValue>(json).is_err());
+    }
+
+    /// A radar reporting only that a control switched to (or out of) auto is
+    /// news the clients rendering from the delta stream have no other way to
+    /// learn: no value came with it, and nothing guarantees a later
+    /// value-bearing report for that control. Regression for #600, where
+    /// HALO's Sea auto flag changed on the radar and every subscriber kept
+    /// showing the old state indefinitely.
+    #[test]
+    fn an_auto_only_change_reaches_the_clients() {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let mut controls = SharedControls::new("nav1234".to_string(), tx, &args, HashMap::new());
+        controls.add(new_auto(
+            ControlId::Sea,
+            0.,
+            100.,
+            AutomaticValue {
+                has_auto: true,
+                has_auto_adjustable: false,
+                auto_adjust_min_value: None,
+                auto_adjust_max_value: None,
+            },
+        ));
+        let mut client = controls.new_client_subscription();
+
+        controls.set_auto_state(&ControlId::Sea, true).unwrap();
+
+        let sent = client
+            .try_recv()
+            .expect("an auto change has to be broadcast");
+        assert_eq!(sent.id, ControlId::Sea);
+        assert_eq!(sent.auto, Some(true));
+    }
+
+    /// The radar repeats its state in every report; only a change is news.
+    #[test]
+    fn an_unchanged_auto_state_is_not_rebroadcast() {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let mut controls = SharedControls::new("nav1234".to_string(), tx, &args, HashMap::new());
+        controls.add(new_auto(
+            ControlId::Sea,
+            0.,
+            100.,
+            AutomaticValue {
+                has_auto: true,
+                has_auto_adjustable: false,
+                auto_adjust_min_value: None,
+                auto_adjust_max_value: None,
+            },
+        ));
+        let mut client = controls.new_client_subscription();
+
+        controls.set_auto_state(&ControlId::Sea, true).unwrap();
+        client.try_recv().expect("the change itself is broadcast");
+
+        controls.set_auto_state(&ControlId::Sea, true).unwrap();
+        assert!(
+            client.try_recv().is_err(),
+            "the same auto state repeated must not be sent again"
+        );
+    }
+
+    /// Having broadcast the auto change, the pending refresh is spent: a later
+    /// value-bearing set must not send the same news a second time.
+    #[test]
+    fn a_broadcast_auto_change_does_not_also_flush_later() {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let mut controls = SharedControls::new("nav1234".to_string(), tx, &args, HashMap::new());
+        controls.add(new_auto(
+            ControlId::Sea,
+            0.,
+            100.,
+            AutomaticValue {
+                has_auto: true,
+                has_auto_adjustable: false,
+                auto_adjust_min_value: None,
+                auto_adjust_max_value: None,
+            },
+        ));
+
+        controls.set_auto_state(&ControlId::Sea, true).unwrap();
+        assert!(
+            !controls.get(&ControlId::Sea).unwrap().needs_refresh,
+            "the refresh was flushed by the broadcast"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Toggling Sea's auto mode looks like it does nothing in clients that read the
Signal K control stream — the OpenCPN plugin's control panel most visibly
(opencpn-radar-pi/mayara_pi#53). The setting really does take effect on the
radar; the client is just never told, so it keeps showing the old state until
some unrelated control interaction happens to flush it.

A HALO reports Sea's auto flag in its short status report with no value beside
it. That path calls `set_auto`, which only raises `needs_refresh` and leaves the
flush to the next `Control::set` — and for this control no value-bearing report
is guaranteed to follow. `set_auto_state` now broadcasts the change itself and
marks the refresh spent, following the same lock → mutate → clone → send shape
as every other setter in that file. An unchanged auto state still sends nothing:
the radar repeats its state in every report, and only a change is news.

## Tested

Against the real HALO24 on a boat, with a subscribed WebSocket client — the
configuration the issue's own capture did not cover:

| PUT to `controls/sea` | deltas before | deltas after |
| --- | --- | --- |
| `{"auto":true}` (a change) | **0** | **1** |
| `{"auto":false}` (a change) | **0** | **1** |
| `{"auto":true}` when already true | 0 | 0 |
| `{"value":N,"auto":…}` | 1 | 1 |

REST reported the new state immediately in every case, before and after — the
bug was only ever in what subscribers were told.

Three unit tests cover it, and each was confirmed to fail against the
unfixed code: an auto-only change reaches clients, an unchanged auto state is
not rebroadcast, and the flushed refresh is not sent a second time by a later
value-bearing set.

## Notes

Worth knowing while reviewing:

- **The GUI cannot show this bug.** `do_toggle_auto` (`web/gui/control.js`)
  updates its own state before sending to the server, so its toggle flips
  whether or not a delta ever arrives. Only clients that render purely from the
  stream — mayara_pi — surface it.
- **The delta's timestamp is unchanged** by this fix; `set_auto` does not touch
  it, matching what REST already reports for the same change. The payload does
  carry the new `auto`, which is what a client applies, and the live test
  confirms clients receive it. Changing timestamp semantics felt like a separate
  decision rather than part of this fix.
- Separately observed and **not** addressed here: a paired
  `{"value":90,"auto":false}` came back as `auto:true` when an auto change was
  already pending. That may be a second bug in the same area or the radar
  genuinely reporting auto still on; it needs log-level evidence before anyone
  claims either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `set_auto_state` broadcasts changed Sea auto states immediately.
- Pending refreshes are marked as handled to prevent duplicate updates.
- Unchanged auto states are not rebroadcast.
- Three unit tests cover auto-only changes, unchanged states, and duplicate refresh prevention.
- REST behavior and delta timestamp semantics remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->