### PR TITLE
fix(stream): honour policy, period and minPeriod on navigation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -248,6 +248,15 @@ Subscription options:
 | `period`    | Update interval in ms (for `fixed` policy)                        |
 | `minPeriod` | Minimum interval between updates in ms (for `ideal`)              |
 
+Pacing applies to controls and navigation — values that stand between updates,
+so holding one back only delays it. Guard-zone notifications and target reports
+are events: each carries a transition that cannot be inferred from the next (an
+alarm clearing, a target lost), so they are always delivered as they happen,
+whatever policy is asked for.
+
+These options govern a stream opened with `subscribe=none`. A `self` or `all`
+stream is served from its baseline as values change.
+
 ### Client → Server: Unsubscribe
 
 ```json

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1798,7 +1798,7 @@ async fn ws_signalk_delta(
             }
 
             _ = ticker.tick() => {
-                if let Err(e) = send_all_subscribed(socket, &radars, &mut subscriptions, &mut meta_radar_data_sent).await
+                if let Err(e) = send_periodic(socket, &radars, &mut subscriptions, &mut meta_radar_data_sent).await
                 {
                     log::warn!("Cannot send subscribed data to websocket");
                     break Err(e);
@@ -2116,33 +2116,45 @@ async fn handle_subscription(
         send_all_ais_vessels(socket).await?;
     }
 
-    send_current_navigation(socket, subscriptions).await?;
+    send_navigation(socket, subscriptions, |subs, path| {
+        subs.is_subscribed_path(path, true)
+    })
+    .await?;
 
     Ok(())
 }
 
-/// Send the current value of any navigation paths the client is subscribed
-/// to, so the client doesn't have to wait for the next upstream change to
-/// receive a starting value. Position rarely changes when stationary, so
-/// without this a freshly-connected client may see no position for minutes.
-async fn send_current_navigation(
+/// Send navigation values as they stand, for the paths `due` picks out.
+///
+/// On subscribe that is every navigation path the client asked for, so it
+/// doesn't have to wait for the next upstream change to receive a starting
+/// value — position rarely changes when stationary, and without this a
+/// freshly-connected client may see no position for minutes. On the periodic
+/// tick it is the paths asked for on a `fixed` policy, which are answered from
+/// the current value rather than from a change.
+///
+/// The paths handled here are the navigation paths `stream::is_navigation_path`
+/// knows can be paced; the two lists say the same thing and have to keep
+/// saying it.
+async fn send_navigation(
     socket: &mut WebSocket,
     subscriptions: &mut ActiveSubscriptions,
+    due: fn(&mut ActiveSubscriptions, &str) -> bool,
 ) -> Result<(), RadarError> {
     let mut delta = SignalKDelta::new();
 
-    if subscriptions.is_subscribed_path("navigation.position", false) {
+    if due(subscriptions, "navigation.position") {
         let (lat, lon) = navdata::get_position();
         if let (Some(lat), Some(lon)) = (lat, lon) {
             delta.add_position_update(lat, lon, "mayara");
         }
     }
-    if subscriptions.is_subscribed_path("navigation.headingTrue", false)
+    if due(subscriptions, "navigation.headingTrue")
         && let Some(h) = navdata::get_heading_true()
     {
         delta.add_navigation_update("navigation.headingTrue", h, "mayara");
     }
-    if subscriptions.is_subscribed_path("navigation.headingMagnetic", false)
+    if due(subscriptions, "navigation.headingMagnetic")
         && let Some(h) = navdata::get_heading_magnetic()
     {
         delta.add_navigation_update("navigation.headingMagnetic", h, "mayara");
@@ -2152,6 +2164,18 @@ async fn send_current_navigation(
         send_message(socket, d).await?;
     }
     Ok(())
+}
+
+/// Everything a client is owed on this tick: the controls it subscribed to,
+/// and the navigation values behind any `fixed` navigation subscription.
+async fn send_periodic(
+    socket: &mut WebSocket,
+    radars: &SharedRadars,
+    subscriptions: &mut ActiveSubscriptions,
+    meta_sent: &mut HashSet<String>,
+) -> Result<(), RadarError> {
+    send_all_subscribed(socket, radars, subscriptions, meta_sent).await?;
+    send_navigation(socket, subscriptions, ActiveSubscriptions::is_due_periodic).await
 }
 
 async fn send_all_subscribed(

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -592,6 +592,18 @@ fn pattern_covers(pattern: &str, path: &str) -> bool {
     pattern == path || (pattern.contains('*') && WildMatch::new(pattern).matches(path))
 }
 
+/// Whether `path` is own-ship navigation. These are values that stand between
+/// updates, so they can be paced: `fixed` is answered from the value as it
+/// stands on the periodic tick, and `minPeriod` limits how often a change is
+/// passed on. Kept in step with the periodic replay in the server, which is
+/// what re-sends them.
+fn is_navigation_path(path: &str) -> bool {
+    matches!(
+        path,
+        "navigation.position" | "navigation.headingTrue" | "navigation.headingMagnetic"
+    )
+}
+
 /// The shorthand for a published control path, if it is one: `radars.{id}.gain`
 /// alongside `radars.{id}.controls.gain`. `None` for anything that is not a
 /// control, which is how the caller tells them apart.
@@ -797,11 +809,11 @@ impl ActiveSubscriptions {
             Subscribe::None => {}
         }
 
-        // A control is throttled by the terms it was asked on; everything else
-        // goes out whenever it changes. Both the path a control is published
-        // under and the shorthand a client may have named it by are offered,
-        // the same pair `is_subscribed` uses — a client that subscribed the
-        // short way must not be answered on connect and then go quiet.
+        // A control is throttled by the terms it was asked on. Both the path a
+        // control is published under and the shorthand a client may have named
+        // it by are offered, the same pair `is_subscribed` uses — a client that
+        // subscribed the short way must not be answered on connect and then go
+        // quiet.
         if let Some(shorthand) = control_shorthand(path) {
             let Some(terms) = self.terms_for(&[path, &shorthand]) else {
                 return false;
@@ -809,7 +821,44 @@ impl ActiveSubscriptions {
             return self.allow_now(path, &terms, full);
         }
 
+        // Navigation is throttled the same way: it is a value that stands, so
+        // holding one back only delays it until the next change or the next
+        // tick.
+        if is_navigation_path(path) {
+            let Some(terms) = self.terms_for(&[path]) else {
+                return false;
+            };
+            return self.allow_now(path, &terms, full);
+        }
+
+        // Everything else — guard-zone notifications, ARPA target reports — is
+        // an event, and each one carries a transition the client cannot infer
+        // from the next: drop the update that clears an alarm and it stays
+        // raised forever, drop the one that loses a target and it is tracked
+        // forever. So events are delivered whenever they happen, whatever
+        // pacing was asked for.
         self.covering(path).next().is_some()
+    }
+
+    /// Whether `path` is owed a value on the periodic tick. Only a path asked
+    /// for on a `fixed` policy is delivered on schedule; `instant` and `ideal`
+    /// go out when the value changes, and a copy on the tick as well is one the
+    /// client never asked for.
+    pub fn is_due_periodic(&mut self, path: &str) -> bool {
+        // Terms govern delivery only under `subscribe=none`, the same as
+        // everywhere else here: a `self` or `all` client is served on change
+        // off the back of its baseline, never from the schedule.
+        if self.mode != Subscribe::None {
+            return false;
+        }
+
+        let Some(terms) = self.terms_for(&[path]) else {
+            return false;
+        };
+        if terms.policy != Policy::Fixed {
+            return false;
+        }
+        self.allow_now(path, &terms, true)
     }
 
     /// Whether the client wants AIS data for `context` (e.g.
@@ -1784,6 +1833,130 @@ mod build_tests {
         assert!(
             !subs.is_subscribed_path(path, true),
             "60ms into the default 1000ms period this path is owed nothing"
+        );
+    }
+
+    /// A `fixed` navigation subscription is answered from the schedule, not
+    /// from the boat: the client asked for a value a second, and a boat
+    /// reporting ten times a second must not be relayed ten times a second.
+    #[test]
+    fn a_fixed_navigation_path_is_not_delivered_on_change() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "navigation.*", "policy": "fixed", "period": 1000}
+        ]})))
+        .unwrap();
+
+        assert!(
+            !subs.is_subscribed_path("navigation.headingTrue", false),
+            "an upstream change does not deliver a fixed subscription"
+        );
+        assert!(
+            subs.is_due_periodic("navigation.headingTrue"),
+            "the tick does"
+        );
+    }
+
+    /// The other half: with nothing owed on the tick a `fixed` navigation
+    /// subscription would be silence rather than a slower stream.
+    #[test]
+    fn a_fixed_navigation_path_is_owed_on_the_tick() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "navigation.position", "policy": "fixed", "period": 100}
+        ]})))
+        .unwrap();
+
+        assert!(subs.is_due_periodic("navigation.position"));
+        assert!(
+            !subs.is_due_periodic("navigation.position"),
+            "a second tick inside the period is owed nothing"
+        );
+        std::thread::sleep(Duration::from_millis(110));
+        assert!(
+            subs.is_due_periodic("navigation.position"),
+            "the tick after the period comes round is owed a value"
+        );
+    }
+
+    /// `minPeriod` lets a client on a slow link ask a busy boat to slow down.
+    #[test]
+    fn a_navigation_path_honours_min_period() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "navigation.*", "policy": "ideal", "minPeriod": 1000}
+        ]})))
+        .unwrap();
+
+        let path = "navigation.headingTrue";
+        assert!(
+            subs.is_subscribed_path(path, false),
+            "the first change goes"
+        );
+        assert!(
+            !subs.is_subscribed_path(path, false),
+            "a change inside minPeriod does not"
+        );
+    }
+
+    /// Change-driven navigation is untouched: no policy means instant, and
+    /// instant means every change.
+    #[test]
+    fn navigation_without_terms_still_flows_on_change() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "navigation.*"}
+        ]})))
+        .unwrap();
+
+        let path = "navigation.position";
+        assert!(subs.is_subscribed_path(path, false));
+        assert!(subs.is_subscribed_path(path, false));
+        assert!(
+            !subs.is_due_periodic(path),
+            "an instant subscription is not owed a copy on the tick as well"
+        );
+    }
+
+    /// A `self` client is served from its baseline, on change. Terms it names
+    /// on top must not add a second, periodic, copy of the same value.
+    #[test]
+    fn a_self_client_is_never_served_from_the_schedule() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::SelfOnly);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "navigation.*", "policy": "fixed", "period": 100}
+        ]})))
+        .unwrap();
+
+        assert!(subs.is_subscribed_path("navigation.position", false));
+        assert!(!subs.is_due_periodic("navigation.position"));
+    }
+
+    /// An event carries a transition the client cannot infer from the next
+    /// one, and there is no current value to re-send on the tick. Pacing a
+    /// notification would leave an alarm raised after it cleared, so events
+    /// keep change-driven delivery whatever policy was asked for.
+    #[test]
+    fn events_are_not_paced() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::None);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "notifications.*", "policy": "fixed", "period": 10000},
+            {"path": "radars.*.targets.*", "policy": "ideal", "minPeriod": 10000}
+        ]})))
+        .unwrap();
+
+        let alarm = "notifications.radar.nav1.guardZone.1";
+        assert!(subs.is_subscribed_path(alarm, false));
+        assert!(
+            subs.is_subscribed_path(alarm, false),
+            "the notification that clears the alarm is not held back"
+        );
+
+        let target = "radars.nav1.targets.5";
+        assert!(subs.is_subscribed_path(target, false));
+        assert!(
+            subs.is_subscribed_path(target, false),
+            "the report that loses the target is not held back"
         );
     }
 


### PR DESCRIPTION
A client that asks for navigation data at a set rate now gets it at that rate. Before this, a chart app subscribing to `navigation.*` once a second received an update every time the boat produced one — on a busy boat that was ten times what it asked for, and on a slow or metered link there was no way to ask for less: `minPeriod` was ignored too.

Measured against a live server with `subscribe=none`, a `fixed` subscription at 1000 ms delivered 79 navigation messages in 8 seconds instead of 8.

Guard-zone alarms and target reports are unchanged, deliberately — see below.

## Cause

`ActiveSubscriptions::is_subscribed_path` resolved subscription terms only for paths naming a control. Everything else — navigation, notifications, targets — fell through to a plain subscribed-or-not test, so the throttling machinery was never reached. The periodic sender had the matching gap: `send_all_subscribed` gathered only control values, so even with the terms honoured there was nothing to send for a `fixed` navigation path when the tick came round. Both halves had to be done together or `fixed` would mean silence rather than a slower stream.

## Approach

Navigation resolves terms the same way controls do, and the tick answers a `fixed` navigation subscription from the value as it stands (`send_navigation`, driven by a new `is_due_periodic`). `is_due_periodic` delivers only on a `fixed` policy, so an `instant` subscriber does not get a periodic copy on top of its change-driven one when some other subscription happens to spin the ticker up.

Notifications and ARPA target reports stay change-driven whatever policy is asked for. Each carries a transition the client cannot infer from the next, and there is no current value to re-send on the tick — a dropped update leaves an alarm raised after it cleared, or a target tracked after it was lost.

## Not in scope

Terms still govern delivery only on a `subscribe=none` stream; `self` and `all` short-circuit to their baseline before terms are consulted, as they already did for controls. Making those honour terms changes control delivery too, so it belongs in its own PR.

closes #634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Applies `policy`, `period`, and `minPeriod` to `navigation` subscriptions.
- Replays current navigation values for due `fixed` subscriptions.
- Preserves change-driven delivery for notifications and target reports.
- Preserves baseline behavior for `self` and `all` subscriptions.
- Documents pacing behavior and adds coverage for navigation throttling and periodic delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->