### PR TITLE
docs(usage): document the flags mayara actually accepts

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -49,12 +49,15 @@ Command Line Options
 | `-i, --interface <INTERFACE>` | Limit radar discovery to a specific network interface                                                   |
 | `--allow-wifi`                | Allow radar discovery on WiFi interfaces (not recommended for most brands due to multicast limitations) |
 | `--parent <PID>`              | Run as a helper process of a chart plotter; see [Running under a chart plotter](#running-under-a-chart-plotter) |
+| `--mdns-hostname <NAME>`      | Host name to claim on mDNS, so the GUI is reachable at `http://<name>.local:<port>/` (default: `mayara`). Give each server on a network its own name; two claiming the same one contend for it, and the loser is renamed |
+| `--no-mdns`                   | Do not advertise on mDNS at all, so `<name>.local` will not resolve and clients must be given the address. Use it when the machine already runs its own mDNS responder (Avahi, Bonjour) |
+| `--no-websocket-compression`  | Disable permessage-deflate on the outbound spoke and Signal K streams. Trades bandwidth for CPU, which is worth it on a LAN where compressing costs more than it saves |
 
 ### Radar Selection
 
 | Option                | Description                                                                            |
 | --------------------- | -------------------------------------------------------------------------------------- |
-| `-b, --brand <BRAND>` | Limit to a specific radar brand: `furuno`, `garmin`, `navico`, `raymarine`, `emulator` |
+| `-b, --brand <BRAND>` | Limit to a specific radar brand: `furuno`, `garmin`, `koden`, `navico`, `raymarine`, `emulator`, `playback` |
 | `--multiple-radar`    | Keep searching for additional radars after finding one                                 |
 | `--emulator`          | Use built-in radar emulator instead of real radar discovery                            |
 
@@ -75,10 +78,13 @@ Command Line Options
 | `-n, --navigation-address <ADDR>` | Navigation service address for GPS/heading data                             |
 |                                   | No value: auto-discover via mDNS                                            |
 |                                   | Interface name: search mDNS on that interface                               |
-|                                   | `tcp:ip:port`: anonymous Signal K TCP stream                                |
-|                                   | `udp:ip:port`: listen for NMEA 0183 UDP broadcasts                          |
-|                                   | `ws:ip:port`: Signal K WebSocket (via discovery)                            |
-|                                   | `wss:ip:port`: Signal K secure WebSocket (requires `--accept-invalid-certs`)|
+|                                   | `tcp:host:port`: anonymous Signal K TCP stream                              |
+|                                   | `udp:host:port`: listen for NMEA 0183 UDP broadcasts                        |
+|                                   | `ws:host:port`: Signal K WebSocket (via discovery)                          |
+|                                   | `wss:host:port`: Signal K secure WebSocket (requires `--accept-invalid-certs`)|
+|                                   | The address may be an IP or a host name. A name is resolved afresh on each  |
+|                                   | connection attempt, so one whose address changes is followed without a      |
+|                                   | restart.                                                                    |
 | `--nmea0183`                      | Use NMEA 0183 instead of Signal K for navigation                            |
 | `--accept-invalid-certs`          | Accept self-signed TLS certificates when connecting to Signal K via         |
 |                                   | HTTPS/WSS. Required for boat-LAN setups that use self-signed certs.         |
@@ -125,8 +131,20 @@ the server to accept IP-based SNI or point Mayara at an on-LAN instance.
 | Option          | Description                                          |
 | --------------- | ---------------------------------------------------- |
 | `--transmit`    | Automatically put detected radars into transmit mode |
-| `-r, --replay`  | Replay mode for pcap file playback                   |
+| `-r, --replay`  | Legacy replay mode: controls are read-only and no beacons are sent, for feeding a radar stream in from outside mayara (`tcpreplay`). To replay a capture file, use `--pcap` |
 | `--fake-errors` | Testing mode that simulates control errors           |
+
+### Capture Replay
+
+These need a build made with the `pcap-replay` feature — it is not among the
+default features, so neither the released binaries nor a plain `cargo build`
+carry it. Build with `cargo build --features pcap-replay`.
+
+| Option                    | Description                                                            |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `--pcap <FILE>`           | Replay a pcap or nnd capture through the full radar pipeline           |
+| `--repeat`                | Loop the capture instead of stopping at the end (only with `--pcap`)   |
+| `--pcap-max-time <SECS>`  | Replay at most this many seconds of the capture, then exit (only with `--pcap`, conflicts with `--repeat`). Useful for a reproducible, time-bounded profiling run |
 
 ### Output & Debugging
 
@@ -204,10 +222,16 @@ mayara-server --emulator -vv
 mayara-server --multiple-radar --merge-targets
 ```
 
-### Replay mode
+### Replaying a capture
 
 ```bash
-# Replay captured radar data (requires tcpreplay of pcap file)
+# Replay a capture file through the full pipeline
+mayara-server --pcap navico-halo24.pcap.gz
+
+# Loop it, for working on the GUI without a radar to hand
+mayara-server --pcap navico-halo24.pcap.gz --repeat
+
+# Feed the stream in from outside mayara instead, e.g. with tcpreplay
 mayara-server --replay
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -81,13 +81,17 @@ Command Line Options
 |                                   | `tcp:host:port`: anonymous Signal K TCP stream                              |
 |                                   | `udp:host:port`: listen for NMEA 0183 UDP broadcasts                        |
 |                                   | `ws:host:port`: Signal K WebSocket (via discovery)                          |
-|                                   | `wss:host:port`: Signal K secure WebSocket (requires `--accept-invalid-certs`)|
+|                                   | `wss:host:port`: Signal K secure WebSocket. A self-signed certificate       |
+|                                   | additionally needs `--accept-invalid-certs`; one signed by a CA the machine |
+|                                   | trusts needs nothing.                                                       |
 |                                   | The address may be an IP or a host name. A name is resolved afresh on each  |
 |                                   | connection attempt, so one whose address changes is followed without a      |
 |                                   | restart.                                                                    |
 | `--nmea0183`                      | Use NMEA 0183 instead of Signal K for navigation                            |
-| `--accept-invalid-certs`          | Accept self-signed TLS certificates when connecting to Signal K via         |
-|                                   | HTTPS/WSS. Required for boat-LAN setups that use self-signed certs.         |
+| `--accept-invalid-certs`          | Accept any TLS certificate when connecting to Signal K over HTTPS or WSS,   |
+|                                   | which a boat LAN using a self-signed one needs. It turns the check off      |
+|                                   | rather than widening it, so leave it off against a server whose certificate |
+|                                   | is signed by a CA the machine already trusts.                               |
 | `--signalk-token <TOKEN>`         | Signal K bearer token for authenticating to a `ws:` or `wss:` upstream.     |
 |                                   | Sent as `?token=...` on the WebSocket and as `Authorization: Bearer ...`    |
 |                                   | on the REST discovery and AIS-store seeding probes. Has no effect on        |


### PR DESCRIPTION
Six command line flags were missing from USAGE.md and two entries described something the binary no longer does, so a reader following the document could not find the mDNS options at all and was pointed at the wrong flag for replaying a capture.

## Added

| Flag | |
|---|---|
| `--mdns-hostname <NAME>` | the answer to two mayaras on one network fighting over `mayara.local` |
| `--no-mdns` | for machines already running Avahi or Bonjour |
| `--no-websocket-compression` | trades bandwidth for CPU on a LAN |
| `--pcap <FILE>`, `--repeat`, `--pcap-max-time <SECS>` | replaying a capture, in a section of their own |

The capture flags need a build made with the `pcap-replay` feature, which is not among the default features — no released binary carries it — and the new section says so.

## Corrected

- `--brand` omitted `koden` and `playback`.
- `-r, --replay` was described as the pcap flag it no longer is. It is the legacy mode for a stream fed in from outside mayara; the example now shows `--pcap` for a file and keeps `--replay` for the `tcpreplay` case.
- The navigation address takes a host name as well as an IP, re-resolved on each connection attempt (#643).

Checked by diffing `--help` against the document, with and without the `pcap-replay` and `emulator` features: no flag is now undocumented, and nothing documented is not a flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `USAGE.md` to document all `mayara` flags, including mDNS, WebSocket compression, capture replay, and supported radar brands. Clarifies legacy `--replay` behavior, documents `pcap-replay` requirements, and explains hostname support for navigation addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->