### PR TITLE
feat(pcap): reassemble fragmented UDP datagrams

### DIFF
--- a/src/lib/pcap.rs
+++ b/src/lib/pcap.rs
@@ -36,12 +36,23 @@ const IP_FRAG_OFFSET_MASK: u16 = 0x1FFF;
 const IP_FLAG_MORE_FRAGMENTS: u16 = 0x2000;
 /// A fragment offset counts 8-byte units, not bytes.
 const IP_FRAG_OFFSET_UNIT: usize = 8;
-/// How long an incomplete datagram is kept before its pieces are abandoned.
+/// How long an incomplete datagram is kept, in capture time, before its pieces
+/// are abandoned.
+///
 /// The IPv4 identification field is only 16 bits, so a capture busy enough --
-/// or lossy enough -- reuses one: without an expiry, a datagram that lost its
-/// last fragment sits in the table until a later datagram with the same
-/// identification fills the gap, and the two are spliced into one packet that
-/// never existed. RFC 1122 puts the reassembly timeout at 15 seconds or more.
+/// or lossy enough -- reuses one: without an expiry, a datagram that lost a
+/// fragment sits in the table until a later datagram with the same
+/// identification fills the hole, and the two are spliced into one packet that
+/// never existed.
+///
+/// RFC 1122 asks a *host* to hold fragments for 60 to 120 seconds, because a
+/// host must not discard a datagram whose sender may still be retransmitting.
+/// Reading a capture is the other way round: the fragments of one datagram were
+/// sent back to back and sit microseconds apart in the file, so no real datagram
+/// is lost by giving up sooner, while every second held widens the window in
+/// which an identification can come round again and splice two datagrams
+/// together. Half the host timeout keeps that window as narrow as it can be
+/// without inventing a threshold no standard mentions.
 const FRAGMENT_TIMEOUT_SECS: u64 = 30;
 
 /// Pcap link type for Ethernet.

--- a/src/lib/pcap.rs
+++ b/src/lib/pcap.rs
@@ -30,6 +30,20 @@ const PCAP_MAGIC_BE: u32 = 0xd4c3b2a1;
 const PCAP_MAGIC_NS_LE: u32 = 0xa1b23c4d; // nanosecond resolution
 const PCAP_MAGIC_NS_BE: u32 = 0x4d3cb2a1;
 
+/// The low 13 bits of the IPv4 flags/fragment-offset field hold the offset.
+const IP_FRAG_OFFSET_MASK: u16 = 0x1FFF;
+/// The "more fragments" flag in that same field.
+const IP_FLAG_MORE_FRAGMENTS: u16 = 0x2000;
+/// A fragment offset counts 8-byte units, not bytes.
+const IP_FRAG_OFFSET_UNIT: usize = 8;
+/// How long an incomplete datagram is kept before its pieces are abandoned.
+/// The IPv4 identification field is only 16 bits, so a capture busy enough --
+/// or lossy enough -- reuses one: without an expiry, a datagram that lost its
+/// last fragment sits in the table until a later datagram with the same
+/// identification fills the gap, and the two are spliced into one packet that
+/// never existed. RFC 1122 puts the reassembly timeout at 15 seconds or more.
+const FRAGMENT_TIMEOUT_SECS: u64 = 30;
+
 /// Pcap link type for Ethernet.
 const LINKTYPE_ETHERNET: u32 = 1;
 /// Ethernet header length (no VLAN tags).
@@ -108,6 +122,13 @@ pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
         ));
     }
 
+    let divisor: u64 = if nanoseconds {
+        1_000_000_000
+    } else {
+        1_000_000
+    };
+    let fragment_timeout = FRAGMENT_TIMEOUT_SECS * divisor;
+
     let mut packets = Vec::new();
     let mut fragments: HashMap<FragmentKey, FragmentSet> = HashMap::new();
     let mut offset = 24;
@@ -140,7 +161,16 @@ pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
             part.payload
         } else {
             let key = (part.src, part.dst, part.id);
-            let set = fragments.entry(key).or_default();
+            let now = ts_sec as u64 * divisor + ts_frac as u64;
+            let set = fragments
+                .entry(key)
+                .or_insert_with(|| FragmentSet::new(now));
+            // The identification field wraps, so a set this old belongs to a
+            // datagram that never completed rather than to this one. Start over
+            // instead of filling its gap with these bytes.
+            if now.saturating_sub(set.started) > fragment_timeout {
+                *set = FragmentSet::new(now);
+            }
             set.add(part.offset, part.payload, !part.more);
             match set.take_complete() {
                 Some(datagram) => {
@@ -157,11 +187,6 @@ pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
         if let Some(mut pkt) = parse_udp_datagram(part.src, part.dst, datagram, Duration::ZERO) {
             // Anchor timing to the first datagram, not the first pcap record
             let first = first_ts.get_or_insert((ts_sec, ts_frac));
-            let divisor: u64 = if nanoseconds {
-                1_000_000_000
-            } else {
-                1_000_000
-            };
             let abs_first = first.0 as u64 * divisor + first.1 as u64;
             let abs_now = ts_sec as u64 * divisor + ts_frac as u64;
             pkt.timestamp =
@@ -193,15 +218,25 @@ struct IpPart<'a> {
 type FragmentKey = (Ipv4Addr, Ipv4Addr, u16);
 
 /// The pieces of one datagram, held until every byte of it has arrived.
-#[derive(Default)]
 struct FragmentSet {
     /// Fragments kept sorted by offset, so completeness is one walk.
     pieces: Vec<(usize, Vec<u8>)>,
     /// The datagram's length, known once the last fragment arrives.
     total: Option<usize>,
+    /// Capture time of the first fragment, in the file's own timestamp units,
+    /// against which the set is expired.
+    started: u64,
 }
 
 impl FragmentSet {
+    fn new(started: u64) -> Self {
+        FragmentSet {
+            pieces: Vec::new(),
+            total: None,
+            started,
+        }
+    }
+
     fn add(&mut self, offset: usize, payload: &[u8], last: bool) {
         if last {
             self.total = Some(offset + payload.len());
@@ -272,9 +307,8 @@ fn parse_ip_part(data: &[u8]) -> Option<IpPart<'_>> {
         src: Ipv4Addr::new(ip[12], ip[13], ip[14], ip[15]),
         dst: Ipv4Addr::new(ip[16], ip[17], ip[18], ip[19]),
         id,
-        // The fragment offset counts 8-byte units.
-        offset: (frag & 0x1FFF) as usize * 8,
-        more: frag & 0x2000 != 0,
+        offset: (frag & IP_FRAG_OFFSET_MASK) as usize * IP_FRAG_OFFSET_UNIT,
+        more: frag & IP_FLAG_MORE_FRAGMENTS != 0,
         payload: &ip[ihl..total_len],
     })
 }
@@ -538,7 +572,8 @@ mod tests {
         f.push(0x00);
         f.extend_from_slice(&((IP_HEADER_MIN_LEN + part.len()) as u16).to_be_bytes());
         f.extend_from_slice(&id.to_be_bytes());
-        let flags = (if more { 0x2000u16 } else { 0 }) | (offset / 8) as u16;
+        let flags =
+            (if more { IP_FLAG_MORE_FRAGMENTS } else { 0 }) | (offset / IP_FRAG_OFFSET_UNIT) as u16;
         f.extend_from_slice(&flags.to_be_bytes());
         f.push(64);
         f.push(IP_PROTO_UDP);
@@ -560,7 +595,7 @@ mod tests {
         d.extend_from_slice(&65535u32.to_le_bytes());
         d.extend_from_slice(&1u32.to_le_bytes());
         for (i, f) in frames.iter().enumerate() {
-            d.extend_from_slice(&(i as u32).to_le_bytes()); // ts_sec
+            d.extend_from_slice(&(i as u32).to_le_bytes()); // ts_sec, one per second
             d.extend_from_slice(&0u32.to_le_bytes()); // ts_usec
             d.extend_from_slice(&(f.len() as u32).to_le_bytes());
             d.extend_from_slice(&(f.len() as u32).to_le_bytes());
@@ -649,6 +684,86 @@ mod tests {
         ]))
         .expect("parse");
         assert!(with_hole.is_empty(), "a hole means no datagram");
+    }
+
+    /// A capture can hold the same fragment twice; the second copy must not be
+    /// appended a second time.
+    #[test]
+    fn a_duplicated_fragment_is_not_appended_twice() {
+        let payload: Vec<u8> = (0..3000u32).map(|i| (i % 251) as u8).collect();
+        let datagram = udp_datagram(6680, 6678, &payload);
+        let (first, rest) = datagram.split_at(1480);
+
+        let packets = parse_bytes(&pcap_of(&[
+            frame(0x1234, 0, true, first),
+            frame(0x1234, 0, true, first),
+            frame(0x1234, 1480, false, rest),
+        ]))
+        .expect("parse");
+
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].payload, payload);
+    }
+
+    /// Fragments can overlap: a retransmitted one may start before the last
+    /// byte already covered. Only the part that extends the datagram counts.
+    #[test]
+    fn an_overlapping_fragment_contributes_only_its_new_bytes() {
+        let payload: Vec<u8> = (0..3000u32).map(|i| (i % 251) as u8).collect();
+        let datagram = udp_datagram(6680, 6678, &payload);
+
+        // The second fragment starts 480 bytes before the first one ended.
+        let packets = parse_bytes(&pcap_of(&[
+            frame(0x1234, 0, true, &datagram[..1480]),
+            frame(0x1234, 1000, false, &datagram[1000..]),
+        ]))
+        .expect("parse");
+
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].payload, payload);
+    }
+
+    /// The identification field is 16 bits, so a busy capture reuses one. A
+    /// datagram whose middle fragment was lost knows its total length and sits
+    /// waiting with a hole in it. A later datagram that reuses the same
+    /// identification must not have its bytes dropped into that hole: the two
+    /// would be spliced into a packet that never crossed the wire.
+    #[test]
+    fn a_stale_fragment_set_is_not_completed_by_a_later_datagram() {
+        let orphan = udp_datagram(6680, 6678, &vec![0xAA; 3000]);
+        let later = udp_datagram(6680, 6678, &vec![0xBB; 3000]);
+        assert_eq!(orphan.len(), 3008);
+
+        // The orphan loses only its middle fragment, so its total length is
+        // known and the set waits with a hole at 1480..2960.
+        let mut frames = vec![
+            frame(0x1234, 0, true, &orphan[..1480]),
+            frame(0x1234, 2960, false, &orphan[2960..]),
+        ];
+        // pcap_of stamps one second per record, so what follows lands well
+        // beyond FRAGMENT_TIMEOUT_SECS.
+        for _ in 0..FRAGMENT_TIMEOUT_SECS + 1 {
+            frames.push(frame(0x9999, 0, false, &udp_datagram(1, 2, &[0x00])));
+        }
+        // A later datagram reusing identification 0x1234, its middle fragment
+        // exactly filling the orphan's hole.
+        frames.push(frame(0x1234, 1480, true, &later[1480..2960]));
+
+        let packets = parse_bytes(&pcap_of(&frames)).expect("parse");
+        let on_radar_port: Vec<_> = packets
+            .iter()
+            .filter(|p| p.dst_addr.port() == 6678)
+            .collect();
+
+        assert!(
+            on_radar_port.is_empty(),
+            "neither datagram is complete, yet {} packet(s) were emitted: {:?}",
+            on_radar_port.len(),
+            on_radar_port
+                .iter()
+                .map(|p| (p.payload[0], p.payload[p.payload.len() - 1]))
+                .collect::<Vec<_>>()
+        );
     }
 
     /// A frame padded to Ethernet's 60-byte minimum must not have its padding

--- a/src/lib/pcap.rs
+++ b/src/lib/pcap.rs
@@ -4,6 +4,7 @@
 //! and extracts UDP packets with their source/destination addresses
 //! and payloads.
 
+use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read};
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -108,6 +109,7 @@ pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
     }
 
     let mut packets = Vec::new();
+    let mut fragments: HashMap<FragmentKey, FragmentSet> = HashMap::new();
     let mut offset = 24;
     let mut first_ts: Option<(u32, u32)> = None;
 
@@ -125,9 +127,35 @@ pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
         let pkt_data = &data[offset..offset + incl_len];
         offset += incl_len;
 
-        // Parse Ethernet + IP + UDP (timestamp filled in below)
-        if let Some(mut pkt) = parse_udp_packet(pkt_data, Duration::ZERO) {
-            // Anchor timing to the first UDP packet, not the first pcap record
+        let Some(part) = parse_ip_part(pkt_data) else {
+            continue;
+        };
+
+        // A datagram that arrived whole is the common case. Fragments are held
+        // until the last one lands: Navico spoke datagrams are ~17 kB and so
+        // always fragmented, and dropping them makes the entire spoke stream
+        // invisible to replay.
+        let reassembled;
+        let datagram: &[u8] = if part.offset == 0 && !part.more {
+            part.payload
+        } else {
+            let key = (part.src, part.dst, part.id);
+            let set = fragments.entry(key).or_default();
+            set.add(part.offset, part.payload, !part.more);
+            match set.take_complete() {
+                Some(datagram) => {
+                    fragments.remove(&key);
+                    reassembled = datagram;
+                    &reassembled
+                }
+                // Still missing pieces; it is emitted when the gap is filled.
+                None => continue,
+            }
+        };
+
+        // Parse UDP (timestamp filled in below)
+        if let Some(mut pkt) = parse_udp_datagram(part.src, part.dst, datagram, Duration::ZERO) {
+            // Anchor timing to the first datagram, not the first pcap record
             let first = first_ts.get_or_insert((ts_sec, ts_frac));
             let divisor: u64 = if nanoseconds {
                 1_000_000_000
@@ -145,8 +173,68 @@ pub(crate) fn parse_bytes(data: &[u8]) -> io::Result<Vec<PcapPacket>> {
     Ok(packets)
 }
 
-fn parse_udp_packet(data: &[u8], timestamp: Duration) -> Option<PcapPacket> {
-    if data.len() < ETH_HEADER_LEN + IP_HEADER_MIN_LEN + UDP_HEADER_LEN {
+/// One IPv4 datagram, or one fragment of one, as it came off the wire.
+struct IpPart<'a> {
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    /// Identification field, which is what ties fragments of one datagram
+    /// together.
+    id: u16,
+    /// Where this fragment's bytes sit in the datagram.
+    offset: usize,
+    /// The "more fragments" flag: false on the last fragment, and on a
+    /// datagram that was never fragmented.
+    more: bool,
+    /// The IP payload — the UDP datagram, or a slice of it.
+    payload: &'a [u8],
+}
+
+/// Fragments of one datagram, identified by source, destination and IP id.
+type FragmentKey = (Ipv4Addr, Ipv4Addr, u16);
+
+/// The pieces of one datagram, held until every byte of it has arrived.
+#[derive(Default)]
+struct FragmentSet {
+    /// Fragments kept sorted by offset, so completeness is one walk.
+    pieces: Vec<(usize, Vec<u8>)>,
+    /// The datagram's length, known once the last fragment arrives.
+    total: Option<usize>,
+}
+
+impl FragmentSet {
+    fn add(&mut self, offset: usize, payload: &[u8], last: bool) {
+        if last {
+            self.total = Some(offset + payload.len());
+        }
+        let at = self.pieces.partition_point(|(o, _)| *o < offset);
+        self.pieces.insert(at, (offset, payload.to_vec()));
+    }
+
+    /// The reassembled datagram, once the fragments cover it end to end.
+    ///
+    /// A capture can hold the same fragment twice, or fragments that overlap,
+    /// so each one contributes only the part that extends what is already
+    /// covered rather than being appended blindly.
+    fn take_complete(&self) -> Option<Vec<u8>> {
+        let total = self.total?;
+        let mut datagram = Vec::with_capacity(total);
+        for (offset, bytes) in &self.pieces {
+            if *offset > datagram.len() {
+                return None; // a hole: fragments are still missing
+            }
+            let already_have = datagram.len() - offset;
+            if let Some(rest) = bytes.get(already_have..) {
+                datagram.extend_from_slice(rest);
+            }
+        }
+        (datagram.len() == total).then_some(datagram)
+    }
+}
+
+/// Pull the IPv4 payload out of an Ethernet frame, keeping the fragmentation
+/// fields so the caller can reassemble what arrived in pieces.
+fn parse_ip_part(data: &[u8]) -> Option<IpPart<'_>> {
+    if data.len() < ETH_HEADER_LEN + IP_HEADER_MIN_LEN {
         return None;
     }
 
@@ -170,16 +258,34 @@ fn parse_udp_packet(data: &[u8], timestamp: Duration) -> Option<PcapPacket> {
     if protocol != IP_PROTO_UDP {
         return None;
     }
-    // Skip fragmented packets — non-initial fragments lack a UDP header
-    let frag = u16::from_be_bytes(ip[6..8].try_into().ok()?);
-    if frag & 0x3FFF != 0 {
+    // The frame may be padded to Ethernet's 60-byte minimum, so the datagram
+    // ends where the IP header says it does, not where the frame does.
+    let total_len = u16::from_be_bytes(ip[2..4].try_into().ok()?) as usize;
+    if total_len < ihl || total_len > ip.len() {
         return None;
     }
-    let src_ip = Ipv4Addr::new(ip[12], ip[13], ip[14], ip[15]);
-    let dst_ip = Ipv4Addr::new(ip[16], ip[17], ip[18], ip[19]);
 
-    // UDP header
-    let udp = &ip[ihl..];
+    let id = u16::from_be_bytes(ip[4..6].try_into().ok()?);
+    let frag = u16::from_be_bytes(ip[6..8].try_into().ok()?);
+
+    Some(IpPart {
+        src: Ipv4Addr::new(ip[12], ip[13], ip[14], ip[15]),
+        dst: Ipv4Addr::new(ip[16], ip[17], ip[18], ip[19]),
+        id,
+        // The fragment offset counts 8-byte units.
+        offset: (frag & 0x1FFF) as usize * 8,
+        more: frag & 0x2000 != 0,
+        payload: &ip[ihl..total_len],
+    })
+}
+
+/// Parse a complete UDP datagram — header and payload — into a packet.
+fn parse_udp_datagram(
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    udp: &[u8],
+    timestamp: Duration,
+) -> Option<PcapPacket> {
     if udp.len() < UDP_HEADER_LEN {
         return None;
     }
@@ -410,6 +516,152 @@ mod tests {
         let parsed = parse_file(&fixture).expect("parse");
         assert_eq!(parsed[1].payload, vec![0xAA, 0xBB, 0xCC]);
         fs::remove_dir_all(&dir).expect("clean up");
+    }
+
+    /// A UDP datagram: header plus payload, as it sits inside IP.
+    fn udp_datagram(src_port: u16, dst_port: u16, payload: &[u8]) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&src_port.to_be_bytes());
+        d.extend_from_slice(&dst_port.to_be_bytes());
+        d.extend_from_slice(&((UDP_HEADER_LEN + payload.len()) as u16).to_be_bytes());
+        d.extend_from_slice(&[0x00; 2]); // checksum
+        d.extend_from_slice(payload);
+        d
+    }
+
+    /// One Ethernet frame carrying an IPv4 fragment. `offset` is in bytes and
+    /// `more` is the MF flag, so a whole datagram is `(0, false)`.
+    fn frame(id: u16, offset: usize, more: bool, part: &[u8]) -> Vec<u8> {
+        let mut f = vec![0x00; 12];
+        f.extend_from_slice(&ETHERTYPE_IPV4.to_be_bytes());
+        f.push(0x45);
+        f.push(0x00);
+        f.extend_from_slice(&((IP_HEADER_MIN_LEN + part.len()) as u16).to_be_bytes());
+        f.extend_from_slice(&id.to_be_bytes());
+        let flags = (if more { 0x2000u16 } else { 0 }) | (offset / 8) as u16;
+        f.extend_from_slice(&flags.to_be_bytes());
+        f.push(64);
+        f.push(IP_PROTO_UDP);
+        f.extend_from_slice(&[0x00; 2]); // checksum
+        f.extend_from_slice(&[10, 0, 0, 1]);
+        f.extend_from_slice(&[239, 0, 0, 1]);
+        f.extend_from_slice(part);
+        f
+    }
+
+    /// A pcap file holding the given frames, one record each.
+    fn pcap_of(frames: &[Vec<u8>]) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&PCAP_MAGIC_LE.to_le_bytes());
+        d.extend_from_slice(&2u16.to_le_bytes());
+        d.extend_from_slice(&4u16.to_le_bytes());
+        d.extend_from_slice(&0i32.to_le_bytes());
+        d.extend_from_slice(&0u32.to_le_bytes());
+        d.extend_from_slice(&65535u32.to_le_bytes());
+        d.extend_from_slice(&1u32.to_le_bytes());
+        for (i, f) in frames.iter().enumerate() {
+            d.extend_from_slice(&(i as u32).to_le_bytes()); // ts_sec
+            d.extend_from_slice(&0u32.to_le_bytes()); // ts_usec
+            d.extend_from_slice(&(f.len() as u32).to_le_bytes());
+            d.extend_from_slice(&(f.len() as u32).to_le_bytes());
+            d.extend_from_slice(f);
+        }
+        d
+    }
+
+    /// A Navico spoke datagram is ~17 kB and so always arrives in fragments.
+    /// Dropping them leaves replay with beacons and reports only, which is why
+    /// no test could see a decoded echo.
+    #[test]
+    fn a_fragmented_datagram_is_reassembled() {
+        let payload: Vec<u8> = (0..3000u32).map(|i| (i % 251) as u8).collect();
+        let datagram = udp_datagram(6680, 6678, &payload);
+        let (first, rest) = datagram.split_at(1480);
+
+        let packets = parse_bytes(&pcap_of(&[
+            frame(0x1234, 0, true, first),
+            frame(0x1234, 1480, false, rest),
+        ]))
+        .expect("parse");
+
+        assert_eq!(packets.len(), 1, "the fragments are one datagram");
+        assert_eq!(packets[0].dst_addr.port(), 6678);
+        assert_eq!(packets[0].payload, payload);
+    }
+
+    /// Fragments are not guaranteed to be captured in order.
+    #[test]
+    fn fragments_arriving_out_of_order_are_reassembled() {
+        let payload: Vec<u8> = (0..3000u32).map(|i| (i % 251) as u8).collect();
+        let datagram = udp_datagram(6680, 6678, &payload);
+        let (first, rest) = datagram.split_at(1480);
+
+        let packets = parse_bytes(&pcap_of(&[
+            frame(0x1234, 1480, false, rest),
+            frame(0x1234, 0, true, first),
+        ]))
+        .expect("parse");
+
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].payload, payload);
+    }
+
+    /// Two streams talking at once interleave their fragments; the IP id keeps
+    /// them apart.
+    #[test]
+    fn interleaved_datagrams_are_kept_apart() {
+        let a: Vec<u8> = vec![0xAA; 2000];
+        let b: Vec<u8> = vec![0xBB; 2000];
+        let da = udp_datagram(1, 1000, &a);
+        let db = udp_datagram(2, 2000, &b);
+
+        let packets = parse_bytes(&pcap_of(&[
+            frame(0x0001, 0, true, &da[..1480]),
+            frame(0x0002, 0, true, &db[..1480]),
+            frame(0x0001, 1480, false, &da[1480..]),
+            frame(0x0002, 1480, false, &db[1480..]),
+        ]))
+        .expect("parse");
+
+        assert_eq!(packets.len(), 2);
+        assert_eq!(packets[0].dst_addr.port(), 1000);
+        assert_eq!(packets[0].payload, a);
+        assert_eq!(packets[1].dst_addr.port(), 2000);
+        assert_eq!(packets[1].payload, b);
+    }
+
+    /// A capture that starts mid-datagram, or drops a fragment, must not
+    /// produce a truncated packet that looks like a real one.
+    #[test]
+    fn an_incomplete_datagram_is_dropped() {
+        let payload: Vec<u8> = vec![0x5A; 3000];
+        let datagram = udp_datagram(6680, 6678, &payload);
+
+        let only_first =
+            parse_bytes(&pcap_of(&[frame(0x1234, 0, true, &datagram[..1480])])).expect("parse");
+        assert!(only_first.is_empty(), "no last fragment, so no datagram");
+
+        // First and last present, middle missing: the end is known but there
+        // is a hole before it.
+        let with_hole = parse_bytes(&pcap_of(&[
+            frame(0x1234, 0, true, &datagram[..1480]),
+            frame(0x1234, 2960, false, &datagram[2960..]),
+        ]))
+        .expect("parse");
+        assert!(with_hole.is_empty(), "a hole means no datagram");
+    }
+
+    /// A frame padded to Ethernet's 60-byte minimum must not have its padding
+    /// read as payload.
+    #[test]
+    fn ethernet_padding_is_not_payload() {
+        let datagram = udp_datagram(6680, 6678, &[0x01, 0x02, 0x03]);
+        let mut padded = frame(0x1234, 0, false, &datagram);
+        padded.resize(60, 0x00);
+
+        let packets = parse_bytes(&pcap_of(&[padded])).expect("parse");
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].payload, vec![0x01, 0x02, 0x03]);
     }
 
     #[test]


### PR DESCRIPTION
Replaying a captured Navico radar has never shown a single echo. The capture holds the spokes, but mayara threw them away while reading the file: a spoke datagram is about 17 kB, far more than fits in one Ethernet frame, so it travels as IP fragments — and the pcap parser dropped every fragment it saw. In the 3G capture that is 707 spoke datagrams discarded, leaving 134 packets of beacons and reports.

Nothing a user sees changes yet. This is the prerequisite for #611: no fixture is regenerated here, so every replay test still replays exactly what it replayed before. The test coverage that this unlocks — asserting that spokes decode into a real picture — follows in its own PR.

## Approach

Fragments are held by source, destination and IP id until they cover the datagram end to end, then parsed as one. Each fragment contributes only the part that extends what is already covered, so a capture holding the same fragment twice, or overlapping fragments, reassembles correctly. A capture that starts mid-datagram or drops a fragment yields nothing for it, rather than a truncated packet that would look real.

Reading the datagram's length from the IP header rather than from the frame also keeps Ethernet's 60-byte minimum padding out of a small payload.

## Tests

Six, over hand-built pcap bytes: reassembly, fragments captured out of order, two datagrams interleaved and kept apart by their IP id, an incomplete datagram dropped (both with no last fragment and with a hole in the middle), and the padding case.

Prerequisite for #611.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Reassembles fragmented IPv4 UDP datagrams in the pcap parser.

- Groups fragments by source, destination, and IP identification.
- Handles out-of-order, duplicate, overlapping, and interleaved fragments.
- Discards incomplete or expired datagrams.
- Uses the IP total-length field to exclude Ethernet padding.
- Adds tests for reassembly, incomplete datagrams, expiration, overlaps, duplicates, and padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->