### PR TITLE
fix(navdata): let a fixed position outrank the navigation source

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -826,9 +826,9 @@ pub async fn start_session(
     navdata::init_nav_broadcast(radars.get_sk_client_tx());
 
     // Seed navigation data from --static-position (for shore-based installations
-    // without a connected Signal K/NMEA navigation source). Mirrors the emulator
-    // pattern: set atomics once, then periodically re-broadcast so late-joining
-    // GUI clients receive the current heading/position.
+    // whose position is known and fixed). The seeding makes these values
+    // authoritative -- see navdata::set_static_nav -- and the task below
+    // re-asserts them so they stay fresh and reach late-joining GUI clients.
     if let Some(static_pos) = args.get_static_position() {
         if static_pos.lat.is_finite()
             && static_pos.lon.is_finite()
@@ -837,10 +837,7 @@ pub async fn start_session(
             && (-180.0..=180.0).contains(&static_pos.lon)
         {
             let heading_rad = static_pos.heading.to_radians();
-            navdata::set_position(Some(static_pos.lat), Some(static_pos.lon), "static");
-            navdata::set_heading_true(Some(heading_rad), "static");
-            navdata::set_sog(Some(0.0));
-            navdata::set_cog(Some(heading_rad));
+            navdata::set_static_nav(static_pos.lat, static_pos.lon, heading_rad);
 
             subsystem.start(SubsystemBuilder::new(
                 "Static Navigation",
@@ -852,7 +849,16 @@ pub async fn start_session(
                         tokio::select! { biased;
                             _ = subsys.on_shutdown_requested() => break,
                             _ = interval.tick() => {
-                                navdata::broadcast_heading("static");
+                                // Re-assert as well as re-broadcast: this keeps
+                                // own-ship nav fresh, so a fixed installation
+                                // with no upstream never ages into "no
+                                // navigation data", while late-joining clients
+                                // still learn a position that never changes.
+                                navdata::refresh_static_nav(
+                                    static_pos.lat,
+                                    static_pos.lon,
+                                    heading_rad,
+                                );
                             }
                         }
                     }

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -39,6 +39,9 @@ static POSITION_LAT: AtomicF64 = AtomicF64::new(f64::NAN);
 static POSITION_LON: AtomicF64 = AtomicF64::new(f64::NAN);
 static COG: AtomicF64 = AtomicF64::new(f64::NAN);
 static SOG: AtomicF64 = AtomicF64::new(f64::NAN);
+/// Set once `--static-position` has seeded own-ship nav, after which nothing
+/// else may move the vessel. See [`set_static_nav`].
+static STATIC_NAV: AtomicBool = AtomicBool::new(false);
 
 /// Broadcast sender for navigation updates to GUI clients
 static NAV_BROADCAST_TX: OnceLock<tokio::sync::broadcast::Sender<SignalKDelta>> = OnceLock::new();
@@ -385,6 +388,47 @@ fn build_seed_updates(vessel: &Value) -> Option<Value> {
 /// a real (authoritative) true source or the derivation path.
 const DERIVED_SOURCE: &str = "magnetic+variation";
 
+/// The source name the `--static-position` seeding writes under.
+const STATIC_SOURCE: &str = "static";
+
+/// Whether a write from `source` has to be refused because the installation
+/// was given a fixed position. A shore station or a radar on a pier knows
+/// where it is and which way it points; an upstream that disagrees is wrong,
+/// and an upstream that disconnects must not be able to take the position
+/// away with it.
+fn static_nav_refuses(static_nav: bool, source: &str) -> bool {
+    static_nav && source != STATIC_SOURCE
+}
+
+fn static_nav_holds() -> bool {
+    STATIC_NAV.load(Ordering::Acquire)
+}
+
+/// Re-assert a fixed position and publish it, whether or not it changed.
+///
+/// A fixed installation's values never change, so the change-gated broadcasts
+/// in the setters would only ever fire once, and a GUI client connecting later
+/// would never be told where the radar is or which way it points. Called on a
+/// timer, this both keeps own-ship nav fresh and answers late joiners.
+pub fn refresh_static_nav(lat: f64, lon: f64, heading_rad: f64) {
+    set_static_nav(lat, lon, heading_rad);
+    broadcast_position_update(lat, lon, STATIC_SOURCE);
+    broadcast_heading(STATIC_SOURCE);
+}
+
+/// Seed own-ship nav from `--static-position` and make it authoritative.
+/// Idempotent: the periodic refresh calls it to keep the values fresh, so a
+/// fixed installation never ages into "no navigation data".
+pub fn set_static_nav(lat: f64, lon: f64, heading_rad: f64) {
+    STATIC_NAV.store(true, Ordering::Release);
+    // Position and heading carry the source the guard recognises; COG and SOG
+    // have no source, so they are stored past the guard rather than through it.
+    set_position(Some(lat), Some(lon), STATIC_SOURCE);
+    set_heading_true(Some(heading_rad), STATIC_SOURCE);
+    store_cog(Some(heading_rad));
+    store_sog(Some(0.0));
+}
+
 ///
 /// Get the heading in radians [0..2*PI>
 ///
@@ -411,6 +455,10 @@ pub fn get_heading_magnetic() -> Option<f64> {
 ///
 pub(crate) fn set_heading_true(heading: Option<f64>, source: &str) {
     use std::f64::consts::TAU;
+
+    if static_nav_refuses(static_nav_holds(), source) {
+        return;
+    }
 
     if let Some(h) = heading {
         assert!(
@@ -456,6 +504,13 @@ fn should_derive(true_authoritative: bool) -> bool {
 /// Set the magnetic heading in radians. Broadcast to the GUI (for the readout
 /// toggle) and feed the magnetic→true derivation.
 pub(crate) fn set_heading_magnetic(heading: Option<f64>, source: &str) {
+    // A fixed installation that reports someone else's magnetic heading
+    // contradicts the true heading it is reporting, so this is refused with
+    // the rest of own-ship nav.
+    if static_nav_refuses(static_nav_holds(), source) {
+        return;
+    }
+
     use std::f64::consts::TAU;
 
     if let Some(h) = heading {
@@ -478,6 +533,12 @@ pub(crate) fn set_heading_magnetic(heading: Option<f64>, source: &str) {
 /// Set the magnetic variation in radians and feed the magnetic→true derivation.
 /// Not displayed, so no GUI broadcast.
 pub(crate) fn set_magnetic_variation(variation: Option<f64>) {
+    // Variation is a property of where you are, and a fixed installation is
+    // not where the upstream vessel is.
+    if static_nav_holds() {
+        return;
+    }
+
     match variation {
         Some(v) => MAGNETIC_VARIATION.store(v, Ordering::Release),
         None => MAGNETIC_VARIATION.store(f64::NAN, Ordering::Release),
@@ -535,6 +596,9 @@ pub fn get_position() -> (Option<f64>, Option<f64>) {
 }
 
 pub(crate) fn set_position(lat: Option<f64>, lon: Option<f64>, source: &str) {
+    if static_nav_refuses(static_nav_holds(), source) {
+        return;
+    }
     if let (Some(lat), Some(lon)) = (lat, lon) {
         log::trace!("navdata::set_position(lat={}, lon={})", lat, lon);
         mark_own_ship_nav_fresh();
@@ -561,6 +625,12 @@ pub(crate) fn set_position(lat: Option<f64>, lon: Option<f64>, source: &str) {
 /// own-ship nav was ever received, so a transport that never carried nav
 /// (e.g. anonymous tcp on a hidden-vessels server) doesn't churn broadcasts.
 pub(crate) fn clear_own_ship_nav() {
+    // A fixed installation keeps knowing where it is when an upstream goes
+    // away: the position came from the command line, not from the peer that
+    // just dropped, and clearing it would leave the radar with nothing.
+    if static_nav_holds() {
+        return;
+    }
     if own_ship_nav_age_secs().is_none() {
         return;
     }
@@ -584,6 +654,13 @@ pub(crate) fn get_cog() -> Option<f64> {
 }
 
 pub(crate) fn set_cog(cog: Option<f64>) {
+    if static_nav_holds() {
+        return;
+    }
+    store_cog(cog);
+}
+
+fn store_cog(cog: Option<f64>) {
     use std::f64::consts::TAU;
 
     if let Some(c) = cog {
@@ -607,6 +684,13 @@ pub(crate) fn get_sog() -> Option<f64> {
 }
 
 pub(crate) fn set_sog(sog: Option<f64>) {
+    if static_nav_holds() {
+        return;
+    }
+    store_sog(sog);
+}
+
+fn store_sog(sog: Option<f64>) {
     if let Some(s) = sog {
         SOG.store(s, Ordering::Release);
     } else {
@@ -1752,6 +1836,40 @@ mod tests {
             // ...and nav_status must map it to the matching string.
             assert_eq!(nav_status(&cli(&["-n", &arg])).transport, expected);
         }
+    }
+
+    /// A fixed installation knows where it is. Once `--static-position` has
+    /// seeded own-ship nav, an upstream that disagrees is wrong and must not
+    /// move the vessel.
+    #[test]
+    fn a_static_position_refuses_upstream_navigation() {
+        assert!(static_nav_refuses(true, "signalk"));
+        assert!(static_nav_refuses(true, "nmea0183"));
+        assert!(static_nav_refuses(true, DERIVED_SOURCE));
+    }
+
+    /// The seeding, and the periodic re-assert that keeps it fresh, write
+    /// under the static source and have to be let through.
+    #[test]
+    fn a_static_position_accepts_its_own_writes() {
+        assert!(!static_nav_refuses(true, STATIC_SOURCE));
+    }
+
+    /// An upstream dropping clears own-ship nav so the GUI stops showing a
+    /// frozen value. A fixed position is not that: it came from the command
+    /// line, not from the peer that went away, so the clear must not take it.
+    #[test]
+    fn a_dropped_upstream_cannot_clear_a_static_position() {
+        assert!(static_nav_refuses(true, "disconnect"));
+    }
+
+    /// Without `--static-position` nothing is refused; every source writes as
+    /// it always did.
+    #[test]
+    fn without_a_static_position_every_source_writes() {
+        assert!(!static_nav_refuses(false, "signalk"));
+        assert!(!static_nav_refuses(false, "disconnect"));
+        assert!(!static_nav_refuses(false, STATIC_SOURCE));
     }
 
     // ----- nav freshness / staleness (revoked-token / dropped upstream) -----

--- a/src/lib/navdata.rs
+++ b/src/lib/navdata.rs
@@ -1838,6 +1838,123 @@ mod tests {
         }
     }
 
+    /// Own-ship nav lives in process-global atomics that the whole suite
+    /// shares, so the tests that write them take this lock and restore what
+    /// they touched on the way out.
+    static NAV_GLOBALS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct NavGlobals(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+    impl Drop for NavGlobals {
+        fn drop(&mut self) {
+            STATIC_NAV.store(false, Ordering::Release);
+            TRUE_HEADING_AUTHORITATIVE.store(false, Ordering::Release);
+            set_heading_true(None, "test-reset");
+            set_position(None, None, "test-reset");
+            set_cog(None);
+            set_sog(None);
+        }
+    }
+
+    fn nav_globals() -> NavGlobals {
+        // A test that panicked while holding the lock poisoned it; the guard
+        // restores the globals either way, so the state is still usable.
+        NavGlobals(NAV_GLOBALS.lock().unwrap_or_else(|e| e.into_inner()))
+    }
+
+    const STATIC_LAT: f64 = 52.0;
+    const STATIC_LON: f64 = 4.0;
+    const STATIC_HEADING: f64 = 2.1537;
+
+    /// The whole point of `--static-position`: an upstream that disagrees is
+    /// wrong, and a fixed installation stays where it was put.
+    #[test]
+    fn a_static_position_outranks_every_other_source() {
+        let _globals = nav_globals();
+        set_static_nav(STATIC_LAT, STATIC_LON, STATIC_HEADING);
+
+        set_position(Some(32.95), Some(129.10), "signalk");
+        set_heading_true(Some(5.49), "signalk");
+        set_heading_magnetic(Some(1.54), "signalk");
+        set_cog(Some(1.0));
+        set_sog(Some(5.0));
+
+        assert_eq!(
+            get_radar_position(),
+            Some(GeoPosition::new(STATIC_LAT, STATIC_LON))
+        );
+        assert_eq!(get_heading_true(), Some(STATIC_HEADING));
+        assert_eq!(get_heading_magnetic(), None, "no vessel's magnetic heading");
+        assert_eq!(get_cog(), Some(STATIC_HEADING));
+        assert_eq!(get_sog(), Some(0.0));
+    }
+
+    /// An upstream dropping clears own-ship nav so a stale position stops
+    /// being shown. A fixed position did not come from that peer and must
+    /// survive it -- losing it leaves the radar with nothing at all.
+    #[test]
+    fn a_dropped_upstream_leaves_a_static_position_alone() {
+        let _globals = nav_globals();
+        set_static_nav(STATIC_LAT, STATIC_LON, STATIC_HEADING);
+
+        clear_own_ship_nav();
+
+        assert_eq!(
+            get_radar_position(),
+            Some(GeoPosition::new(STATIC_LAT, STATIC_LON))
+        );
+        assert_eq!(get_heading_true(), Some(STATIC_HEADING));
+        assert!(
+            own_ship_nav_age_secs().is_some(),
+            "a fixed installation never has 'no navigation data'"
+        );
+    }
+
+    /// Without the flag nothing is guarded: the upstream writes, and its
+    /// disconnect still clears what it wrote.
+    #[test]
+    fn without_a_static_position_the_upstream_writes_and_clears() {
+        let _globals = nav_globals();
+
+        set_position(Some(32.95), Some(129.10), "signalk");
+        set_heading_true(Some(5.49), "signalk");
+        assert_eq!(get_radar_position(), Some(GeoPosition::new(32.95, 129.10)));
+
+        clear_own_ship_nav();
+
+        assert_eq!(get_radar_position(), None);
+        assert_eq!(get_heading_true(), None);
+    }
+
+    /// A fixed position never changes, so the change-gated broadcasts in the
+    /// setters would announce it once and never again, and a client
+    /// connecting later would never learn where the radar is.
+    #[test]
+    fn refreshing_a_static_position_republishes_it_unchanged() {
+        let _globals = nav_globals();
+        let (tx, _) = tokio::sync::broadcast::channel(16);
+        let mut rx = NAV_BROADCAST_TX.get_or_init(|| tx).subscribe();
+
+        set_static_nav(STATIC_LAT, STATIC_LON, STATIC_HEADING);
+        while rx.try_recv().is_ok() {} // the seeding's own announcements
+
+        refresh_static_nav(STATIC_LAT, STATIC_LON, STATIC_HEADING);
+
+        let published: Vec<String> = std::iter::from_fn(|| rx.try_recv().ok())
+            .map(|d| serde_json::to_string(&d).unwrap())
+            .collect();
+        assert!(
+            published.iter().any(|d| d.contains("navigation.position")),
+            "a late joiner has to be told the position: {published:?}"
+        );
+        assert!(
+            published
+                .iter()
+                .any(|d| d.contains("navigation.headingTrue")),
+            "and the heading: {published:?}"
+        );
+    }
+
     /// A fixed installation knows where it is. Once `--static-position` has
     /// seeded own-ship nav, an upstream that disagrees is wrong and must not
     /// move the vessel.
@@ -1882,8 +1999,9 @@ mod tests {
     #[test]
     fn marking_nav_fresh_makes_it_live() {
         // Receiving own-ship nav stamps the freshness clock: age is small and
-        // nav_live is true. (Safe under parallelism: a set can only make nav
-        // *fresher*, never staler, between the set and the read.)
+        // nav_live is true. Takes the nav lock because a concurrent test
+        // holding a static position would refuse this write.
+        let _globals = nav_globals();
         set_heading_true(Some(1.0), "test");
         let age = own_ship_nav_age_secs();
         assert!(


### PR DESCRIPTION
A radar installed ashore or on a pier, started with `--static-position`, was
moved by whatever Signal K or NMEA source happened to turn up: the flag seeded
own-ship navigation once at startup and nothing defended it afterwards. Worse,
when that source disconnected, the disconnect handler cleared position and
heading outright — so an installation that had been given a perfectly good
fixed position ended up with **no position at all** until restarted, taking
true-motion trails and target positions with it.

## What changes

`--static-position` now wins. The seeding latches, and own-ship writes from any
other source are refused while it holds — position, true and magnetic heading,
magnetic variation, COG and SOG — the disconnect clear included.

mayara still connects upstream: AIS and the rest of the Signal K data are still
wanted. Only the vessel's own idea of where it is is overridden.

The periodic task re-asserts instead of merely re-broadcasting, so a fixed
installation with no upstream at all no longer ages into "no navigation data",
and late-joining clients are still told a position that never changes.

## Verified against a live Signal K server

A killable relay between mayara and a boat's Signal K, with mayara started as
`--static-position 52.0 4.0 123.4` while the boat sat at 32.95N 129.10E on a
true heading of 5.49 rad:

| | before | after |
|---|---|---|
| upstream connected | position 32.9521771 (the boat) | position 52.0 / 4.0, heading 2.1537 |
| upstream dropped | `have_position: false, nav_live: false` | `have_position: true, nav_live: true` |

Before the change the boat's `headingMagnetic` also leaked through while
`headingTrue` reported the static value — an incoherent pair a client could
read either half of.

The precedence rule itself is unit-tested as a pure decision, so the tests do
not have to arm a process-global latch that other tests share.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Makes `--static-position` authoritative for own-ship navigation data.
- Latches position, heading, magnetic variation, COG, and SOG against upstream updates and disconnect clears.
- Reasserts static navigation values periodically for source-independent updates and late-joining clients.
- Keeps upstream connections active for AIS and other Signal K data.
- Adds `set_static_nav` and `refresh_static_nav` APIs with coverage for source precedence, writes, disconnects, and non-static behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->