### PR TITLE
build: drop the unused reqwest build-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,9 +2394,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ windows = { version = "0.62.2", features = ["Win32_NetworkManagement_IpHelper", 
 
 [build-dependencies]
 protobuf-codegen = "3.7.2"
-reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls", "blocking"] }
 rust-embed = { version = "8.11.0", features = ["axum","interpolate-folder-path"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Building mayara from source is slower than it needs to be, especially when cross-compiling for the Pi or Windows: the build script pulls in an HTTP client and a full TLS stack it never calls.

## Technical detail

`build.rs` fetches the GUI by shelling out to `npm install @marineyachtradar/mayara-gui`. It never references `reqwest`, so the `[build-dependencies]` entry is dead weight.

It is a separate dependency edge from the normal one (which `telemetry.rs` and the AIS seed in `navdata.rs` do use), and build-dependencies compile for the *host*. On a cross build that meant a second full `reqwest` + `rustls` + `hyper` + `tokio` compile purely to satisfy a build script that makes no HTTP calls.

The normal and dev dependencies are untouched. Their features are already minimal — all three declarations use `default-features = false`, and `rustls-tls`/`json` remain load-bearing for the HTTPS telemetry endpoint and the Signal K AIS seed.

## Test plan

- [x] `cargo build` succeeds with the build-dependency removed
- [x] `cargo test` passes (511 tests)
- [x] `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D warnings` clean
- [x] Lockfile change is limited to dropping `futures-channel` and `futures-util` from reqwest's edge — no crate leaves the graph, since reqwest is still a normal dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes the unused `reqwest` build dependency. Keeps the runtime and development `reqwest` dependencies unchanged. Updates the lockfile without removing crates from the dependency graph.

Validation passes with `cargo build`, 511 tests, `cargo fmt --check`, and Clippy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->