### PR TITLE
fix(stream): deliver fixed-policy subscriptions on schedule

### DIFF
--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1712,8 +1712,21 @@ async fn ws_signalk_delta(
         send_message(socket, sk_delta).await?;
     }
 
+    // A fresh `sleep` per iteration would be cancelled and restarted by every
+    // other branch, so on a busy radar the periodic delivery would starve and
+    // a `fixed` subscription would answer once. An interval keeps its own
+    // schedule across iterations; it is rebuilt only when a subscription
+    // changes how often we have to wake.
+    let mut period = subscriptions.get_timeout();
+    let mut ticker = periodic_ticker(period);
+
     loop {
         let mut shutdown_rx = shutdown_tx.subscribe();
+
+        if subscriptions.get_timeout() != period {
+            period = subscriptions.get_timeout();
+            ticker = periodic_ticker(period);
+        }
 
         tokio::select! {
             _ = shutdown_rx.recv() => {
@@ -1784,7 +1797,7 @@ async fn ws_signalk_delta(
                 }
             }
 
-            _ = tokio::time::sleep(subscriptions.get_timeout()) => {
+            _ = ticker.tick() => {
                 if let Err(e) = send_all_subscribed(socket, &radars, &mut subscriptions, &mut meta_radar_data_sent).await
                 {
                     log::warn!("Cannot send subscribed data to websocket");
@@ -1793,6 +1806,14 @@ async fn ws_signalk_delta(
             }
         }
     }
+}
+
+/// A ticker whose first tick is a full period away: the values as they stand
+/// have just been sent, so the client is owed the next one, not another copy.
+fn periodic_ticker(period: std::time::Duration) -> tokio::time::Interval {
+    let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ticker
 }
 
 fn map_axum_error(e: axum::Error) -> Result<(), RadarError> {

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -24,6 +24,12 @@ use crate::{
 /// (e.g. `vessels.urn:mrn:signalk:uuid:…`) is detected from the upstream.
 const SELF_CONTEXT: &str = "vessels.self";
 
+/// No fixed-policy subscription means nothing to deliver on a schedule.
+const NEVER: Duration = Duration::from_secs(99999999);
+
+/// Signal K's default for a `fixed` subscription that names no period.
+const DEFAULT_FIXED_PERIOD_MS: u64 = 1000;
+
 /// Notification path for "this run is not saving radar settings". Under
 /// `mayara.` rather than `radar.<id>.`: the condition belongs to the server,
 /// not to any one radar.
@@ -608,19 +614,28 @@ impl ActiveSubscriptions {
     pub fn new(mode: Subscribe) -> ActiveSubscriptions {
         ActiveSubscriptions {
             mode,
-            timeout: Duration::from_secs(99999999),
+            timeout: NEVER,
             requests: Vec::new(),
             last_sent: HashMap::new(),
         }
     }
 
-    fn set_timeout(&mut self, timeout: u64) {
-        if timeout < u64::MAX {
-            let timeout = Duration::from_millis(timeout);
-            if self.timeout < timeout {
-                self.timeout = timeout;
-            };
-        }
+    /// How often the stream has to wake up to deliver on schedule: the
+    /// shortest period any fixed-policy request asked for. Only `fixed` is
+    /// delivered periodically -- `instant` and `ideal` go out when a value
+    /// changes -- so with no fixed request there is nothing to wake up for.
+    /// Recomputed from the live requests, so dropping the fastest
+    /// subscription slows the loop back down.
+    fn recompute_timeout(&mut self) {
+        self.timeout = self
+            .requests
+            .iter()
+            .filter(|r| r.policy == Some(Policy::Fixed))
+            .map(|r| r.period.unwrap_or(DEFAULT_FIXED_PERIOD_MS))
+            .filter(|p| *p > 0)
+            .min()
+            .map(Duration::from_millis)
+            .unwrap_or(NEVER);
     }
 
     pub fn get_timeout(&mut self) -> Duration {
@@ -636,8 +651,6 @@ impl ActiveSubscriptions {
     }
 
     pub fn subscribe(&mut self, subscription: Subscription) -> Result<bool, RadarError> {
-        let mut period = u64::MAX;
-
         // Answering `true` makes the caller send every vessel it knows of, so
         // it means "newly asked for", not "asked for". A client repeating a
         // subscription it already holds is not asking again.
@@ -646,13 +659,6 @@ impl ActiveSubscriptions {
         for path_subscription in subscription.subscribe {
             let path = &path_subscription.path;
             log::debug!("Subscribing to path: {}", path);
-
-            if let Some(p) = path_subscription.min_period {
-                period = min(p, period);
-            }
-            if let Some(p) = path_subscription.period {
-                period = min(p, period);
-            }
 
             // Asking twice for the same thing is one subscription, but asking
             // for it differently is not — the terms may differ.
@@ -665,7 +671,7 @@ impl ActiveSubscriptions {
                 self.requests.push(path_subscription);
             }
         }
-        self.set_timeout(period);
+        self.recompute_timeout();
 
         Ok(!asked_before && self.asks_for_vessels())
     }
@@ -687,6 +693,7 @@ impl ActiveSubscriptions {
             // to cover the same ground still asked for.
             self.requests.retain(|r| r.path != *path);
         }
+        self.recompute_timeout();
 
         Ok(())
     }
@@ -749,15 +756,22 @@ impl ActiveSubscriptions {
             if !full {
                 return false;
             }
+            // Periodic delivery happens on the stream's tick, so a period is
+            // only ever answered to the nearest tick. Half a tick of slack
+            // rounds to the closest one; without it the tick that lands a
+            // scheduling hair before the boundary is refused and every other
+            // one is lost, delivering at twice the period the client asked
+            // for. Paths asking for longer periods than the tick still wait
+            // the ticks out.
             if let (Some(period), Some(last)) = (terms.period, last)
-                && last + Duration::from_micros(period) > now
+                && last + Duration::from_millis(period) > now + self.timeout / 2
             {
                 return false;
             }
         }
 
         if let (Some(min_period), Some(last)) = (terms.min_period, last)
-            && last + Duration::from_micros(min_period) > now
+            && last + Duration::from_millis(min_period) > now
         {
             return false;
         }
@@ -1583,6 +1597,128 @@ mod build_tests {
         delta.add_meta_for_control("nav1034A", &control);
 
         assert_eq!(delta.build().map(|d| d.updates.len()), Some(1));
+    }
+
+    fn subscribe_to(json: serde_json::Value) -> Subscription {
+        serde_json::from_value(json).expect("a valid subscription")
+    }
+
+    /// The stream has to wake up at least as often as the shortest period a
+    /// client asked for, or a `fixed` subscription is answered once and never
+    /// again.
+    #[test]
+    fn the_wake_up_interval_is_the_shortest_period_asked_for() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        assert_eq!(
+            subs.get_timeout(),
+            NEVER,
+            "nothing to deliver on a schedule"
+        );
+
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "fixed", "period": 1000}
+        ]})))
+        .unwrap();
+        assert_eq!(subs.get_timeout(), Duration::from_millis(1000));
+
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.nav1034A.controls.gain", "policy": "fixed", "period": 250}
+        ]})))
+        .unwrap();
+        assert_eq!(
+            subs.get_timeout(),
+            Duration::from_millis(250),
+            "the faster subscription sets the pace"
+        );
+    }
+
+    /// Dropping the fastest subscription lets the loop slow back down.
+    #[test]
+    fn dropping_a_subscription_relaxes_the_wake_up_interval() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "fixed", "period": 1000},
+            {"path": "radars.nav1034A.controls.gain", "policy": "fixed", "period": 250}
+        ]})))
+        .unwrap();
+        assert_eq!(subs.get_timeout(), Duration::from_millis(250));
+
+        subs.desubscribe(
+            serde_json::from_value(json!({"desubscribe": [
+                {"path": "radars.nav1034A.controls.gain"}
+            ]}))
+            .expect("a valid desubscription"),
+        )
+        .unwrap();
+        assert_eq!(subs.get_timeout(), Duration::from_millis(1000));
+    }
+
+    /// Signal K states periods in milliseconds. Read as microseconds a
+    /// 1000 ms period expires a thousand times too early, and `fixed`
+    /// degenerates into "send everything, always".
+    #[test]
+    fn a_period_is_milliseconds() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.nav1034A.controls.gain", "policy": "fixed", "period": 1000}
+        ]})))
+        .unwrap();
+
+        let path = "radars.nav1034A.controls.gain";
+        assert!(subs.is_subscribed_path(path, true), "first tick delivers");
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(
+            !subs.is_subscribed_path(path, true),
+            "20ms into a 1000ms period the client is not owed another value"
+        );
+    }
+
+    /// Delivery happens on the stream's tick, so a period is answered to the
+    /// nearest tick: a tick landing a hair early still delivers, or every
+    /// other one is dropped and the client is served at half the rate it
+    /// asked for.
+    #[test]
+    fn a_tick_landing_just_early_still_delivers() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.nav1034A.controls.gain", "policy": "fixed", "period": 100}
+        ]})))
+        .unwrap();
+
+        let path = "radars.nav1034A.controls.gain";
+        assert!(subs.is_subscribed_path(path, true));
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(
+            subs.is_subscribed_path(path, true),
+            "60ms into a 100ms period is the tick this value belongs to"
+        );
+    }
+
+    /// A `fixed` subscription that names no period still has to be delivered:
+    /// Signal K's default period applies.
+    #[test]
+    fn fixed_without_a_period_uses_the_default() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "fixed"}
+        ]})))
+        .unwrap();
+        assert_eq!(
+            subs.get_timeout(),
+            Duration::from_millis(DEFAULT_FIXED_PERIOD_MS)
+        );
+    }
+
+    /// Change-driven policies are delivered when a value changes, so they must
+    /// not spin the loop up on their own.
+    #[test]
+    fn a_rate_limited_subscription_does_not_schedule_wake_ups() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "ideal", "minPeriod": 200}
+        ]})))
+        .unwrap();
+        assert_eq!(subs.get_timeout(), NEVER);
     }
 
     /// An emptied update must not take a full one down with it, nor survive

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -631,7 +631,7 @@ impl ActiveSubscriptions {
             .requests
             .iter()
             .filter(|r| r.policy == Some(Policy::Fixed))
-            .map(|r| r.period.unwrap_or(DEFAULT_FIXED_PERIOD_MS))
+            .filter_map(effective_period)
             .filter(|p| *p > 0)
             .min()
             .map(Duration::from_millis)
@@ -740,7 +740,7 @@ impl ActiveSubscriptions {
                 if policy.permits_more_than(&found.policy) {
                     found.policy = policy;
                 }
-                found.period = least(found.period, request.period);
+                found.period = least(found.period, effective_period(request));
                 found.min_period = least(found.min_period, request.min_period);
             }
         }
@@ -831,6 +831,18 @@ struct Terms {
     policy: Policy,
     period: Option<u64>,
     min_period: Option<u64>,
+}
+
+/// How often a request is answered. A `fixed` request that names no period
+/// still has Signal K's default, and that has to be the same number the wake-up
+/// interval and the throttle both work from: defaulting in one but not the
+/// other lets a path be woken every second and then refused until the next
+/// period a different subscription happens to name.
+fn effective_period(request: &PathSubscribe) -> Option<u64> {
+    match request.policy {
+        Some(Policy::Fixed) => Some(request.period.unwrap_or(DEFAULT_FIXED_PERIOD_MS)),
+        _ => request.period,
+    }
 }
 
 /// The smaller of two optional periods, treating absence as no limit.
@@ -1706,6 +1718,34 @@ mod build_tests {
         assert_eq!(
             subs.get_timeout(),
             Duration::from_millis(DEFAULT_FIXED_PERIOD_MS)
+        );
+    }
+
+    /// The default period has to reach the throttle as well as the wake-up
+    /// interval. Applied to only one of them, a `fixed` subscription that
+    /// names no period is delivered at whatever pace some other subscription
+    /// happens to set -- here every 100ms instead of the second it is owed.
+    #[test]
+    fn the_default_period_throttles_as_well_as_it_schedules() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "fixed"},
+            {"path": "radars.nav1034B.controls.gain", "policy": "fixed", "period": 100}
+        ]})))
+        .unwrap();
+        assert_eq!(
+            subs.get_timeout(),
+            Duration::from_millis(100),
+            "the fast subscription still sets the pace"
+        );
+
+        // Covered only by the wildcard, so it is owed the default period.
+        let path = "radars.nav1034A.controls.gain";
+        assert!(subs.is_subscribed_path(path, true));
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(
+            !subs.is_subscribed_path(path, true),
+            "60ms into the default 1000ms period this path is owed nothing"
         );
     }
 

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -27,7 +27,7 @@ const SELF_CONTEXT: &str = "vessels.self";
 /// No fixed-policy subscription means nothing to deliver on a schedule.
 const NEVER: Duration = Duration::from_secs(99999999);
 
-/// Signal K's default for a `fixed` subscription that names no period.
+/// Signal K's default for a `fixed` subscription that names no usable period.
 const DEFAULT_FIXED_PERIOD_MS: u64 = 1000;
 
 /// Notification path for "this run is not saving radar settings". Under
@@ -632,7 +632,6 @@ impl ActiveSubscriptions {
             .iter()
             .filter(|r| r.policy == Some(Policy::Fixed))
             .filter_map(effective_period)
-            .filter(|p| *p > 0)
             .min()
             .map(Duration::from_millis)
             .unwrap_or(NEVER);
@@ -840,7 +839,13 @@ struct Terms {
 /// period a different subscription happens to name.
 fn effective_period(request: &PathSubscribe) -> Option<u64> {
     match request.policy {
-        Some(Policy::Fixed) => Some(request.period.unwrap_or(DEFAULT_FIXED_PERIOD_MS)),
+        // A period of zero is not a rate anyone can be served at, and Signal K
+        // gives it no meaning; it is read as "no period named", which is the
+        // one reading that cannot produce either silence or a firehose.
+        Some(Policy::Fixed) => Some(match request.period {
+            Some(period) if period > 0 => period,
+            _ => DEFAULT_FIXED_PERIOD_MS,
+        }),
         _ => request.period,
     }
 }
@@ -1740,6 +1745,39 @@ mod build_tests {
         );
 
         // Covered only by the wildcard, so it is owed the default period.
+        let path = "radars.nav1034A.controls.gain";
+        assert!(subs.is_subscribed_path(path, true));
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(
+            !subs.is_subscribed_path(path, true),
+            "60ms into the default 1000ms period this path is owed nothing"
+        );
+    }
+
+    /// A period of zero is read as "none named" in both halves. Handled in one
+    /// and not the other it is either silence -- nothing schedules the wake-up
+    /// -- or a firehose, delivered on every tick some other subscription set.
+    #[test]
+    fn a_zero_period_is_read_as_no_period() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "fixed", "period": 0}
+        ]})))
+        .unwrap();
+        assert_eq!(
+            subs.get_timeout(),
+            Duration::from_millis(DEFAULT_FIXED_PERIOD_MS),
+            "a zero period still has to schedule a wake-up"
+        );
+
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.nav1034B.controls.gain", "policy": "fixed", "period": 100}
+        ]})))
+        .unwrap();
+        assert_eq!(subs.get_timeout(), Duration::from_millis(100));
+
+        // Covered by the zero-period wildcard, so it is owed the default
+        // period rather than every tick the faster subscription brings round.
         let path = "radars.nav1034A.controls.gain";
         assert!(subs.is_subscribed_path(path, true));
         std::thread::sleep(Duration::from_millis(60));


### PR DESCRIPTION
A client that subscribes with `policy: fixed` and a period — asking to be sent
the current value on a schedule, whether or not it changed — got one batch on
subscribing and then nothing. Measured against a live HALO24, before and after:

```
12s, period 1000:   before: 2 messages       after: 10 messages, one per second
```

## Cause

Three defects, each of which alone would have been survivable:

1. **`set_timeout` only ever moved the timeout up**, from a starting value of
   three years, so the periodic branch of the stream loop never fired. It now
   recomputes the shortest period any fixed-policy request asked for, and
   relaxes again when that subscription is dropped. `instant` and `ideal` are
   change-driven and no longer spin the loop up on their own.
2. **The period fields were read as microseconds** in the throttle and
   milliseconds in the timeout. Signal K states both in milliseconds.
3. **The periodic branch slept on a future rebuilt every loop iteration**, so
   every broadcast from a busy radar cancelled it before it could fire. It now
   keeps its own interval, rebuilt only when a subscription changes the pace.

Fixing the first two is not enough on a live radar: the third alone keeps the
schedule from ever arriving.

One further thing that only showed up live: delivery happens on the stream's
tick, so a period can only be answered to the nearest tick. Without rounding,
the tick that lands a scheduling hair before the boundary is refused and every
other one is lost — the measurement showed a steady 2 s cadence for a 1 s
subscription. Half a tick of slack rounds to the closest tick.

A `fixed` subscription that names no period now uses Signal K's default of
1000 ms rather than going silent.

## Verification

Against the HALO24 on the boat:

| subscription | delivered |
|---|---|
| `fixed`, period 1000 | 1.01s, 2.02s, 3.05s, 4.07s, 5.09s, 6.01s, 7.01s |
| `fixed`, period 250 | 12 batches in 3 s |
| `instant` / `subscribe=self` | unchanged, change-driven |

closes #551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Restores periodic delivery for `policy: fixed` subscriptions.
- Schedules delivery using the shortest active fixed-subscription period.
- Uses milliseconds consistently and defaults unspecified fixed periods to 1000 ms.
- Recomputes the schedule when subscriptions change.
- Uses a persistent interval ticker that is not cancelled by unrelated broadcasts.
- Preserves change-driven behavior for `instant` and `subscribe=self`.
- Adds coverage for timeout recomputation, period handling, default periods, and scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->