### PR TITLE
style(windows): pass OVERLAPPED by shared reference

### DIFF
--- a/src/lib/network/windows/mod.rs
+++ b/src/lib/network/windows/mod.rs
@@ -102,13 +102,13 @@ fn create_ip_addr_change_event() -> Result<HANDLE, RadarError> {
         }
 
         // Prepare an OVERLAPPED structure with the event handle
-        let mut overlapped = OVERLAPPED {
+        let overlapped = OVERLAPPED {
             hEvent: event,
             ..Default::default()
         };
 
         // Register for address change notifications
-        let notify_result = NotifyAddrChange(null_mut(), &mut overlapped);
+        let notify_result = NotifyAddrChange(null_mut(), &overlapped);
         if notify_result != ERROR_SUCCESS.0 && notify_result != ERROR_IO_PENDING.0 {
             let windows_error = W32Error::new(notify_result);
             log::error!(


### PR DESCRIPTION
Contributors building on Windows cannot commit any Rust change: the `.githooks/pre-commit` hook runs `cargo clippy --no-deps --all-targets -- -D warnings`, and that already fails on `main` before any edit is made. CI does not catch it because it lints on Linux, where the offending code is compiled out.

The lint is `clippy::unnecessary_mut_passed` on `NotifyAddrChange`, whose binding takes `*const OVERLAPPED`, so the `&mut` borrow was never needed. This is the only clippy warning in the tree on Windows across all targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H85CDR2cLqoPEm2UpQazcA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Passes `OVERLAPPED` to `NotifyAddrChange` by shared reference. Removes unnecessary mutability and resolves the Windows `clippy::unnecessary_mut_passed` warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->