### PR TITLE
feat(gui): ask what radar to expect when none turns up

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -33,6 +33,8 @@ mayara-server --openapi
 | GET    | `/signalk/v2/api/vessels/self/radars`                        | List all detected radars                           |
 | GET    | `/signalk/v2/api/vessels/self/radars/interfaces`             | List network interfaces and radar discovery status |
 | GET    | `/signalk/v2/api/vessels/self/radars/diagnostics`            | Download a gzipped JSON network diagnostics snapshot |
+| GET    | `/signalk/v2/api/vessels/self/radars/status`                 | Whether settings can be stored, radars seen before, and the brands this build supports |
+| GET    | `/signalk/v2/api/vessels/self/radars/network-check/{kind}`   | Whether this host's network can reach a given kind of radar |
 | GET    | `/signalk/v2/api/vessels/self/radars/telemetry`              | Whether to ask the user about anonymous usage reports |
 | PUT    | `/signalk/v2/api/vessels/self/radars/telemetry`              | Store the user's answer to that question |
 | GET    | `/signalk/v2/api/vessels/self/radars/{id}/capabilities`      | Get radar capabilities and legend                  |

--- a/src/bin/mayara-server/web/signalk/diagnostics.rs
+++ b/src/bin/mayara-server/web/signalk/diagnostics.rs
@@ -140,7 +140,7 @@ fn config_summary(args: &mayara::Cli) -> Value {
 /// than hang the HTTP request indefinitely.
 const INTERFACE_API_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
-async fn fetch_interface_api(state: &Web) -> InterfaceApi {
+pub(crate) async fn fetch_interface_api(state: &Web) -> InterfaceApi {
     let (tx, mut rx) = mpsc::channel(1);
     if state.tx_interface_request.send(Some(tx)).is_err() {
         return InterfaceApi::default();

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -10,6 +10,7 @@ use http::StatusCode;
 use hyper;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::str::FromStr;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     net::Ipv4Addr,
@@ -27,9 +28,8 @@ use crate::web::{signalk::diagnostics, spokes_handler};
 
 use super::super::{Message, Web, WebSocket, WebSocketUpgrade};
 use mayara::{
-    InterfaceApi,
-    config::Consent,
-    config::SettingsStorage,
+    Brand, Expectation, InterfaceApi, NetworkCheck,
+    config::{Consent, KnownRadar, SettingsStorage},
     navdata,
     radar::{
         GeoPosition, Legend, RadarError, RadarInfo, SharedRadars,
@@ -50,6 +50,7 @@ const RADAR_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}";
 const RADAR_CAPABILITIES_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/capabilities";
 const INTERFACES_URI: &str = "/signalk/v2/api/vessels/self/radars/interfaces";
 const STATUS_URI: &str = "/signalk/v2/api/vessels/self/radars/status";
+const NETWORK_CHECK_URI: &str = "/signalk/v2/api/vessels/self/radars/network-check/{expectation}";
 const TELEMETRY_URI: &str = "/signalk/v2/api/vessels/self/radars/telemetry";
 const RADAR_CONTROLS_URI: &str = "/signalk/v2/api/vessels/self/radars/{radar_id}/controls";
 const RADAR_CONTROL_URI: &str =
@@ -82,6 +83,7 @@ const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
         get_radar_info,
         get_interfaces,
         get_status,
+        get_network_check,
         get_telemetry,
         set_telemetry,
         diagnostics::get_diagnostics,
@@ -100,6 +102,8 @@ const CONTROL_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
         RadarApiV3,
         RadarsResponse,
         ServerStatus,
+        KnownRadarApi,
+        NetworkCheck,
         TelemetryState,
         TelemetryConsentRequest,
         Capabilities,
@@ -121,6 +125,7 @@ pub(crate) fn routes(axum: axum::Router<Web>) -> axum::Router<Web> {
     axum.route(BASE_URI, get(get_radars))
         .route(INTERFACES_URI, get(get_interfaces))
         .route(STATUS_URI, get(get_status))
+        .route(NETWORK_CHECK_URI, get(get_network_check))
         .route(TELEMETRY_URI, get(get_telemetry).put(set_telemetry))
         .route(
             diagnostics::DIAGNOSTICS_URI,
@@ -374,23 +379,53 @@ struct ServerStatus {
     /// on a replay run, which wants none.
     #[serde(skip_serializing_if = "Option::is_none")]
     settings_path: Option<String>,
+    /// Radars this install has seen before. Empty on a first run, and on any
+    /// run that cannot store settings.
+    known_radars: Vec<KnownRadarApi>,
+    /// Brands this build can look for. A client must not offer the user a
+    /// radar this server could never find.
+    #[schema(example = json!(["Navico", "Furuno"]))]
+    brands: Vec<Brand>,
 }
 
-impl From<SettingsStorage> for ServerStatus {
-    fn from(storage: SettingsStorage) -> Self {
-        match storage {
-            SettingsStorage::Stored(path) => ServerStatus {
-                settings_stored: true,
-                settings_path: Some(path.display().to_string()),
-            },
-            SettingsStorage::Unwritable(path) => ServerStatus {
-                settings_stored: false,
-                settings_path: Some(path.display().to_string()),
-            },
-            SettingsStorage::NotWanted => ServerStatus {
-                settings_stored: false,
-                settings_path: None,
-            },
+/// A radar the user has had working before.
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct KnownRadarApi {
+    /// `Navico`, `Furuno`, … Absent for a key written by a version that used
+    /// a prefix this one does not know.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    brand: Option<Brand>,
+    #[schema(example = "Halo A")]
+    name: String,
+    #[schema(example = "HALO24")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+}
+
+impl From<KnownRadar> for KnownRadarApi {
+    fn from(known: KnownRadar) -> Self {
+        KnownRadarApi {
+            brand: known.brand,
+            name: known.name,
+            model: known.model,
+        }
+    }
+}
+
+impl ServerStatus {
+    fn new(storage: SettingsStorage, known_radars: Vec<KnownRadar>) -> Self {
+        let (settings_stored, settings_path) = match storage {
+            SettingsStorage::Stored(path) => (true, Some(path.display().to_string())),
+            SettingsStorage::Unwritable(path) => (false, Some(path.display().to_string())),
+            SettingsStorage::NotWanted => (false, None),
+        };
+
+        ServerStatus {
+            settings_stored,
+            settings_path,
+            known_radars: known_radars.into_iter().map(KnownRadarApi::from).collect(),
+            brands: Brand::compiled_in(),
         }
     }
 }
@@ -435,7 +470,50 @@ fn consent_name(consent: Consent) -> &'static str {
     tag = "Radars"
 )]
 async fn get_status(State(state): State<Web>) -> Response {
-    Json(ServerStatus::from(state.radars.settings_storage())).into_response()
+    Json(ServerStatus::new(
+        state.radars.settings_storage(),
+        state.radars.known_radars(),
+    ))
+    .into_response()
+}
+
+#[derive(Deserialize, ToSchema)]
+struct ExpectationParam {
+    /// `navico`, `furuno`, `garmin`, `koden`, `raymarine-rd`,
+    /// `raymarine-quantum-mfd` or `raymarine-quantum-standalone`.
+    #[schema(example = "raymarine-rd")]
+    expectation: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/signalk/v2/api/vessels/self/radars/network-check/{expectation}",
+    summary = "Can this host reach the radar the user is waiting for?",
+    description = "Answers whether this host's addresses can carry a given kind of radar, for \
+                   a discovery page that has found nothing and has to say something more useful \
+                   than 'still searching'. Raymarine is split into three: an RD self-assigns a \
+                   10/8 address, a Quantum on an MFD network is a DHCP client on 198.18/21, and \
+                   a standalone Quantum can be anywhere (and is not supported yet).",
+    params(("expectation" = String, Path, description = "What the user expects", example = "raymarine-rd")),
+    responses(
+        (status = 200, body = NetworkCheck, description = "Whether the network can carry it"),
+        (status = 404, description = "Unknown kind of radar")
+    ),
+    tag = "Radars"
+)]
+async fn get_network_check(
+    Path(params): Path<ExpectationParam>,
+    State(state): State<Web>,
+) -> Response {
+    let Ok(expectation) = Expectation::from_str(&params.expectation) else {
+        return SignalKResponse::failed(
+            StatusCode::NOT_FOUND,
+            format!("Unknown radar kind '{}'", params.expectation),
+        );
+    };
+
+    let interfaces = diagnostics::fetch_interface_api(&state).await;
+    Json(expectation.check(&interfaces)).into_response()
 }
 
 #[utoipa::path(

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -9,6 +9,7 @@ use std::io::{BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+use crate::Brand;
 use crate::radar::RadarInfo;
 use crate::radar::range::Ranges;
 use crate::radar::settings::ControlId;
@@ -145,6 +146,20 @@ pub(crate) struct Persistence {
 
 const SETTINGS_FILE: &str = "settings.json";
 
+/// A radar this install has seen before, remembered across restarts.
+///
+/// Discovery is the same for everyone, but the advice is not: someone whose
+/// radar worked last week has a different problem from someone setting one up
+/// for the first time, and the page can only say so if it knows.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KnownRadar {
+    pub brand: Option<Brand>,
+    /// The name the user gave it, or the one the radar reported.
+    pub name: String,
+    /// Model as last detected, e.g. `HALO24`.
+    pub model: Option<String>,
+}
+
 /// What this run does with radar settings. Reported by the status endpoint
 /// and, when settings are going nowhere, sent to every connecting client as
 /// a Signal K notification.
@@ -202,6 +217,28 @@ impl Persistence {
             unwritable,
             consent_unwritable: false,
         }
+    }
+
+    /// Every radar in the settings file, whether or not it is on the air now.
+    pub(crate) fn known_radars(&self) -> Vec<KnownRadar> {
+        let mut known: Vec<KnownRadar> = self
+            .config
+            .radars
+            .iter()
+            .map(|(key, radar)| KnownRadar {
+                brand: Brand::from_key(key),
+                name: if radar.user_name.is_empty() {
+                    key.clone()
+                } else {
+                    radar.user_name.clone()
+                },
+                model: radar.model_name.clone(),
+            })
+            .collect();
+        // A map's order is nobody's idea of an order; the page shows these to
+        // a person.
+        known.sort_by(|a, b| a.name.cmp(&b.name));
+        known
     }
 
     pub(crate) fn storage(&self) -> SettingsStorage {
@@ -720,6 +757,40 @@ mod tests {
             p.config.radars.get("kod3456").map(|r| r.user_name.as_str()),
             Some("Current Name")
         );
+    }
+
+    /// The discovery page names the radars this install has had working, so
+    /// someone whose radar worked last week is told something different from
+    /// someone setting one up for the first time. A radar the user renamed is
+    /// named the way they named it.
+    #[test]
+    fn known_radars_are_listed_by_the_name_the_user_would_recognise() {
+        let mut p = persistence_with("nav1034A", "Bow Radar");
+        p.config.radars.insert(
+            "fur6424A".to_string(),
+            Radar {
+                user_name: String::new(),
+                model_name: Some("DRS4D-NXT".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let known = p.known_radars();
+
+        assert_eq!(known.len(), 2);
+        // Sorted, so the page does not reshuffle them between visits.
+        assert_eq!(known[0].name, "Bow Radar");
+        assert_eq!(known[0].brand, Some(Brand::Navico));
+        // No name of its own falls back to the key, which at least identifies it.
+        assert_eq!(known[1].name, "fur6424A");
+        assert_eq!(known[1].brand, Some(Brand::Furuno));
+        assert_eq!(known[1].model.as_deref(), Some("DRS4D-NXT"));
+    }
+
+    /// A first run has nothing to say about radars seen before.
+    #[test]
+    fn a_run_with_no_stored_radars_knows_of_none() {
+        assert!(Persistence::disabled(None).known_radars().is_empty());
     }
 
     /// The question is only ever put to a user whose answer can be kept.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -344,6 +344,53 @@ impl Brand {
             Self::Playback => "play",
         }
     }
+
+    /// Whether this build can look for this brand at all. Brands are cargo
+    /// features, so a build can be missing one entirely -- and then no amount
+    /// of correct network configuration will ever produce a radar.
+    pub fn is_compiled_in(&self) -> bool {
+        match self {
+            Self::Navico => cfg!(feature = "navico"),
+            Self::Furuno => cfg!(feature = "furuno"),
+            Self::Garmin => cfg!(feature = "garmin"),
+            Self::Koden => cfg!(feature = "koden"),
+            Self::Raymarine => cfg!(feature = "raymarine"),
+            Self::Emulator => cfg!(feature = "emulator"),
+            Self::Playback => true,
+        }
+    }
+
+    /// Every brand this build can look for, for a client that should not
+    /// offer the user a radar this server could never find.
+    pub fn compiled_in() -> Vec<Brand> {
+        [
+            Self::Navico,
+            Self::Furuno,
+            Self::Garmin,
+            Self::Koden,
+            Self::Raymarine,
+        ]
+        .into_iter()
+        .filter(Self::is_compiled_in)
+        .collect()
+    }
+
+    /// The brand a radar key belongs to. Keys are built as prefix + identity
+    /// by `radar_key`, so a stored key still says which brand wrote it long
+    /// after that radar was last seen.
+    pub fn from_key(key: &str) -> Option<Brand> {
+        [
+            Self::Furuno,
+            Self::Garmin,
+            Self::Koden,
+            Self::Navico,
+            Self::Raymarine,
+            Self::Emulator,
+            Self::Playback,
+        ]
+        .into_iter()
+        .find(|brand| key.starts_with(brand.to_prefix()))
+    }
 }
 
 impl From<&str> for Brand {
@@ -464,6 +511,233 @@ pub struct InterfaceApi {
     /// Map of network interface name to its radar listener information
     #[schema(value_type = HashMap<String, RadarInterfaceApi>)]
     interfaces: HashMap<InterfaceId, RadarInterfaceApi>,
+}
+
+/// What the user says they are waiting to see.
+///
+/// Finer than `Brand`, because Raymarine's three product families need three
+/// different networks: an RD picks its own `10/8` address from its MAC, a
+/// Quantum on an Axiom network is a DHCP client on `198.18/21`, and a Quantum
+/// on its own can be anywhere at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, ToSchema)]
+#[strum(serialize_all = "kebab-case", ascii_case_insensitive)]
+pub enum Expectation {
+    Navico,
+    Furuno,
+    Garmin,
+    Koden,
+    RaymarineRd,
+    RaymarineQuantumMfd,
+    RaymarineQuantumStandalone,
+}
+
+/// Whether this host's network can carry the radar the user is waiting for.
+#[derive(Serialize, Debug, PartialEq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkCheck {
+    /// False only when we can say something is definitely wrong. Searching
+    /// continues either way; a radar mayara cannot name a requirement for is
+    /// not a radar mayara has given up on.
+    pub met: bool,
+    /// What this radar needs of the network, in the user's terms.
+    pub requirement: String,
+    /// What this host has, or what it is missing.
+    pub finding: String,
+    /// What to do about it. Absent when there is nothing to do.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remedy: Option<String>,
+}
+
+impl Expectation {
+    /// What this radar asks of the network, in the user's terms.
+    fn requirement_text(&self) -> String {
+        match self.required_network() {
+            Some((_, _, human)) => {
+                format!("This radar can only be reached from a host in {}.", human)
+            }
+            None => "This radar announces itself by multicast or broadcast and needs no particular address on this host.".to_string(),
+        }
+    }
+
+    /// The network this radar has to be reachable on, as a prefix and the
+    /// wording a user would recognise. `None` for radars that impose nothing
+    /// mayara can check.
+    fn required_network(&self) -> Option<(Ipv4Addr, u8, &'static str)> {
+        match self {
+            // A DRS only answers a host inside its own fixed subnet.
+            Self::Furuno => Some((Ipv4Addr::new(172, 31, 0, 0), 16, "172.31.x.x")),
+            // 172.16.0.0/12, the whole marine range Garmin uses.
+            Self::Garmin => Some((Ipv4Addr::new(172, 16, 0, 0), 12, "172.16.x.x - 172.31.x.x")),
+            // An RD self-assigns 10.<three bytes of its MAC> and will never
+            // answer a host outside that /8.
+            Self::RaymarineRd => Some((Ipv4Addr::new(10, 0, 0, 0), 8, "10.x.x.x")),
+            // The network an Axiom insists on, and hands out DHCP leases from.
+            Self::RaymarineQuantumMfd => {
+                Some((Ipv4Addr::new(198, 18, 0, 0), 21, "198.18.0.x - 198.18.7.x"))
+            }
+            // Navico and Koden find each other by multicast and broadcast;
+            // a standalone Quantum can be on any address its DHCP server hands
+            // out, which is why mayara cannot check it (and does not yet
+            // support it).
+            Self::Navico | Self::Koden | Self::RaymarineQuantumStandalone => None,
+        }
+    }
+
+    /// The brand this expectation belongs to. Raymarine's three families are
+    /// one brand as far as discovery is concerned.
+    pub fn brand(&self) -> Brand {
+        match self {
+            Self::Navico => Brand::Navico,
+            Self::Furuno => Brand::Furuno,
+            Self::Garmin => Brand::Garmin,
+            Self::Koden => Brand::Koden,
+            Self::RaymarineRd | Self::RaymarineQuantumMfd | Self::RaymarineQuantumStandalone => {
+                Brand::Raymarine
+            }
+        }
+    }
+
+    /// Judge this host's addresses against what the radar needs.
+    pub fn check(&self, interfaces: &InterfaceApi) -> NetworkCheck {
+        self.check_supported(interfaces, self.brand().is_compiled_in())
+    }
+
+    fn check_supported(&self, interfaces: &InterfaceApi, supported: bool) -> NetworkCheck {
+        let addresses = interfaces.ipv4_addresses();
+
+        // A network the radar could be reached on means nothing if this build
+        // has no code to look for it. Saying the network is fine would send
+        // the user checking cables for a radar that can never appear.
+        if !supported {
+            return NetworkCheck {
+                met: false,
+                requirement: self.requirement_text(),
+                finding: format!(
+                    "This build of mayara has no {} support compiled in, so it will never find one however the network is set up.",
+                    self.brand()
+                ),
+                remedy: Some(format!(
+                    "Use a mayara build with {} support -- the official builds include every brand.",
+                    self.brand()
+                )),
+            };
+        }
+
+        if *self == Self::RaymarineQuantumStandalone {
+            return NetworkCheck {
+                met: false,
+                requirement: "A Quantum with no MFD accepts an address from whatever DHCP server it finds, so there is no fixed network to check.".to_string(),
+                finding: "Mayara does not support a standalone Quantum yet: it can only find one that is part of a Raymarine network with an MFD.".to_string(),
+                remedy: Some("Connect the Quantum to a Raymarine MFD network, or follow the issue for standalone support.".to_string()),
+            };
+        }
+
+        // Being confidently wrong is worse than saying nothing: with no
+        // interface list to read, "your host has no address" would send the
+        // user reconfiguring a network that is fine.
+        if !interfaces.is_known() {
+            return NetworkCheck {
+                met: true,
+                requirement: self.requirement_text(),
+                finding: "Mayara could not read this host's network interfaces just now, so it cannot check them.".to_string(),
+                remedy: None,
+            };
+        }
+
+        let Some((network, prefix, human)) = self.required_network() else {
+            return NetworkCheck {
+                met: true,
+                requirement: self.requirement_text(),
+                finding: if addresses.is_empty() {
+                    "This host has no usable IPv4 address at all, so nothing can be found."
+                        .to_string()
+                } else {
+                    "Nothing about this host's addresses prevents it from being found."
+                        .to_string()
+                },
+                remedy: (addresses.is_empty())
+                    .then(|| "Connect this computer to the radar network by wired Ethernet and give it an IPv4 address.".to_string()),
+            };
+        };
+
+        let matching: Vec<&(String, Ipv4Addr)> = addresses
+            .iter()
+            .filter(|(_, ip)| in_network(*ip, network, prefix))
+            .collect();
+
+        if let Some((interface, ip)) = matching.first() {
+            NetworkCheck {
+                met: true,
+                requirement: self.requirement_text(),
+                // Naming the interface matters: a container bridge or a
+                // virtual interface can sit in the same range while carrying
+                // no radar traffic at all, and on a containerised install
+                // that is more likely than not.
+                finding: format!(
+                    "{} has {}, which is in that range — check that {} is the interface your radar is wired to.",
+                    interface, ip, interface
+                ),
+                remedy: None,
+            }
+        } else {
+            let has = if addresses.is_empty() {
+                "This host has no usable IPv4 address at all.".to_string()
+            } else {
+                format!(
+                    "This host has {}, none of which is in that range.",
+                    addresses
+                        .iter()
+                        .map(|(interface, ip)| format!("{} on {}", ip, interface))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+
+            NetworkCheck {
+                met: false,
+                requirement: self.requirement_text(),
+                finding: has,
+                remedy: Some(format!(
+                    "Give the interface the radar is wired to an address in {}, then reload this page.",
+                    human
+                )),
+            }
+        }
+    }
+}
+
+/// Whether an address falls inside a network, by prefix length.
+fn in_network(ip: Ipv4Addr, network: Ipv4Addr, prefix: u8) -> bool {
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    u32::from(ip) & mask == u32::from(network) & mask
+}
+
+impl InterfaceApi {
+    /// Whether the interface list could be read at all. Empty means the
+    /// locator did not answer (or is not running, as under `--emulator`) --
+    /// not that the host has no addresses.
+    pub fn is_known(&self) -> bool {
+        !self.interfaces.is_empty()
+    }
+
+    /// Every usable IPv4 address this host has, with the interface it is on.
+    /// Loopback is left out: a radar never answers there.
+    pub fn ipv4_addresses(&self) -> Vec<(String, Ipv4Addr)> {
+        let mut found: Vec<(String, Ipv4Addr)> = self
+            .interfaces
+            .iter()
+            .filter_map(|(id, interface)| {
+                let ip = interface.ip?;
+                (!ip.is_loopback()).then(|| (id.name.clone(), ip))
+            })
+            .collect();
+        found.sort();
+        found
+    }
 }
 
 impl RadarInterfaceApi {
@@ -753,6 +1027,217 @@ pub async fn start_session(
     }
 
     (radars, tx_interface_request)
+}
+
+#[cfg(test)]
+mod expectation_tests {
+    use super::*;
+
+    fn interfaces(addresses: &[(&str, &str)]) -> InterfaceApi {
+        let mut api = InterfaceApi::default();
+        for (name, ip) in addresses {
+            let ip: Ipv4Addr = ip.parse().unwrap();
+            api.interfaces.insert(
+                InterfaceId::new(name, Some(ip)),
+                RadarInterfaceApi::new(InterfaceStatus::Ok, Some(ip), None, None),
+            );
+        }
+        api
+    }
+
+    /// A host whose interfaces were read and simply carry no IPv4 address --
+    /// which is a different thing from not having been able to read them.
+    fn interfaces_without_addresses() -> InterfaceApi {
+        let mut api = InterfaceApi::default();
+        api.interfaces.insert(
+            InterfaceId::new("eth0", None),
+            RadarInterfaceApi::new(InterfaceStatus::NoIPv4Address, None, None, None),
+        );
+        api
+    }
+
+    /// A DRS answers nobody outside its own subnet, so a host that is not in
+    /// it will wait forever without being told why.
+    #[test]
+    fn furuno_needs_its_own_subnet() {
+        let wrong = Expectation::Furuno.check(&interfaces(&[("eth0", "192.168.1.10")]));
+        assert!(!wrong.met);
+        assert!(wrong.finding.contains("192.168.1.10"), "name what is there");
+        assert!(wrong.remedy.is_some(), "say what to do about it");
+
+        let right = Expectation::Furuno.check(&interfaces(&[("eth0", "172.31.3.100")]));
+        assert!(right.met);
+        assert_eq!(right.remedy, None);
+        assert!(
+            right.finding.contains("eth0"),
+            "name the interface: a container bridge can sit in the range and carry nothing"
+        );
+    }
+
+    /// Garmin's range is the whole of 172.16/12, not just 172.16.x.
+    #[test]
+    fn garmin_accepts_the_whole_marine_range() {
+        assert!(
+            Expectation::Garmin
+                .check(&interfaces(&[("eth0", "172.16.2.5")]))
+                .met
+        );
+        assert!(
+            Expectation::Garmin
+                .check(&interfaces(&[("eth0", "172.30.9.9")]))
+                .met
+        );
+        assert!(
+            !Expectation::Garmin
+                .check(&interfaces(&[("eth0", "172.32.0.1")]))
+                .met
+        );
+    }
+
+    /// An RD self-assigns 10.<three bytes of its MAC>, so the host has to be
+    /// somewhere in 10/8 to hear it at all.
+    #[test]
+    fn a_raymarine_rd_needs_a_ten_network() {
+        assert!(
+            Expectation::RaymarineRd
+                .check(&interfaces(&[("eth0", "10.56.0.1")]))
+                .met
+        );
+
+        let wrong = Expectation::RaymarineRd.check(&interfaces(&[("eth0", "192.168.1.10")]));
+        assert!(!wrong.met);
+        assert!(wrong.requirement.contains("10.x.x.x"));
+    }
+
+    /// An Axiom network is 198.18.0.0/21 -- 198.18.8.x is already outside it.
+    #[test]
+    fn a_quantum_with_an_mfd_needs_the_axiom_network() {
+        assert!(
+            Expectation::RaymarineQuantumMfd
+                .check(&interfaces(&[("eth0", "198.18.0.5")]))
+                .met
+        );
+        assert!(
+            Expectation::RaymarineQuantumMfd
+                .check(&interfaces(&[("eth0", "198.18.7.254")]))
+                .met
+        );
+        assert!(
+            !Expectation::RaymarineQuantumMfd
+                .check(&interfaces(&[("eth0", "198.18.8.1")]))
+                .met,
+            "/21 stops at 198.18.7.255"
+        );
+    }
+
+    /// Mayara cannot find one yet, and saying so beats letting the user wait.
+    #[test]
+    fn a_standalone_quantum_is_reported_as_unsupported() {
+        let check =
+            Expectation::RaymarineQuantumStandalone.check(&interfaces(&[("eth0", "192.168.1.10")]));
+
+        assert!(!check.met);
+        assert!(check.finding.contains("does not support"));
+    }
+
+    /// Being unable to read the interfaces changes nothing about a radar
+    /// mayara cannot find at all, so that answer has to come first.
+    #[test]
+    fn a_standalone_quantum_is_unsupported_even_with_no_interface_list() {
+        let check = Expectation::RaymarineQuantumStandalone.check(&InterfaceApi::default());
+
+        assert!(!check.met);
+        assert!(
+            check.finding.contains("does not support"),
+            "not 'could not read the interfaces', which invites the user to keep waiting"
+        );
+    }
+
+    /// Navico is found by multicast from any address, so the answer is "your
+    /// network is not the problem" -- unless there is no address at all.
+    #[test]
+    fn navico_asks_nothing_of_the_address() {
+        let check = Expectation::Navico.check(&interfaces(&[("eth0", "192.168.1.10")]));
+        assert!(check.met);
+        assert_eq!(check.remedy, None);
+
+        let nothing = Expectation::Navico.check(&interfaces_without_addresses());
+        assert!(nothing.met, "still worth searching");
+        assert!(nothing.remedy.is_some(), "but say the host has no address");
+    }
+
+    /// Loopback is not a radar network and must not count as a match.
+    #[test]
+    fn loopback_is_not_an_address_a_radar_can_use() {
+        let check = Expectation::RaymarineRd.check(&interfaces(&[("lo", "127.0.0.1")]));
+        assert!(!check.met);
+    }
+
+    /// Under `--emulator`, or if the locator does not answer, there is no
+    /// interface list. Telling the user their host has no address would send
+    /// them reconfiguring a network that is fine.
+    #[test]
+    fn an_unreadable_interface_list_is_not_reported_as_a_missing_address() {
+        let check = Expectation::Furuno.check(&InterfaceApi::default());
+
+        assert!(check.met, "nothing is known to be wrong");
+        assert!(check.finding.contains("could not read"));
+        assert_eq!(check.remedy, None);
+        assert!(
+            check.requirement.contains("172.31.x.x"),
+            "the requirement is still worth stating"
+        );
+    }
+
+    /// Brands are cargo features. A build without one will never produce that
+    /// radar, and telling the user their network is fine would have them
+    /// checking cables for something that cannot arrive. Tested through the
+    /// injected flag, because the test build has every brand compiled in.
+    #[test]
+    fn a_brand_this_build_cannot_look_for_is_said_so_plainly() {
+        let check =
+            Expectation::Garmin.check_supported(&interfaces(&[("eth0", "172.16.2.5")]), false);
+
+        assert!(
+            !check.met,
+            "a correct network cannot save an absent locator"
+        );
+        assert!(check.finding.contains("no Garmin support"));
+        assert!(check.remedy.is_some());
+
+        // The same host, with the brand present, is fine.
+        let supported =
+            Expectation::Garmin.check_supported(&interfaces(&[("eth0", "172.16.2.5")]), true);
+        assert!(supported.met);
+    }
+
+    /// Raymarine's three families are one brand to discovery, so all three
+    /// stand or fall with the same feature.
+    #[test]
+    fn every_raymarine_expectation_belongs_to_the_raymarine_brand() {
+        for expectation in [
+            Expectation::RaymarineRd,
+            Expectation::RaymarineQuantumMfd,
+            Expectation::RaymarineQuantumStandalone,
+        ] {
+            assert_eq!(expectation.brand(), Brand::Raymarine);
+        }
+        assert_eq!(Expectation::Navico.brand(), Brand::Navico);
+    }
+
+    #[test]
+    fn an_expectation_is_named_the_way_the_url_spells_it() {
+        use std::str::FromStr;
+        assert_eq!(
+            Expectation::from_str("raymarine-quantum-mfd").unwrap(),
+            Expectation::RaymarineQuantumMfd
+        );
+        assert_eq!(
+            Expectation::from_str("FURUNO").unwrap(),
+            Expectation::Furuno
+        );
+        assert!(Expectation::from_str("nonsense").is_err());
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -33,7 +33,7 @@ pub mod trail;
 pub(crate) mod units;
 
 use crate::brand::CommandSender;
-use crate::config::{Consent, Persistence, SettingsStorage};
+use crate::config::{Consent, KnownRadar, Persistence, SettingsStorage};
 use crate::protos::RadarMessage::RadarMessage;
 use crate::radar::settings::{
     ControlDestination, ControlError, ControlId, ControlUpdate, ControlValue, SharedControls,
@@ -922,6 +922,12 @@ impl SharedRadars {
         } else {
             None
         }
+    }
+
+    /// Radars this install has seen before, for the discovery page to name
+    /// while it waits for them to turn up again.
+    pub fn known_radars(&self) -> Vec<KnownRadar> {
+        self.radars.read().unwrap().persistent_data.known_radars()
     }
 
     /// What this run does with radar settings, for the status endpoint and

--- a/web/gui/api.js
+++ b/web/gui/api.js
@@ -235,6 +235,29 @@ export async function fetchServerStatus() {
 }
 
 /**
+ * Ask whether this host's network can carry the kind of radar the user says
+ * they are waiting for.
+ *
+ * @param {string} expectation - `navico`, `furuno`, `garmin`, `koden`,
+ *   `raymarine-rd`, `raymarine-quantum-mfd`, `raymarine-quantum-standalone`.
+ * @returns {Promise<{met: boolean, requirement: string, finding: string, remedy?: string}|null>}
+ */
+export async function fetchNetworkCheck(expectation) {
+  await detectMode();
+
+  try {
+    const response = await apiFetch(
+      `${getRadarsPath()}/network-check/${encodeURIComponent(expectation)}`
+    );
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (err) {
+    console.log("Network check unavailable:", err);
+    return null;
+  }
+}
+
+/**
  * Ask the server whether the usage-report question should be put to the user.
  *
  * Returns null when the answer cannot be had — an older mayara has no such

--- a/web/gui/discovery.css
+++ b/web/gui/discovery.css
@@ -300,6 +300,73 @@
 }
 
 /* ============================================
+   Help after a radar has stayed missing
+   ============================================ */
+
+.myr_search_help {
+  display: none;
+  background: linear-gradient(135deg, rgba(70, 60, 130, 0.9), rgba(50, 42, 95, 0.9));
+  border: 1px solid rgba(150, 140, 220, 0.5);
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 25px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.myr_search_title {
+  font-size: 20px;
+  font-weight: bold;
+  color: #fff;
+  margin-bottom: 12px;
+}
+
+.myr_search_known {
+  padding: 10px 14px;
+  margin-bottom: 14px;
+  background: rgba(0, 0, 0, 0.22);
+  border-radius: 8px;
+}
+
+.myr_expectation_label {
+  display: block;
+  /* base.css caps every label at 150px for the control panel's form layout,
+     which folds this question into a narrow column. */
+  max-width: none;
+  margin: 16px 0 8px;
+  font-weight: bold;
+}
+
+.myr_expectation_select {
+  width: 100%;
+  max-width: 520px;
+  padding: 10px;
+  font-size: 15px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+}
+
+.myr_check_result {
+  margin-top: 16px;
+  padding: 14px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  border-left: 4px solid rgba(255, 255, 255, 0.4);
+}
+
+/* Green for "your network is fine", amber for "this cannot work" — the
+   distinction the user is reading for. */
+.myr_check_ok {
+  border-left-color: rgba(120, 220, 140, 0.9);
+}
+
+.myr_check_bad {
+  border-left-color: rgba(250, 180, 90, 0.95);
+}
+
+/* ============================================
    One-time question: report that this works?
    ============================================ */
 

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -41,6 +41,9 @@
             </div>
         </div>
 
+        <div id="search_help" class="myr_search_help">
+        </div>
+
         <div id="webgpu_warning" class="myr_webgpu_warning">
         </div>
 

--- a/web/gui/mayara.js
+++ b/web/gui/mayara.js
@@ -11,12 +11,19 @@ import {
   setTelemetryConsent,
 } from "./api.js";
 import { radarCombinations, multiViewUrl } from "./radar-list.js";
+import { HELP_AFTER_MS, renderSearchHelp } from "./search-help.js";
 
 const { a, tr, td, div, p, strong, details, summary, code, br, span, button } =
   van.tags;
 
 // Global WebGPU availability flag
 let webGPUAvailable = false;
+
+// When the current run of finding nothing began, and what the server told us
+// about radars seen before. Both feed the help offered after HELP_AFTER_MS.
+let searchingSince = Date.now();
+let knownRadars = [];
+let compiledBrands = [];
 
 // Network requirements for different radar brands
 const NETWORK_REQUIREMENTS = {
@@ -527,11 +534,16 @@ function radarsLoaded(d) {
 
   // Only rebuild if radar count changed (avoids collapsing the help details)
   if (c === previousRadarCount && c === 0) {
-    // No change, just reschedule poll
+    // Still nothing: the list needs no rebuild, but the help may be due.
+    updateSearchHelp(c);
     setTimeout(loadRadars, 2000);
     return;
   }
   previousRadarCount = c;
+  if (c > 0) {
+    searchingSince = Date.now();
+  }
+  updateSearchHelp(c);
 
   // Clear previous content
   r.innerHTML = "";
@@ -915,6 +927,12 @@ function showActionButtons() {
 // page holds no WebSocket to carry the matching Signal K notification.
 async function showSettingsWarning() {
   const status = await fetchServerStatus();
+  if (status && Array.isArray(status.knownRadars)) {
+    knownRadars = status.knownRadars;
+  }
+  if (status && Array.isArray(status.brands)) {
+    compiledBrands = status.brands;
+  }
   if (!status || status.settingsStored || !status.settingsPath) return;
 
   const warningDiv = document.getElementById("settings_warning");
@@ -984,6 +1002,34 @@ async function askAboutTelemetry() {
       )
     )
   );
+}
+
+// True while the help is on screen, so a poll does not re-render a dropdown
+// the user is reading.
+let helpShown = false;
+
+// Offer the "what were you expecting?" help once a radar has stayed missing
+// for long enough, and take it away the moment one turns up.
+function updateSearchHelp(radarCount) {
+  const box = document.getElementById("search_help");
+  if (!box) return;
+
+  const waited = Date.now() - searchingSince;
+  const due = radarCount === 0 && waited >= HELP_AFTER_MS;
+
+  if (!due) {
+    box.style.display = "none";
+    box.replaceChildren();
+    helpShown = false;
+    return;
+  }
+
+  // Rendering again would throw away a dropdown the user is reading.
+  if (helpShown) return;
+
+  helpShown = true;
+  box.style.display = "block";
+  renderSearchHelp(box, knownRadars, compiledBrands);
 }
 
 async function loadRadars() {

--- a/web/gui/search-help.js
+++ b/web/gui/search-help.js
@@ -1,0 +1,139 @@
+// What the discovery page says once a radar has not turned up.
+//
+// The network hints below the radar list describe every brand at once, which
+// is the right thing to read while you are still hopeful. After a while it
+// stops being useful: the user is looking at a page that says "searching" and
+// has no idea which of five brands' requirements applies to them. So we ask
+// the one question that narrows it down -- what were you expecting? -- and let
+// the server answer whether this host could carry it.
+
+import van from "./vendor/van-1.5.2.debug.js";
+import { fetchNetworkCheck } from "./api.js";
+
+const { div, p, span, strong, select, option, label } = van.tags;
+
+// How long to let discovery run before offering help. Long enough that a
+// radar that is merely slow to announce itself is not preempted -- a HALO
+// answers within a couple of seconds, a cold Quantum takes longer -- and short
+// enough that nobody is left watching a spinner wondering if it is broken.
+export const HELP_AFTER_MS = 20000;
+
+// The question is about the radar the user owns, not about the protocol
+// family mayara sorts them into, so Raymarine appears three times: the three
+// products need three different networks.
+export const EXPECTATIONS = [
+  ["navico", "Navico", "Navico — Simrad, Lowrance, B&G (HALO, 3G/4G, BR24)"],
+  ["furuno", "Furuno", "Furuno DRS (DRS4D-NXT, DRS6A-NXT, …)"],
+  ["garmin", "Garmin", "Garmin (xHD, xHD2, Fantom)"],
+  ["raymarine-rd", "Raymarine", "Raymarine RD (RD418HD, RD424HD, analogue via E-series)"],
+  ["raymarine-quantum-mfd", "Raymarine", "Raymarine Quantum, on a network with an MFD"],
+  ["raymarine-quantum-standalone", "Raymarine", "Raymarine Quantum, on its own (no MFD)"],
+  ["koden", "Koden", "Koden"],
+];
+
+const PROMPT = ["", "", "Select the radar you are expecting…"];
+
+/// The radars worth offering: brands are cargo features, and a build without
+/// one will never find that radar however the network is set up. An older
+/// server that does not report its brands gets the full list rather than an
+/// empty one.
+export function expectationsFor(brands) {
+  const offered =
+    Array.isArray(brands) && brands.length > 0
+      ? EXPECTATIONS.filter(([, brand]) => brands.includes(brand))
+      : EXPECTATIONS;
+
+  return [PROMPT, ...offered];
+}
+
+/// What to say about the radars this install has had working before.
+///
+/// Someone whose radar worked last week has a different problem from someone
+/// setting one up for the first time, and saying so is most of the reassurance
+/// that the page is actually looking for *their* radar.
+export function knownRadarsMessage(knownRadars) {
+  if (!knownRadars || knownRadars.length === 0) return null;
+
+  const named = knownRadars.map((radar) => {
+    const model = radar.model ? ` (${radar.model})` : "";
+    return radar.name + model;
+  });
+
+  return named.length === 1
+    ? `Mayara is looking for every radar it supports, and for ${named[0]} in particular — it has worked here before.`
+    : `Mayara is looking for every radar it supports, and in particular for these, which have worked here before: ${named.join(", ")}.`;
+}
+
+// Render the server's verdict about one kind of radar.
+function verdict(check) {
+  if (!check) {
+    return div(
+      { class: "myr_check_result" },
+      p("Mayara could not check the network just now. Try the Network button below.")
+    );
+  }
+
+  return div(
+    { class: "myr_check_result " + (check.met ? "myr_check_ok" : "myr_check_bad") },
+    p(strong(check.met ? "The network looks right." : "That will not work as set up.")),
+    p(check.requirement),
+    p(check.finding),
+    check.remedy ? p(strong("What to do: "), check.remedy) : null,
+    check.met
+      ? p("Mayara keeps searching. If the radar still does not appear, check that it is powered and wired to this network.")
+      : null
+  );
+}
+
+/// Ask which radar the user is waiting for, and answer whether this host could
+/// see it. `container` is emptied and filled.
+export function renderSearchHelp(container, knownRadars, brands) {
+  container.replaceChildren();
+
+  const known = knownRadarsMessage(knownRadars);
+  if (known) {
+    van.add(container, p({ class: "myr_search_known" }, known));
+  }
+
+  const result = div({ class: "myr_check_slot" });
+
+  // Answers arrive out of order if the user tries a second radar while the
+  // first is still in flight, and the loser would overwrite the winner.
+  let pending = 0;
+
+  const dropdown = select(
+    {
+      class: "myr_expectation_select",
+      onchange: async (e) => {
+        const expectation = e.target.value;
+        const generation = ++pending;
+
+        if (!expectation) {
+          result.replaceChildren();
+          return;
+        }
+        result.replaceChildren(
+          div({ class: "myr_check_result" }, p("Checking this host's network…"))
+        );
+
+        const check = await fetchNetworkCheck(expectation);
+        if (generation !== pending) return;
+        result.replaceChildren(verdict(check));
+      },
+    },
+    expectationsFor(brands).map(([value, , text]) => option({ value }, text))
+  );
+
+  van.add(
+    container,
+    div({ class: "myr_search_title" }, "Still nothing found"),
+    p(
+      "Mayara has been searching for a while without finding a radar. Answering ",
+      "this lets it tell you whether this computer's network can reach that radar ",
+      "at all."
+    ),
+    label({ class: "myr_expectation_label" }, "What brand of radar were you expecting to show up?"),
+    dropdown,
+    result
+  );
+}


### PR DESCRIPTION
## Summary

When no radar turns up, the discovery page says "Searching for radars…" and
offers network hints covering every brand at once. That is the right thing to
read while you are still hopeful, and useless ten minutes later: the user has
no way to know which of five brands' requirements is theirs.

After 20 seconds without a radar, the page now does two things.

**It says what it is looking for.** If this install has had radars working
before, it names them — someone whose radar worked last week has a different
problem from someone setting one up today, and saying so is most of the
reassurance that mayara is looking for *their* radar:

> Mayara is looking for every radar it supports, and in particular for these,
> which have worked here before: HALO24 034 A (HALO24), HALO24 034 B (HALO24).

**It asks the one question that narrows everything down** — which radar were
you expecting? — and the server answers whether this host's addresses can carry
it at all:

> This radar can only be reached from a host in 172.31.x.x.
> This host has 10.67.0.2 on boatnet, 172.18.0.1 on br-758b421635a9, …, none of
> which is in that range.
> **What to do:** Give the interface the radar is wired to an address in
> 172.31.x.x, then reload this page.

Raymarine needs three entries rather than one, which is what the recent
addressing research bought us:

| expectation | needs | why |
| --- | --- | --- |
| Raymarine RD | `10.x.x.x` | self-assigns `10.<three bytes of its MAC>`, answers nobody outside that /8 |
| Quantum, with an MFD | `198.18.0.x–198.18.7.x` | the W3 board is a DHCP client on the mandatory Axiom `/21` |
| Quantum, standalone | — | says plainly that mayara cannot find one yet, instead of letting the user wait |
| Furuno / Garmin | `172.31.x.x` / `172.16–172.31.x.x` | already known |
| Navico / Koden | nothing | found by multicast and broadcast |

The check lives on the server, beside the brand code that already knows these
subnets, so the subnet arithmetic is unit-tested rather than reimplemented in
JavaScript. `GET …/radars/network-check/{expectation}` answers it;
`…/radars/status` now also carries `knownRadars`.

## Two things it deliberately will not claim

Both came out of testing, and both are cases where being directive would have
been directive in the wrong direction:

- **With no interface list, it says so.** Under `--emulator`, or when the
  locator does not answer, there are no interfaces to read. The first version
  reported "this host has no IPv4 address at all", which would send someone
  reconfiguring a network that is fine.
- **A match names the interface.** On the test Pi, Garmin came back *met*
  because a **Docker bridge** at `172.18.0.1` falls in Garmin's range while
  carrying no radar traffic. On a containerised install that is more likely
  than not, so the answer now says which interface matched and to check that it
  is the one the radar is wired to.

## Tested

Against a real Pi with the radar switched off: `knownRadars` returned both
HALO24s by name, and the checks answered correctly for its actual addresses —
RD met (`boatnet` has 10.67.0.2), Quantum+MFD not met, Furuno not met, Navico
unconstrained, Garmin met-with-the-caveat above. The panel was confirmed on
screen, including a CSS fix: `base.css` caps every `label` at 150px for the
control panel's form layout, which folded the question into a narrow column.

Nine unit tests cover the subnet logic, including the `/21` boundary
(198.18.7.254 in, 198.18.8.1 out), loopback not counting as a match, and the
unreadable-interface-list case. Two more cover `knownRadars`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds delayed radar discovery help after 20 seconds without a detected radar.
- Shows previously known radars and lets users select the expected radar type.
- Adds `GET …/radars/network-check/{expectation}` with checks for supported radar brands.
- Reports matching network interfaces, Docker bridges, missing interface data, and remedies.
- Filters expectations to radar brands compiled into the current build. Older servers remain supported.
- Extends radar status responses with `knownRadars` and `brands`.
- Adds persistence and network-check unit tests, including subnet boundaries, loopback handling, interface errors, brand filtering, and fallback behavior.
- Adds styling for the search-help panel and fixes the control-panel form layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->