### PR TITLE
fix(windows): detect wireless and unusable interfaces correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ rtnetlink = "0.23.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 w32-error = "1.0.0"
-windows = { version = "0.62.2", features = ["Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_WiFi", "Win32_Networking_WinSock", "Win32_System", "Win32_System_Threading", "Win32_Security", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_System_SystemServices" ] }
+windows = { version = "0.62.2", features = ["Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_System", "Win32_System_Threading", "Win32_Security", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_System_SystemServices" ] }
 
 [build-dependencies]
 protobuf-codegen = "3.7.2"

--- a/src/lib/locator.rs
+++ b/src/lib/locator.rs
@@ -19,6 +19,7 @@ use tokio::{task::JoinSet, time::sleep};
 use tokio_graceful_shutdown::SubsystemHandle;
 
 use crate::brand::{LocatorId, RadarLocator, create_brand_listeners};
+use crate::network::LinkKind;
 use crate::radar::{RadarError, SharedRadars};
 use crate::{Brand, Cli, InterfaceApi, InterfaceId, InterfaceStatus, RadarInterfaceApi, network};
 
@@ -371,16 +372,27 @@ impl Locator {
                     let mut active: bool = false;
 
                     if only_interface.is_none() || only_interface.as_ref() == Some(&itf.name) {
+                        let link_kind = network::link_kind(&itf.name);
                         for nic_addr in itf.addr {
                             if let (IpAddr::V4(nic_ip), Some(IpAddr::V4(nic_netmask))) =
                                 (nic_addr.ip(), nic_addr.netmask())
                             {
-                                if avoid_wifi && network::is_wireless_interface(&itf.name) {
-                                    log::trace!("Ignoring wireless interface '{}'", itf.name);
+                                let ignored = match link_kind {
+                                    LinkKind::Unusable => Some((
+                                        InterfaceStatus::LinkTypeIgnored,
+                                        "link type cannot carry radar traffic",
+                                    )),
+                                    LinkKind::Wireless if avoid_wifi => {
+                                        Some((InterfaceStatus::WirelessIgnored, "wireless"))
+                                    }
+                                    _ => None,
+                                };
+                                if let Some((status, reason)) = ignored {
+                                    log::trace!("Ignoring interface '{}': {}", itf.name, reason);
                                     if_api.insert(
                                         InterfaceId::new(&itf.name, Some(nic_ip)),
                                         RadarInterfaceApi::new(
-                                            InterfaceStatus::WirelessIgnored,
+                                            status,
                                             Some(nic_ip),
                                             Some(nic_netmask),
                                             None,

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -444,6 +444,9 @@ enum InterfaceStatus {
     Ok,
     NoIPv4Address,
     WirelessIgnored,
+    /// The link cannot carry radar traffic (Bluetooth, tunnel, PPP, ...) and is
+    /// skipped even with `--allow-wifi`.
+    LinkTypeIgnored,
 }
 
 /// Information about a network interface and its radar listeners
@@ -459,7 +462,8 @@ enum InterfaceStatus {
     }
 }))]
 struct RadarInterfaceApi {
-    // Interface status: null (ok), "No IPv4 address" or "Wireless ignored"
+    // Interface status: null (ok), "No IPv4 address", "Wireless ignored" or
+    // "Link type ignored"
     status: InterfaceStatus,
     /// IPv4 address assigned to this interface
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib/network/linux/mod.rs
+++ b/src/lib/network/linux/mod.rs
@@ -1,3 +1,4 @@
+use crate::network::LinkKind;
 use crate::radar::RadarError;
 
 use futures::stream::StreamExt;
@@ -76,7 +77,19 @@ async fn wait_for_ip_addr_change(
     }
 }
 
-pub fn is_wireless_interface(interface_name: &str) -> bool {
+/// Classify an interface by the link technology behind it.
+///
+/// Only WiFi is distinguished here; Linux has no equally cheap probe for the
+/// link types Windows reports as [`LinkKind::Unusable`].
+pub fn link_kind(interface_name: &str) -> LinkKind {
+    if is_wireless_interface(interface_name) {
+        LinkKind::Wireless
+    } else {
+        LinkKind::Wired
+    }
+}
+
+fn is_wireless_interface(interface_name: &str) -> bool {
     use libc::{AF_INET, Ioctl, c_void, ifreq, ioctl, strncpy};
     use std::ffi::CString;
 

--- a/src/lib/network/macos/mod.rs
+++ b/src/lib/network/macos/mod.rs
@@ -11,6 +11,7 @@ use system_configuration::sys::dynamic_store::SCDynamicStoreCreateRunLoopSource;
 use tokio::sync::broadcast::Sender;
 use tokio_util::sync::CancellationToken;
 
+use crate::network::LinkKind;
 use crate::radar::RadarError;
 
 pub async fn spawn_wait_for_ip_addr_change(
@@ -90,7 +91,19 @@ fn wait_for_ip_addr_change(
     Ok(())
 }
 
-pub fn is_wireless_interface(interface_name: &str) -> bool {
+/// Classify an interface by the link technology behind it.
+///
+/// Only WiFi is distinguished here; macOS has no equally cheap probe for the
+/// link types Windows reports as [`LinkKind::Unusable`].
+pub fn link_kind(interface_name: &str) -> LinkKind {
+    if is_wireless_interface(interface_name) {
+        LinkKind::Wireless
+    } else {
+        LinkKind::Wired
+    }
+}
+
+fn is_wireless_interface(interface_name: &str) -> bool {
     use system_configuration::dynamic_store::*;
 
     let Some(store) = SCDynamicStoreBuilder::new("networkInterfaceInfo").build() else {

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -410,6 +410,10 @@ pub(crate) enum LinkKind {
     Wireless,
     /// A link that cannot carry radar traffic at all, such as a Bluetooth
     /// personal area network or a VPN tunnel. Never searched.
+    ///
+    /// Only Windows classifies interfaces this way; Linux and macOS never
+    /// construct it.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     Unusable,
 }
 

--- a/src/lib/network/mod.rs
+++ b/src/lib/network/mod.rs
@@ -401,18 +401,30 @@ pub(crate) fn interface_for(nic_addr: &Ipv4Addr) -> Option<(String, Ipv4Addr)> {
     None
 }
 
+/// What an interface's link type means for radar discovery.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LinkKind {
+    /// A wired link. Radars are searched for here.
+    Wired,
+    /// A wireless link. Searched only when `--allow-wifi` is given.
+    Wireless,
+    /// A link that cannot carry radar traffic at all, such as a Bluetooth
+    /// personal area network or a VPN tunnel. Never searched.
+    Unusable,
+}
+
 #[cfg(target_os = "macos")]
-pub(crate) use macos::is_wireless_interface;
+pub(crate) use macos::link_kind;
 #[cfg(target_os = "macos")]
 pub(crate) use macos::spawn_wait_for_ip_addr_change;
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::is_wireless_interface;
+pub(crate) use linux::link_kind;
 #[cfg(target_os = "linux")]
 pub(crate) use linux::spawn_wait_for_ip_addr_change;
 
 #[cfg(target_os = "windows")]
-pub(crate) use windows::is_wireless_interface;
+pub(crate) use windows::link_kind;
 #[cfg(target_os = "windows")]
 pub(crate) use windows::spawn_wait_for_ip_addr_change;
 

--- a/src/lib/network/windows/mod.rs
+++ b/src/lib/network/windows/mod.rs
@@ -102,13 +102,13 @@ fn create_ip_addr_change_event() -> Result<HANDLE, RadarError> {
         }
 
         // Prepare an OVERLAPPED structure with the event handle
-        let mut overlapped = OVERLAPPED {
+        let overlapped = OVERLAPPED {
             hEvent: event,
             ..Default::default()
         };
 
         // Register for address change notifications
-        let notify_result = NotifyAddrChange(null_mut(), &mut overlapped);
+        let notify_result = NotifyAddrChange(null_mut(), &overlapped);
         if notify_result != ERROR_SUCCESS.0 && notify_result != ERROR_IO_PENDING.0 {
             let windows_error = W32Error::new(notify_result);
             log::error!(

--- a/src/lib/network/windows/mod.rs
+++ b/src/lib/network/windows/mod.rs
@@ -5,12 +5,17 @@ use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use w32_error::W32Error;
 use windows::Win32::Foundation::{
-    CloseHandle, ERROR_IO_PENDING, ERROR_SERVICE_NOT_ACTIVE, ERROR_SUCCESS, HANDLE, WAIT_EVENT,
+    CloseHandle, ERROR_IO_PENDING, ERROR_SUCCESS, HANDLE, WAIT_EVENT,
 };
 use windows::Win32::NetworkManagement::IpHelper::NotifyAddrChange;
+use windows::Win32::NetworkManagement::Ndis::{
+    NDIS_PHYSICAL_MEDIUM, NdisPhysicalMediumBluetooth, NdisPhysicalMediumNative802_11,
+    NdisPhysicalMediumWirelessLan, NdisPhysicalMediumWirelessWan,
+};
 use windows::Win32::System::IO::OVERLAPPED;
 use windows::Win32::System::Threading::{CreateEventW, INFINITE, SetEvent, WaitForMultipleObjects};
 
+use crate::network::LinkKind;
 use crate::radar::RadarError;
 
 /// Create a manual‑reset, initially non‑signaled event.
@@ -124,51 +129,139 @@ fn create_ip_addr_change_event() -> Result<HANDLE, RadarError> {
     }
 }
 
-pub fn is_wireless_interface(interface_name: &str) -> bool {
-    use std::ptr::null_mut;
-    use windows::Win32::NetworkManagement::WiFi::{
-        WLAN_INTERFACE_INFO_LIST, WlanCloseHandle, WlanEnumInterfaces, WlanFreeMemory,
-        WlanOpenHandle,
-    };
+/// Classify an interface by the link technology behind it.
+///
+/// `interface_name` is an adapter *friendly* name, the same string that
+/// `NetworkInterface::show()` reports. `MIB_IF_ROW2` is the only interface table
+/// carrying the friendly name (`Alias`), the adapter type and the physical
+/// medium together, and all three are needed: Windows reports a Bluetooth
+/// personal area network as `IF_TYPE_ETHERNET_CSMACD`, exactly like real
+/// Ethernet, and only `PhysicalMediumType` tells them apart.
+///
+/// An interface missing from the table is reported as [`LinkKind::Wired`] so a
+/// lookup failure never silently hides a radar.
+pub fn link_kind(interface_name: &str) -> LinkKind {
+    lookup_link_kind(interface_name).unwrap_or(LinkKind::Wired)
+}
+
+fn lookup_link_kind(interface_name: &str) -> Option<LinkKind> {
+    use windows::Win32::NetworkManagement::IpHelper::{FreeMibTable, GetIfTable2, MIB_IF_TABLE2};
 
     unsafe {
-        // Open WLAN handle
-        let mut client_handle: HANDLE = Default::default();
-        let mut negotiated_version = 0;
-        let wlan_result = WlanOpenHandle(2, None, &mut negotiated_version, &mut client_handle);
-
-        if wlan_result == ERROR_SERVICE_NOT_ACTIVE.0 {
-            return false;
-        }
-        if wlan_result != 0 {
-            panic!("WlanOpenHandle failed with error: {}", wlan_result);
-        }
-
-        let mut interface_list: *mut WLAN_INTERFACE_INFO_LIST = null_mut();
-        let wlan_enum_result = WlanEnumInterfaces(client_handle, None, &mut interface_list);
-
-        if wlan_enum_result != 0 {
-            WlanCloseHandle(client_handle, None);
-            panic!("WlanEnumInterfaces failed with error: {}", wlan_enum_result);
+        let mut table: *mut MIB_IF_TABLE2 = null_mut();
+        let result = GetIfTable2(&mut table);
+        if result != ERROR_SUCCESS {
+            log::warn!(
+                "GetIfTable2 failed with error: {}, treating '{}' as wired",
+                W32Error::new(result.0),
+                interface_name
+            );
+            return None;
         }
 
-        let interfaces = &*interface_list;
+        // `Table` is a C flexible array: its one-element head is followed by
+        // `NumEntries` rows in the same allocation.
+        let rows =
+            std::slice::from_raw_parts((*table).Table.as_ptr(), (*table).NumEntries as usize);
+        let kind = rows
+            .iter()
+            .find(|row| nul_terminated(&row.Alias) == interface_name)
+            .map(|row| classify(row.Type, row.PhysicalMediumType));
 
-        // Check each WLAN interface
-        for i in 0..interfaces.dwNumberOfItems {
-            let wlan_interface = &interfaces.InterfaceInfo[i as usize];
-            let wlan_interface_name =
-                String::from_utf16_lossy(&wlan_interface.strInterfaceDescription);
-            if wlan_interface_name.trim() == interface_name.trim() {
-                WlanFreeMemory(interface_list as _);
-                WlanCloseHandle(client_handle, None);
-                return true;
-            }
-        }
+        FreeMibTable(table as _);
+        kind
+    }
+}
 
-        WlanFreeMemory(interface_list as _);
-        WlanCloseHandle(client_handle, None);
+fn classify(if_type: u32, medium: NDIS_PHYSICAL_MEDIUM) -> LinkKind {
+    use windows::Win32::NetworkManagement::IpHelper::{IF_TYPE_ETHERNET_CSMACD, IF_TYPE_IEEE80211};
+
+    // Checked before the adapter type, because a Bluetooth PAN claims to be
+    // Ethernet and would otherwise pass as a usable wired link.
+    if medium == NdisPhysicalMediumBluetooth {
+        return LinkKind::Unusable;
     }
 
-    false
+    let wireless_medium = medium == NdisPhysicalMediumNative802_11
+        || medium == NdisPhysicalMediumWirelessLan
+        || medium == NdisPhysicalMediumWirelessWan;
+
+    match if_type {
+        IF_TYPE_IEEE80211 => LinkKind::Wireless,
+        IF_TYPE_ETHERNET_CSMACD if wireless_medium => LinkKind::Wireless,
+        IF_TYPE_ETHERNET_CSMACD => LinkKind::Wired,
+        // Loopback, tunnels (Teredo, 6to4, IP-HTTPS), PPP/VPN dial-up, cellular
+        // modems and the rest cannot carry a radar's multicast spoke stream.
+        _ => LinkKind::Unusable,
+    }
+}
+
+/// Decode a fixed-size, NUL-padded Windows UTF-16 string.
+fn nul_terminated(buffer: &[u16]) -> String {
+    let end = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+    String::from_utf16_lossy(&buffer[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows::Win32::NetworkManagement::IpHelper::{
+        IF_TYPE_ETHERNET_CSMACD, IF_TYPE_IEEE80211, IF_TYPE_PPP, IF_TYPE_SOFTWARE_LOOPBACK,
+        IF_TYPE_TUNNEL,
+    };
+    use windows::Win32::NetworkManagement::Ndis::{
+        NdisPhysicalMedium802_3, NdisPhysicalMediumUnspecified,
+    };
+
+    #[test]
+    fn ethernet_is_wired() {
+        assert_eq!(
+            classify(IF_TYPE_ETHERNET_CSMACD, NdisPhysicalMedium802_3),
+            LinkKind::Wired
+        );
+    }
+
+    #[test]
+    fn native_80211_is_wireless() {
+        assert_eq!(
+            classify(IF_TYPE_IEEE80211, NdisPhysicalMediumNative802_11),
+            LinkKind::Wireless
+        );
+    }
+
+    #[test]
+    fn bluetooth_pan_is_unusable() {
+        // Values observed on a real adapter: Windows types a Bluetooth PAN as
+        // Ethernet, so only the medium keeps it out of radar discovery.
+        assert_eq!(
+            classify(IF_TYPE_ETHERNET_CSMACD, NdisPhysicalMediumBluetooth),
+            LinkKind::Unusable
+        );
+    }
+
+    #[test]
+    fn tunnels_loopback_and_ppp_are_unusable() {
+        for if_type in [IF_TYPE_TUNNEL, IF_TYPE_PPP, IF_TYPE_SOFTWARE_LOOPBACK] {
+            assert_eq!(
+                classify(if_type, NdisPhysicalMediumUnspecified),
+                LinkKind::Unusable,
+                "if_type {} must be unusable",
+                if_type
+            );
+        }
+    }
+
+    #[test]
+    fn alias_decoding_stops_at_the_nul_padding() {
+        let mut alias = [0u16; 257];
+        for (slot, c) in alias.iter_mut().zip("WiFi".encode_utf16()) {
+            *slot = c;
+        }
+        assert_eq!(nul_terminated(&alias), "WiFi");
+    }
+
+    #[test]
+    fn an_unknown_interface_is_assumed_wired() {
+        assert_eq!(link_kind("no such interface"), LinkKind::Wired);
+    }
 }


### PR DESCRIPTION
On Windows, mayara searched for radars over WiFi even when `--allow-wifi` was not given, so a laptop on a marina hotspot would flood its wireless link with discovery traffic that the flag was meant to suppress. It also probed adapters that can never carry radar data at all — Bluetooth personal area networks, VPN tunnels (Teredo, 6to4, IP-HTTPS), and dial-up/PPP links.

Now WiFi is skipped unless `--allow-wifi` is given, and links that cannot carry a radar's spoke stream are skipped in either mode.

## Technical detail

The WLAN check compared an adapter's *friendly* name, which is what `NetworkInterface::show()` reports (`WiFi`), against `WLAN_INTERFACE_INFO::strInterfaceDescription` (`Broadcom 802.11ac Network Adapter`), so it never matched. The NUL padding on that fixed-size field was not stripped either — `str::trim` does not remove `\0` — so the comparison could not have succeeded even for equal names. `is_wireless_interface` therefore always returned `false`.

Classification now goes through `GetIfTable2`. `MIB_IF_ROW2` carries the friendly name (`Alias`), the adapter type and `PhysicalMediumType` together, and all three are needed: Windows reports a Bluetooth PAN as `IF_TYPE_ETHERNET_CSMACD`, identical to real Ethernet, so an `IfType` allowlist alone does not exclude it. The shared `LinkKind` enum replaces the `is_wireless_interface` predicate on all three platforms; Linux and macOS keep their existing WiFi probe and never report `Unusable`.

Skipped interfaces are reported as `LinkTypeIgnored` in the diagnostics API, and an interface missing from the table falls back to `Wired`, so a lookup failure can never silently hide a radar.

Two latent faults go away with the old code: it panicked on any WLAN API error other than a stopped service, and it indexed `WLAN_INTERFACE_INFO_LIST::InterfaceInfo` — a one-element flexible array head — out of bounds on a machine with two or more wireless adapters.

## Test plan

- [x] Six unit tests cover the classification table and the NUL-padding decode
- [x] `cargo test` passes (480 lib + 16 integration)
- [x] `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D warnings` clean
- [x] Verified on hardware with a WiFi and a Bluetooth PAN adapter: default run skips both, `--allow-wifi` searches WiFi and still skips Bluetooth
- [ ] Not built on Linux or macOS — those two files only wrap their existing `bool` in `LinkKind`

> [!NOTE]
> Stacked on #616, without which the pre-commit hook cannot pass on Windows. Review only the top commit; the base retargets to `main` once #616 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H85CDR2cLqoPEm2UpQazcA