### PR TITLE
fix(stream): honour subscription terms on a self or all stream

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -254,8 +254,9 @@ are events: each carries a transition that cannot be inferred from the next (an
 alarm clearing, a target lost), so they are always delivered as they happen,
 whatever policy is asked for.
 
-These options govern a stream opened with `subscribe=none`. A `self` or `all`
-stream is served from its baseline as values change.
+These options apply on any stream. A path a subscription names is delivered on
+the terms it names; a path no subscription mentions is left to the
+`?subscribe=` baseline, which delivers as values change.
 
 ### Client → Server: Unsubscribe
 

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -2189,11 +2189,10 @@ async fn send_all_subscribed(
     for radar in radars.get_active() {
         rcvs.append(&mut radar.controls.get_radar_control_values());
     }
-    // Under `none`, keep only explicitly-subscribed controls; `self`/`all` get
-    // them all (radar controls are own-ship data, always in those baselines).
-    if subscriptions.mode == Subscribe::None {
-        rcvs.retain(|x| subscriptions.is_subscribed(x, true));
-    }
+    // Keep what the client is owed: the controls it named, on the terms it
+    // named them on, plus everything its baseline carries (radar controls are
+    // own-ship data, so `self` and `all` carry them all).
+    rcvs.retain(|x| subscriptions.is_subscribed(x, true));
     log::debug!("Sending {} subscribed controls", rcvs.len());
     if !rcvs.is_empty() {
         let mut delta: SignalKDelta = SignalKDelta::new();

--- a/src/lib/stream.rs
+++ b/src/lib/stream.rs
@@ -604,6 +604,17 @@ fn is_navigation_path(path: &str) -> bool {
     )
 }
 
+/// Whether `path` carries a value that stands between updates, and so can be
+/// paced: a radar control, or own-ship navigation. Everything else — guard-zone
+/// notifications, ARPA target reports — is an event, and each one carries a
+/// transition the client cannot infer from the next: drop the update that
+/// clears an alarm and it stays raised forever, drop the one that loses a
+/// target and it is tracked forever. So events are delivered whenever they
+/// happen, whatever pacing was asked for.
+fn is_paced_path(path: &str) -> bool {
+    control_shorthand(path).is_some() || is_navigation_path(path)
+}
+
 /// The shorthand for a published control path, if it is one: `radars.{id}.gain`
 /// alongside `radars.{id}.controls.gain`. `None` for anything that is not a
 /// control, which is how the caller tells them apart.
@@ -712,23 +723,15 @@ impl ActiveSubscriptions {
     /// Whether this control goes out now, which is both whether the client
     /// asked for it and whether the terms it asked on allow it yet.
     pub fn is_subscribed(&mut self, rcv: &RadarControlValue, full: bool) -> bool {
-        match self.mode {
-            Subscribe::All => {
-                return true;
-            }
-            Subscribe::SelfOnly => {
-                return true;
-            }
-            Subscribe::None => {}
-        }
-
         let (Some(radar_id), Some(control_id)) = (rcv.radar_id.as_deref(), &rcv.control_id) else {
             panic!("Invalid use of is_subscribed(), can only be done on internal RCV");
         };
         let [canonical, shorthand] = control_paths(radar_id, control_id);
 
         let Some(terms) = self.terms_for(&[&canonical, &shorthand]) else {
-            return false;
+            // Nothing names it, so the baseline decides. Radar controls are
+            // own-ship data, carried by `self` as well as `all`.
+            return self.mode != Subscribe::None;
         };
 
         self.allow_now(&canonical, &terms, full)
@@ -792,66 +795,51 @@ impl ActiveSubscriptions {
     }
 
     pub fn is_subscribed_path(&mut self, path: &str, full: bool) -> bool {
+        // Both the path a control is published under and the shorthand a client
+        // may have named it by are offered, the same pair `is_subscribed` uses
+        // — a client that subscribed the short way must not be answered on
+        // connect and then go quiet.
+        let terms = match control_shorthand(path) {
+            Some(shorthand) => self.terms_for(&[path, &shorthand]),
+            None => self.terms_for(&[path]),
+        };
+
+        let Some(terms) = terms else {
+            return self.baseline_carries(path);
+        };
+
+        // A value that stands is paced on the terms it was asked on; holding
+        // one back only delays it until the next change or the next tick. An
+        // event cannot be held back at all, so being asked for is the whole
+        // answer.
+        if !is_paced_path(path) {
+            return true;
+        }
+
+        self.allow_now(path, &terms, full)
+    }
+
+    /// Whether the stream's `?subscribe=` baseline carries `path` on its own,
+    /// which is what decides a path no request names.
+    fn baseline_carries(&self, path: &str) -> bool {
         match self.mode {
-            Subscribe::All => {
-                return true;
-            }
-            Subscribe::SelfOnly => {
-                // Own-ship data is in the `self` baseline; only AIS (`vessels.*`,
-                // another vessel's context) needs an explicit subscription. The
-                // path prefix is the context discriminator, so this stays correct
-                // even when navigation comes from NMEA 0183 (no upstream own-ship
-                // URN) — `navigation.*` is own-ship by path regardless.
-                if !path.starts_with("vessels.") {
-                    return true;
-                }
-            }
-            Subscribe::None => {}
+            Subscribe::All => true,
+            // Own-ship data is in the `self` baseline; only AIS (`vessels.*`,
+            // another vessel's context) needs an explicit subscription. The
+            // path prefix is the context discriminator, so this stays correct
+            // even when navigation comes from NMEA 0183 (no upstream own-ship
+            // URN) — `navigation.*` is own-ship by path regardless.
+            Subscribe::SelfOnly => !path.starts_with("vessels."),
+            Subscribe::None => false,
         }
-
-        // A control is throttled by the terms it was asked on. Both the path a
-        // control is published under and the shorthand a client may have named
-        // it by are offered, the same pair `is_subscribed` uses — a client that
-        // subscribed the short way must not be answered on connect and then go
-        // quiet.
-        if let Some(shorthand) = control_shorthand(path) {
-            let Some(terms) = self.terms_for(&[path, &shorthand]) else {
-                return false;
-            };
-            return self.allow_now(path, &terms, full);
-        }
-
-        // Navigation is throttled the same way: it is a value that stands, so
-        // holding one back only delays it until the next change or the next
-        // tick.
-        if is_navigation_path(path) {
-            let Some(terms) = self.terms_for(&[path]) else {
-                return false;
-            };
-            return self.allow_now(path, &terms, full);
-        }
-
-        // Everything else — guard-zone notifications, ARPA target reports — is
-        // an event, and each one carries a transition the client cannot infer
-        // from the next: drop the update that clears an alarm and it stays
-        // raised forever, drop the one that loses a target and it is tracked
-        // forever. So events are delivered whenever they happen, whatever
-        // pacing was asked for.
-        self.covering(path).next().is_some()
     }
 
     /// Whether `path` is owed a value on the periodic tick. Only a path asked
     /// for on a `fixed` policy is delivered on schedule; `instant` and `ideal`
     /// go out when the value changes, and a copy on the tick as well is one the
-    /// client never asked for.
+    /// client never asked for. The baseline never delivers from the schedule:
+    /// a path no request names is carried on change.
     pub fn is_due_periodic(&mut self, path: &str) -> bool {
-        // Terms govern delivery only under `subscribe=none`, the same as
-        // everywhere else here: a `self` or `all` client is served on change
-        // off the back of its baseline, never from the schedule.
-        if self.mode != Subscribe::None {
-            return false;
-        }
-
         let Some(terms) = self.terms_for(&[path]) else {
             return false;
         };
@@ -1918,18 +1906,88 @@ mod build_tests {
         );
     }
 
-    /// A `self` client is served from its baseline, on change. Terms it names
-    /// on top must not add a second, periodic, copy of the same value.
+    /// A `self` client asking for a path on terms is answered on those terms:
+    /// the baseline is what carries a path nobody named, not an answer that
+    /// overrides one that was.
     #[test]
-    fn a_self_client_is_never_served_from_the_schedule() {
+    fn a_self_client_is_paced_by_the_terms_it_names() {
         let mut subs = ActiveSubscriptions::new(Subscribe::SelfOnly);
         subs.subscribe(subscribe_to(json!({"subscribe": [
             {"path": "navigation.*", "policy": "fixed", "period": 100}
         ]})))
         .unwrap();
 
+        assert!(
+            !subs.is_subscribed_path("navigation.position", false),
+            "a fixed subscription is not delivered on change"
+        );
+        assert!(
+            subs.is_due_periodic("navigation.position"),
+            "it is delivered on the schedule it asked for"
+        );
+    }
+
+    /// What the baseline is for: a `self` client that names nothing is served
+    /// everything own-ship, on change, as it always was.
+    #[test]
+    fn a_self_client_naming_nothing_is_served_from_the_baseline() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::SelfOnly);
+
         assert!(subs.is_subscribed_path("navigation.position", false));
-        assert!(!subs.is_due_periodic("navigation.position"));
+        assert!(subs.is_subscribed_path("navigation.position", false));
+        assert!(subs.is_subscribed_path("radars.nav1.controls.gain", false));
+        assert!(subs.is_subscribed_path("radars.nav1.targets.5", false));
+        assert!(
+            !subs.is_subscribed_path("vessels.urn:mrn:imo:mmsi:431004411", false),
+            "another vessel is not own-ship data"
+        );
+        assert!(
+            !subs.is_due_periodic("navigation.position"),
+            "the baseline delivers on change, never from the schedule"
+        );
+    }
+
+    /// Terms name paths, not everything: a path the client did not ask about
+    /// keeps whatever the baseline gives it.
+    #[test]
+    fn terms_pace_only_the_paths_they_cover() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::SelfOnly);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "navigation.*", "policy": "ideal", "minPeriod": 1000}
+        ]})))
+        .unwrap();
+
+        assert!(subs.is_subscribed_path("navigation.headingTrue", false));
+        assert!(
+            !subs.is_subscribed_path("navigation.headingTrue", false),
+            "the named path is rate-limited"
+        );
+
+        let gain = "radars.nav1.controls.gain";
+        assert!(subs.is_subscribed_path(gain, false));
+        assert!(
+            subs.is_subscribed_path(gain, false),
+            "a path no request names is still carried on change"
+        );
+    }
+
+    /// An `all` client can pace what it asked for too, and its AIS baseline is
+    /// untouched by terms on an own-ship path.
+    #[test]
+    fn an_all_client_is_paced_by_the_terms_it_names() {
+        let mut subs = ActiveSubscriptions::new(Subscribe::All);
+        subs.subscribe(subscribe_to(json!({"subscribe": [
+            {"path": "radars.*.controls.*", "policy": "ideal", "minPeriod": 1000}
+        ]})))
+        .unwrap();
+
+        let gain = "radars.nav1.controls.gain";
+        assert!(subs.is_subscribed_path(gain, false));
+        assert!(!subs.is_subscribed_path(gain, false));
+        assert!(
+            subs.is_subscribed_ais("vessels.urn:mrn:imo:mmsi:431004411"),
+            "AIS still rides the all baseline"
+        );
     }
 
     /// An event carries a transition the client cannot infer from the next


### PR DESCRIPTION
A client on the default `subscribe=self` can now ask for data at the rate it wants and actually get it. Before this, `policy`, `period` and `minPeriod` were accepted on such a stream and then ignored, so a chart app on a metered or high-latency link had only one way to slow anything down: reopen the stream as `subscribe=none` and name every single path it needed — exactly the work the baseline exists to save.

This covers radar controls as well as navigation. #646 paced both, but only on a `subscribe=none` stream.

A client that names no subscriptions sees no change at all, and the embedded GUI is unaffected — it opens every stream with `subscribe=none`.

## Cause

The `?subscribe=` mode was checked before the terms were, in each of the three places that decide delivery, so a `self` or `all` client short-circuited to "yes, on change" and never reached `terms_for` / `allow_now`. The baseline was answering for paths the client had explicitly spoken about.

## Approach

Terms resolve first; the baseline becomes the fallback for a path no request names (`baseline_carries`). An explicit subscription replaces the baseline for the paths it covers instead of being ignored underneath it. With the terms lookup now common to all paths, the separate control / navigation / event branches in `is_subscribed_path` collapse into a single `is_paced_path` check. `send_all_subscribed` drops its `mode == Subscribe::None` guard and always filters, which is now correct in every mode.

## Behaviour change

An existing `subscribe=self` client that sends a subscription with a policy was getting a firehose and will now get the rate it asked for. That is the fix, but it is a change in what such a client receives.

One test from #646 asserted the old behaviour (`a_self_client_is_never_served_from_the_schedule`) — that assertion is the bug here, so it is replaced. Three tests are added: a `self` client naming nothing is served everything own-ship on change and never from the schedule, terms pace only the paths they cover, and an `all` client can pace controls while AIS still rides its baseline.

## Not in scope

AIS pacing. A `vessels.*` delta is subscribed as a whole by context, not by leaf path, so it needs a different mechanism than the per-path throttle.

closes #647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Enables `policy`, `period`, and `minPeriod` terms for `subscribe=self` and `subscribe=all` streams.

- Applies explicit terms to named navigation and radar paths.
- Uses the `subscribe` baseline for unnamed paths.
- Applies pacing to radar controls in `send_all_subscribed`.
- Preserves existing behavior for clients without named subscriptions.
- Keeps AIS pacing out of scope.
- Updates pacing documentation and adds coverage for self, path-specific, and all-mode subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->