### PR TITLE
fix(garmin): record the transmit channel mode instead of refusing it

### DIFF
--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -514,12 +514,16 @@ impl GarminReportReceiver {
             MSG_TRANSMIT_CHANNEL_MODE => {
                 let v = self.extract_xhd_value(data)?;
                 log::debug!("{}: transmit channel mode: {}", self.common.key, v);
-                // 0=manual, 1=auto
-                self.common.set_value_auto(
-                    &ControlId::TransmitChannel,
-                    0.0,
-                    if v == 1 { 1 } else { 0 },
-                );
+                // 0=manual, 1=auto. The mode arrives without a channel beside
+                // it, and the channel numbers start at 1, so setting the auto
+                // flag through a value-bearing call would offer 0 and have the
+                // whole update refused for being below the minimum. The channel
+                // itself comes from MSG_TRANSMIT_CHANNEL_SELECT below.
+                let _ = self
+                    .common
+                    .info
+                    .controls
+                    .set_auto_state(&ControlId::TransmitChannel, v == 1);
             }
             MSG_TRANSMIT_CHANNEL_SELECT => {
                 let v = self.extract_xhd_value(data)?;

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -4434,6 +4434,53 @@ mod test {
         assert!(serde_json::from_str::<ControlValue>(json).is_err());
     }
 
+    /// A control whose values start above zero can still have its auto state
+    /// recorded. Garmin reports the transmit-channel mode on its own, with no
+    /// channel beside it, and the channels are numbered from 1: offering a
+    /// placeholder 0 has the whole update refused for being below the minimum,
+    /// and the auto flag is discarded with it. Regression for #658.
+    #[test]
+    fn auto_state_is_recorded_for_a_control_whose_values_start_above_zero() {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let mut controls = SharedControls::new("gar1234".to_string(), tx, &args, HashMap::new());
+        controls.add(new_auto(
+            ControlId::TransmitChannel,
+            1.,
+            4.,
+            AutomaticValue {
+                has_auto: true,
+                has_auto_adjustable: false,
+                auto_adjust_min_value: None,
+                auto_adjust_max_value: None,
+            },
+        ));
+
+        // How the mode used to be recorded: a placeholder value alongside the
+        // flag. The value is refused, and the flag never lands.
+        assert!(
+            matches!(
+                controls.set_value_auto(&ControlId::TransmitChannel, true, 0.),
+                Err(ControlError::TooLow(..))
+            ),
+            "a channel of 0 is below the minimum of 1"
+        );
+        assert_eq!(
+            controls.get(&ControlId::TransmitChannel).unwrap().auto,
+            None,
+            "the refused value took the auto flag with it"
+        );
+
+        // The mode on its own, which is all the radar reported.
+        controls
+            .set_auto_state(&ControlId::TransmitChannel, true)
+            .unwrap();
+        assert_eq!(
+            controls.get(&ControlId::TransmitChannel).unwrap().auto,
+            Some(true)
+        );
+    }
+
     /// A radar reporting only that a control switched to (or out of) auto is
     /// news the clients rendering from the delta stream have no other way to
     /// learn: no value came with it, and nothing guarantees a later


### PR DESCRIPTION
A Garmin Fantom Pro logged an error every time the radar reported its transmit channel mode:

```
garce30A: Control transmitChannel value 0 is lower than minimum value 1
```

Nothing was wrong with the radar, and the channel number itself was fine — it arrives in a different message. The error is noise that sends anyone debugging a Fantom Pro down the wrong path, and the auto/manual flag the message carried was thrown away with the value that was refused.

## Cause

The mode message carries a mode and no channel, so the handler passed 0 as a placeholder value alongside the flag. Channels are numbered from 1, and `Control::set` range-checks the value **before** applying the auto flag, so the update was refused wholesale and the flag went with it.

## Approach

`SharedControls::set_auto_state` already exists for this exact case — an auto flag arriving in a status report with no value beside it, added for HALO's Sea — so the handler now uses it. The channel continues to come from the select message just below.

The issue text claimed no auto-only setter existed. That was wrong: it was there, and Navico and Koden already use it.

## What this does not fix

The flag is now recorded rather than refused, but it does not yet survive: `Control::set` treats `auto: None` as "clear it", so the channel report that arrives immediately afterwards wipes what the mode report just set. Filed separately as #661, because it is a core control change affecting every brand that splits auto and value across messages, not something to bundle into a Garmin fix.

So this PR removes the error and makes the mode land; the Fantom Pro will show its auto state once #661 lands too.

## Tests

A regression test at the settings boundary: a control whose values start at 1 refuses the old placeholder call with `TooLow` and keeps `auto: None`, then records the flag through `set_auto_state`. Replaying the committed `garmin-fantom-pro` fixture now logs the error zero times, where it appeared on every mode report before.

closes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates Garmin Fantom Pro transmit-channel mode handling to record the auto/manual state with `set_auto_state` instead of passing an invalid channel value of `0`. Channel values remain recorded from the separate select message. Adds regression coverage for controls whose valid values start above zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->