### PR TITLE
fix(fixtures): leave a fixture alone when its packets are unchanged

### DIFF
--- a/examples/generate-fixtures.rs
+++ b/examples/generate-fixtures.rs
@@ -12,7 +12,7 @@
 
 use std::path::Path;
 
-use mayara::pcap::{PcapPacket, parse_file, write_file};
+use mayara::pcap::{PcapPacket, parse_file, write_file_if_changed};
 
 fn main() {
     let recordings = std::env::var("RADAR_RECORDINGS").unwrap_or_else(|_| {
@@ -185,11 +185,12 @@ fn generate_fixture(
         .filter(|p| filter(p))
         .take(max_packets)
         .collect();
+    let wrote = write_file_if_changed(dst, &filtered).expect("write fixture");
     println!(
-        "{}: {} -> {} packets",
+        "{}: {} -> {} packets{}",
         dst.file_name().unwrap().to_string_lossy(),
         src.display(),
-        filtered.len()
+        filtered.len(),
+        if wrote { "" } else { " (unchanged)" }
     );
-    write_file(dst, &filtered).expect("write fixture");
 }

--- a/src/lib/pcap.rs
+++ b/src/lib/pcap.rs
@@ -42,21 +42,26 @@ const ETHERTYPE_IPV4: u16 = 0x0800;
 /// UDP IP protocol number.
 const IP_PROTO_UDP: u8 = 17;
 
+/// Read a file, decompressing it when it is gzipped.
+fn read_maybe_gzip(path: &Path) -> io::Result<Vec<u8>> {
+    if path.extension().is_some_and(|e| e == "gz") {
+        let file = fs::File::open(path)?;
+        let mut decoder = flate2::read::GzDecoder::new(file);
+        let mut buf = Vec::new();
+        decoder.read_to_end(&mut buf)?;
+        Ok(buf)
+    } else {
+        fs::read(path)
+    }
+}
+
 /// Parse a pcap or NND file (optionally gzipped) and return all UDP packets.
 ///
 /// Auto-detects the file format: NND files start with `Time:`, pcap files
 /// start with a 4-byte magic number. Both `.gz` and uncompressed files are
 /// supported.
 pub fn parse_file(path: &Path) -> io::Result<Vec<PcapPacket>> {
-    let data = if path.extension().is_some_and(|e| e == "gz") {
-        let file = fs::File::open(path)?;
-        let mut decoder = flate2::read::GzDecoder::new(file);
-        let mut buf = Vec::new();
-        decoder.read_to_end(&mut buf)?;
-        buf
-    } else {
-        fs::read(path)?
-    };
+    let data = read_maybe_gzip(path)?;
 
     if crate::nnd::is_nnd(&data) {
         return crate::nnd::parse_bytes(&data, path);
@@ -199,6 +204,48 @@ fn parse_udp_packet(data: &[u8], timestamp: Duration) -> Option<PcapPacket> {
 /// Ethernet + IPv4 + UDP headers wrapping each payload.
 #[cfg(any(test, feature = "pcap-replay"))]
 pub fn write_file(path: &Path, packets: &[PcapPacket]) -> io::Result<()> {
+    write_bytes(path, &encode_packets(packets))
+}
+
+/// Write `packets` to `path` unless it already holds exactly these packets,
+/// reporting whether it wrote.
+///
+/// The comparison is against what the file decompresses to, not against its
+/// bytes. The same packets compress to different bytes under different gzip
+/// implementations, and the fixtures in `testdata/` were written by several of
+/// them over the years, so writing unconditionally rewrites files whose content
+/// has not moved — leaving a diff of unreadable binary churn for a reviewer to
+/// wade through.
+#[cfg(any(test, feature = "pcap-replay"))]
+pub fn write_file_if_changed(path: &Path, packets: &[PcapPacket]) -> io::Result<bool> {
+    let data = encode_packets(packets);
+    if read_maybe_gzip(path).is_ok_and(|existing| existing == data) {
+        return Ok(false);
+    }
+    write_bytes(path, &data)?;
+    Ok(true)
+}
+
+/// Write `data` to `path`, gzipping it when the path says so.
+#[cfg(any(test, feature = "pcap-replay"))]
+fn write_bytes(path: &Path, data: &[u8]) -> io::Result<()> {
+    if path.extension().is_some_and(|e| e == "gz") {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        let file = fs::File::create(path)?;
+        let mut encoder = GzEncoder::new(file, Compression::default());
+        encoder.write_all(data)?;
+        encoder.finish()?;
+        Ok(())
+    } else {
+        fs::write(path, data)
+    }
+}
+
+/// Encode packets as pcap bytes, before any compression.
+#[cfg(any(test, feature = "pcap-replay"))]
+fn encode_packets(packets: &[PcapPacket]) -> Vec<u8> {
     let mut data = Vec::new();
 
     // Global header (24 bytes): magic, version 2.4, timezone 0, sigfigs 0, snaplen 65535, linktype 1 (Ethernet)
@@ -257,23 +304,89 @@ pub fn write_file(path: &Path, packets: &[PcapPacket]) -> io::Result<()> {
         data.extend_from_slice(&pkt.payload);
     }
 
-    if path.extension().is_some_and(|e| e == "gz") {
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-        use std::io::Write;
-        let file = fs::File::create(path)?;
-        let mut encoder = GzEncoder::new(file, Compression::default());
-        encoder.write_all(&data)?;
-        encoder.finish()?;
-        Ok(())
-    } else {
-        fs::write(path, data)
-    }
+    data
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_packets() -> Vec<PcapPacket> {
+        vec![
+            PcapPacket {
+                timestamp: Duration::from_millis(0),
+                src_addr: SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1234),
+                dst_addr: SocketAddrV4::new(Ipv4Addr::new(239, 0, 0, 1), 5678),
+                payload: vec![0x01, 0x02, 0x03],
+            },
+            PcapPacket {
+                timestamp: Duration::from_millis(100),
+                src_addr: SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 4321),
+                dst_addr: SocketAddrV4::new(Ipv4Addr::new(239, 0, 0, 2), 8765),
+                payload: vec![0xAA, 0xBB],
+            },
+        ]
+    }
+
+    /// The bug this guards: a fixture holding exactly these packets, but
+    /// compressed by a different gzip than the one we write with, must be left
+    /// alone. Comparing file bytes would rewrite it and fill the diff with
+    /// binary churn that says nothing.
+    #[test]
+    fn a_fixture_compressed_differently_is_left_alone() {
+        let packets = sample_packets();
+        let tmp = std::env::temp_dir().join("test_if_changed_recompressed.pcap.gz");
+
+        // Same content, deliberately compressed at a level `write_file` never
+        // uses, standing in for whichever gzip wrote the committed fixtures.
+        {
+            use flate2::Compression;
+            use flate2::write::GzEncoder;
+            use std::io::Write;
+            let file = fs::File::create(&tmp).expect("create");
+            let mut encoder = GzEncoder::new(file, Compression::best());
+            encoder.write_all(&encode_packets(&packets)).expect("write");
+            encoder.finish().expect("finish");
+        }
+        let before = fs::read(&tmp).expect("read");
+        assert_ne!(
+            before,
+            {
+                write_file(&tmp.with_extension("other"), &packets).expect("write");
+                fs::read(tmp.with_extension("other")).expect("read")
+            },
+            "the two gzips must differ, or this test proves nothing"
+        );
+
+        assert!(
+            !write_file_if_changed(&tmp, &packets).expect("compare"),
+            "identical packets must not be rewritten"
+        );
+        assert_eq!(fs::read(&tmp).expect("read"), before, "file was touched");
+    }
+
+    /// The other half: content that really did move is written.
+    #[test]
+    fn a_fixture_whose_packets_changed_is_rewritten() {
+        let mut packets = sample_packets();
+        let tmp = std::env::temp_dir().join("test_if_changed_moved.pcap.gz");
+        assert!(
+            write_file_if_changed(&tmp, &packets).expect("write"),
+            "a fixture that does not exist yet is written"
+        );
+        assert!(
+            !write_file_if_changed(&tmp, &packets).expect("compare"),
+            "writing it again changes nothing"
+        );
+
+        packets[1].payload = vec![0xAA, 0xBB, 0xCC];
+        assert!(
+            write_file_if_changed(&tmp, &packets).expect("write"),
+            "a changed payload is written"
+        );
+        let parsed = parse_file(&tmp).expect("parse");
+        assert_eq!(parsed[1].payload, vec![0xAA, 0xBB, 0xCC]);
+    }
 
     #[test]
     fn roundtrip_write_parse() {

--- a/src/lib/pcap.rs
+++ b/src/lib/pcap.rs
@@ -311,6 +311,16 @@ fn encode_packets(packets: &[PcapPacket]) -> Vec<u8> {
 mod tests {
     use super::*;
 
+    /// A directory of this test's own. Cleared on entry, so a run that panics
+    /// half way cannot leave a file behind that decides the next run's result,
+    /// and two runs at once cannot collide.
+    fn scratch_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("mayara-pcap-{}-{}", name, std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
     fn sample_packets() -> Vec<PcapPacket> {
         vec![
             PcapPacket {
@@ -335,57 +345,71 @@ mod tests {
     #[test]
     fn a_fixture_compressed_differently_is_left_alone() {
         let packets = sample_packets();
-        let tmp = std::env::temp_dir().join("test_if_changed_recompressed.pcap.gz");
+        let dir = scratch_dir("recompressed");
+        let fixture = dir.join("fixture.pcap.gz");
 
-        // Same content, deliberately compressed at a level `write_file` never
-        // uses, standing in for whichever gzip wrote the committed fixtures.
+        // The same content, written by a gzip that stamps its header
+        // differently from ours — standing in for whichever gzip wrote the
+        // committed fixtures.
         {
             use flate2::Compression;
-            use flate2::write::GzEncoder;
+            use flate2::GzBuilder;
             use std::io::Write;
-            let file = fs::File::create(&tmp).expect("create");
-            let mut encoder = GzEncoder::new(file, Compression::best());
+            let file = fs::File::create(&fixture).expect("create");
+            let mut encoder = GzBuilder::new()
+                .mtime(0x5EA5_0000)
+                .write(file, Compression::best());
             encoder.write_all(&encode_packets(&packets)).expect("write");
             encoder.finish().expect("finish");
         }
-        let before = fs::read(&tmp).expect("read");
+        let before = fs::read(&fixture).expect("read");
+
+        // Both files are gzip, so this compares one gzip encoding against the
+        // other. Without it the test would pass even if the two agreed byte for
+        // byte, which is the one case in which it proves nothing.
+        let ours = dir.join("ours.pcap.gz");
+        write_file(&ours, &packets).expect("write");
         assert_ne!(
             before,
-            {
-                write_file(&tmp.with_extension("other"), &packets).expect("write");
-                fs::read(tmp.with_extension("other")).expect("read")
-            },
+            fs::read(&ours).expect("read"),
             "the two gzips must differ, or this test proves nothing"
         );
 
         assert!(
-            !write_file_if_changed(&tmp, &packets).expect("compare"),
+            !write_file_if_changed(&fixture, &packets).expect("compare"),
             "identical packets must not be rewritten"
         );
-        assert_eq!(fs::read(&tmp).expect("read"), before, "file was touched");
+        assert_eq!(
+            fs::read(&fixture).expect("read"),
+            before,
+            "file was touched"
+        );
+        fs::remove_dir_all(&dir).expect("clean up");
     }
 
     /// The other half: content that really did move is written.
     #[test]
     fn a_fixture_whose_packets_changed_is_rewritten() {
         let mut packets = sample_packets();
-        let tmp = std::env::temp_dir().join("test_if_changed_moved.pcap.gz");
+        let dir = scratch_dir("moved");
+        let fixture = dir.join("fixture.pcap.gz");
         assert!(
-            write_file_if_changed(&tmp, &packets).expect("write"),
+            write_file_if_changed(&fixture, &packets).expect("write"),
             "a fixture that does not exist yet is written"
         );
         assert!(
-            !write_file_if_changed(&tmp, &packets).expect("compare"),
+            !write_file_if_changed(&fixture, &packets).expect("compare"),
             "writing it again changes nothing"
         );
 
         packets[1].payload = vec![0xAA, 0xBB, 0xCC];
         assert!(
-            write_file_if_changed(&tmp, &packets).expect("write"),
+            write_file_if_changed(&fixture, &packets).expect("write"),
             "a changed payload is written"
         );
-        let parsed = parse_file(&tmp).expect("parse");
+        let parsed = parse_file(&fixture).expect("parse");
         assert_eq!(parsed[1].payload, vec![0xAA, 0xBB, 0xCC]);
+        fs::remove_dir_all(&dir).expect("clean up");
     }
 
     #[test]


### PR DESCRIPTION
Adding one pcap fixture used to rewrite eight others. Regenerating fixtures produced 100 KB of binary churn in files whose content had not moved, and anyone adding a capture had to notice and revert the other eight by hand — the tests pass either way, so missing it was the easy path and reviewers got a diff they could not read.

Found while adding the Fantom Pro fixture in #644, where the eight had to be reverted by hand.

## Cause

The packets never changed — only the compression did. The eight affected fixtures were compressed by a different gzip from the one `write_file` uses (an older flate2, or another implementation entirely), so identical content re-encoded to different bytes. Sizes moved in both directions, which is why it was never as simple as a compression-level change. The remaining five happened to regenerate byte-for-byte, which is what made the problem intermittent enough to keep surprising people.

## Approach

`write_file_if_changed` encodes the packets it would write and compares that against what the destination decompresses to, skipping the write when they match. Comparing decompressed content rather than file bytes keeps it correct no matter which gzip wrote the existing file. `write_file` is split into `encode_packets` + `write_bytes` so both paths share one encoder, and `parse_file`'s decompress-or-read step is factored out as `read_maybe_gzip` and reused for the comparison. The generator now marks each skipped fixture `(unchanged)`.

## Verification

Run against the real recordings, both directions:

- with this change, all 11 fixtures that have a source report `(unchanged)` and `git status testdata/` is empty
- stashing the change and re-running the previous code rewrites exactly the eight files named in the issue, so the clean result is the fix rather than a machine that happens to produce matching bytes

Two tests cover it. One writes the same packets at a different compression level, asserts those bytes genuinely differ from what `write_file` produces, then asserts the file is neither rewritten nor touched. The other checks that a missing file is written, a repeat write is skipped, and a changed payload is written and reads back.

closes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates fixture generation to compare decompressed packet content before writing. Reuses shared encoding and decompression helpers, skips unchanged fixtures, and reports `(unchanged)`.

Adds tests for compression differences, missing files, repeated writes, and changed payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->