### PR TITLE
feat(navico): let an unwatched radar stand down after a set time

### DIFF
--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -171,5 +171,5 @@ Integration tests in `tests/replay_*.rs` replay brand-specific pcap fixtures and
 - [Adding a New Radar Brand](new_radar_brand.md) — full guide with checklist
 - [Capturing Radar Traffic](../capturing-traffic.md) — pcap capture for bug reports and new-brand fixtures
 - [ARPA Target Tracking](arpa.md) — IMM filtering and blob detection
-- [Radar Status Model](radar-status.md) — design intent for lifecycle/health status vs. idle, and the ARPA/idle interaction
+- [Radar Status Model](radar-status.md) — design intent for lifecycle/health status vs. idle, stand-down of an unwatched radar, and the ARPA/idle interaction
 - [Mayara Server for radar_pi Developers](radar_pi_comparison.md) — concept map for developers coming from the radar_pi OpenCPN plugin

--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -71,12 +71,50 @@ unknown.
 Widening idle to cover the transmit-but-unwatched case is possible, but only once the
 subscriber count counts ARPA (below).
 
-## ARPA counts as a subscriber
+### 3. Stand-down — letting an *unwatched* radar go (issue #633)
+
+A headless mayara must not hold a radar transmitting for an audience of nobody: that ages
+the magnetron and burns power. So when nobody has watched a radar for the period set by its
+**Auto standby** control (Off / 1 / 5 / 15 / 30 min, default 1 min; category Installation)
+the brand receiver stops holding it up and lets the radar decide for itself. Stand-down is
+independent of idle and of the radar's power state; it is a *policy* for the receiver, not
+a state of the radar.
+
+"Watched" is deliberately narrow: a subscriber on the spoke broadcast (`message_tx`) — the
+GUI or any spoke WebSocket client, the `--output` stdout forwarder, or a running recording.
+Control PUTs, REST reads and the control WebSocket do **not** count. Neither does ARPA
+tracking or an armed guard zone: a radar nobody is looking at stands down even while it is
+tracking. That is an accepted consequence, not an oversight — the radar is meant to come
+back only when a client asks for it.
+
+The ranges of a dual-range radar share one antenna, so the decision is made **per
+antenna** and written to every range: the antenna stands down only when *every* range has
+auto standby enabled and has been unwatched for its own period. A range set to Off holds
+the whole antenna up. The 5 s radar watchdog computes this (`SharedRadars::refresh_stand_down`
+in `src/lib/radar/mod.rs`; the pure predicate `antenna_should_stand_down` and its tests pin
+the rule) and each brand receiver reads `RadarInfo::stand_down()` on its own tick.
+
+The control is offered only by brands whose receiver honours it (`new_auto_standby()` in
+the brand's `settings.rs`); on other brands `SharedControls::auto_standby()` is `None` and
+the radar never stands down. Per brand:
+
+- **Navico**: the radar is held up by the `a0 c1` "stay on scanner A" ping mayara sends
+  every 5 s with its state queries. While standing down the ping is left out; the two
+  queries (`04 c2`, `01 c2`) continue so the radar's state keeps arriving. No standby
+  command is sent — the ping is a per-client watchdog, so an MFD that is also using the
+  radar keeps it up with its own, and mayara needs no "am I the only controller" check.
+  Once a client reconnects the ping resumes, but the radar stays in Standby until that
+  client asks for Transmit. Measured on a HALO24: the radar leaves Transmit about 25 s
+  after the last ping, so with the 1 min default the antenna goes quiet roughly 85 s after
+  the last viewer disconnects.
+- **Raymarine, Koden, Furuno, Garmin**: not yet; see the issue for the per-brand notes.
+
+## ARPA counts as a subscriber — for idle
 
 A radar with an active ARPA / MARPA tracker is **not idle**, even if no GUI is open. ARPA is
 a legitimate consumer of the spoke stream — if it's tracking targets, something (autopilot,
-guard zone, plotter) cares about that radar. Do not treat "no WebSocket viewers" as "nobody
-is watching."
+guard zone, plotter) cares about that radar. For the *idle* predicate, do not treat "no
+WebSocket viewers" as "nobody is watching." (Stand-down, above, deliberately does.)
 
 ### ⚠️ ARPA / idle gotcha — be careful here
 

--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -98,11 +98,11 @@ The control is offered only by brands whose receiver honours it (`new_auto_stand
 the brand's `settings.rs`); on other brands `SharedControls::auto_standby()` is `None` and
 the radar never stands down. Per brand:
 
-- **Navico**: the radar is held up by the `a0 c1` "stay on scanner A" ping mayara sends
-  every 5 s with its state queries. While standing down the ping is left out; the two
-  queries (`04 c2`, `01 c2`) continue so the radar's state keeps arriving. No standby
-  command is sent — the ping is a per-client watchdog, so an MFD that is also using the
-  radar keeps it up with its own, and mayara needs no "am I the only controller" check.
+- **Navico**: the radar is held up by the stay-alive ping mayara sends with its periodic
+  state queries. While standing down the ping is left out; the queries continue so the
+  radar's state keeps arriving. No standby command is sent — the ping is a per-client
+  watchdog, so an MFD that is also using the radar keeps it up with its own, and mayara
+  needs no "am I the only controller" check.
   Once a client reconnects the ping resumes, but the radar stays in Standby until that
   client asks for Transmit. Measured on a HALO24: the radar leaves Transmit about 25 s
   after the last ping, so with the 1 min default the antenna goes quiet roughly 85 s after

--- a/src/bin/mayara-server/web/signalk/v2.rs
+++ b/src/bin/mayara-server/web/signalk/v2.rs
@@ -1442,6 +1442,7 @@ fn control_needs_persistence(id: ControlId) -> bool {
             | ControlId::ExclusionRect3
             | ControlId::ExclusionRect4
             | ControlId::UserName
+            | ControlId::AutoStandby
     )
 }
 
@@ -2080,7 +2081,10 @@ async fn handle_control_request(
             if result.is_ok()
                 && matches!(
                     control_value.id,
-                    ControlId::GuardZone1 | ControlId::GuardZone2 | ControlId::UserName
+                    ControlId::GuardZone1
+                        | ControlId::GuardZone2
+                        | ControlId::UserName
+                        | ControlId::AutoStandby
                 )
             {
                 radars.save_persistence(&radar.key());

--- a/src/lib/brand/navico/command.rs
+++ b/src/lib/brand/navico/command.rs
@@ -199,10 +199,24 @@ impl Command {
         Ok(cmd)
     }
 
-    pub(super) async fn send_report_requests(&mut self) -> Result<(), RadarError> {
-        self.send(&REQUEST_STATE_PROPERTIES).await?;
-        self.send(&REQUEST_STATE_BATCH).await?;
-        self.send(&COMMAND_STAY_ON_A).await?;
+    /// The datagrams of one report-request tick. The stay-alive is what holds
+    /// the radar up for us, so it is left out while the radar should stand
+    /// down; the two queries stay so the radar's state keeps arriving.
+    fn report_request_frames(stay_alive: bool) -> Vec<&'static [u8]> {
+        let mut frames: Vec<&'static [u8]> = vec![&REQUEST_STATE_PROPERTIES, &REQUEST_STATE_BATCH];
+        if stay_alive {
+            frames.push(&COMMAND_STAY_ON_A);
+        }
+        frames
+    }
+
+    pub(super) async fn send_report_requests(
+        &mut self,
+        stay_alive: bool,
+    ) -> Result<(), RadarError> {
+        for frame in Self::report_request_frames(stay_alive) {
+            self.send(frame).await?;
+        }
         Ok(())
     }
 }
@@ -593,5 +607,23 @@ mod tests {
             manual_level_is_irrelevant,
             [0x11, 0xc1, 0x01, 0x00, 0xce, 0x04]
         );
+    }
+
+    /// The stay-alive is what holds the radar up, so it rides along with the
+    /// state queries while somebody is watching ...
+    #[test]
+    fn report_requests_include_the_stay_alive_while_watched() {
+        let frames = Command::report_request_frames(true);
+
+        assert_eq!(frames, vec![&[0x04, 0xc2], &[0x01, 0xc2], &[0xa0, 0xc1]]);
+    }
+
+    /// ... and only the stay-alive is left out when the radar should stand
+    /// down: the queries keep the radar's state arriving.
+    #[test]
+    fn report_requests_drop_only_the_stay_alive_when_standing_down() {
+        let frames = Command::report_request_frames(false);
+
+        assert_eq!(frames, vec![&[0x04, 0xc2], &[0x01, 0xc2]]);
     }
 }

--- a/src/lib/brand/navico/report.rs
+++ b/src/lib/brand/navico/report.rs
@@ -211,6 +211,9 @@ pub(crate) struct NavicoReportReceiver {
     /// fault override (active errors -> [`Power::Fault`]) can be lifted once the
     /// errors clear without waiting for the next state-mode report.
     reported_power: Power,
+    /// Whether the last report-request tick left out the stay-alive, so the
+    /// transition is logged once rather than every 5 s.
+    stood_down: bool,
 
     // For data (spokes)
     data_buf: Vec<u8>,
@@ -444,6 +447,7 @@ impl NavicoReportReceiver {
             has_use_mode_from_ext: false,
             active_errors: BTreeSet::new(),
             reported_power: Power::Standby,
+            stood_down: false,
             data_buf: Vec::with_capacity(size_of::<RadarFramePkt>()),
             data_socket: None,
             doppler: DopplerMode::None,
@@ -741,7 +745,19 @@ impl NavicoReportReceiver {
 
     async fn send_report_requests(&mut self) -> Result<(), RadarError> {
         if let Some(command_sender) = &mut self.command_sender {
-            command_sender.send_report_requests().await?;
+            let stand_down = self.common.info.stand_down();
+            if stand_down != self.stood_down {
+                self.stood_down = stand_down;
+                if stand_down {
+                    log::info!(
+                        "{}: nobody watching, dropping stay-alive so the radar can stand down",
+                        self.common.key
+                    );
+                } else {
+                    log::info!("{}: client connected, resuming stay-alive", self.common.key);
+                }
+            }
+            command_sender.send_report_requests(!stand_down).await?;
         }
         self.report_request_timeout += REPORT_REQUEST_INTERVAL;
         Ok(())

--- a/src/lib/brand/navico/settings.rs
+++ b/src/lib/brand/navico/settings.rs
@@ -242,3 +242,20 @@ pub(crate) fn update_from_capabilities(
 
     log::debug!("update_from_capabilities: refined controls from TLV");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::time::Duration;
+
+    /// Navico is a brand whose receiver honours stand-down, so it must offer
+    /// the control, enabled at its default.
+    #[test]
+    fn navico_offers_auto_standby_at_one_minute() {
+        let args = Cli::parse_from(["mayara-server"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let controls = new("nav1234".to_string(), tx, &args, None);
+        assert_eq!(controls.auto_standby(), Some(Duration::from_secs(60)));
+    }
+}

--- a/src/lib/brand/navico/settings.rs
+++ b/src/lib/brand/navico/settings.rs
@@ -7,8 +7,8 @@ use crate::{
     Cli,
     radar::RadarInfo,
     radar::settings::{
-        AutomaticValue, ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list,
-        new_numeric, new_sector, new_string,
+        AutomaticValue, ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto,
+        new_auto_standby, new_list, new_numeric, new_sector, new_string,
     },
     radar::units::Units,
     stream::SignalKDelta,
@@ -83,6 +83,9 @@ pub(crate) fn new(
     // Navico supports all three range unit modes
     // 0 = Nautical (default), 1 = Metric, 2 = Mixed
     new_list(ControlId::RangeUnits, &["Nautical", "Metric", "Mixed"]).build(&mut controls);
+
+    // The report receiver drops the stay-alive while the radar should stand down
+    new_auto_standby().build(&mut controls);
 
     SharedControls::new(radar_id, sk_client_tx, args, controls)
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -12,7 +12,7 @@ use std::time::SystemTime;
 use crate::Brand;
 use crate::radar::RadarInfo;
 use crate::radar::range::Ranges;
-use crate::radar::settings::ControlId;
+use crate::radar::settings::{ControlId, DEFAULT_AUTO_STANDBY};
 
 pub(crate) fn get_project_dirs() -> ProjectDirs {
     directories::ProjectDirs::from("net", "verruijt", "mayara")
@@ -21,6 +21,10 @@ pub(crate) fn get_project_dirs() -> ProjectDirs {
 
 pub(crate) fn default_range_units() -> i32 {
     0 // Nautical (default)
+}
+
+fn default_auto_standby() -> i32 {
+    DEFAULT_AUTO_STANDBY as i32
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
@@ -57,6 +61,8 @@ pub(crate) struct Radar {
     pub spoke_processing: i32, // 0 = Clean, 1 = Fill, 2 = Reduce, 3 = Smooth
     #[serde(default = "default_range_units")]
     pub range_units: i32, // 0 = Nautical, 1 = Metric, 2 = Mixed
+    #[serde(default = "default_auto_standby")]
+    pub auto_standby: i32, // Index into the AutoStandby control's choices
 
     // Data that is computed and not immediately known when starting
     pub model_name: Option<String>, // Descriptive model name (4G, HALO)
@@ -493,6 +499,12 @@ impl Persistence {
             radar.range_units = range_units;
             modified = true;
         }
+        if let Some(auto_standby) = radar_info.controls.auto_standby_index()
+            && radar.auto_standby != auto_standby
+        {
+            radar.auto_standby = auto_standby;
+            modified = true;
+        }
         let ranges = Some(radar_info.ranges.all.iter().map(|r| r.distance()).collect());
         if radar.ranges != ranges {
             radar.ranges = ranges;
@@ -644,6 +656,7 @@ impl Persistence {
             info.controls.set_user_name(p.user_name.clone());
             info.controls.set_spoke_processing(p.spoke_processing);
             info.controls.set_range_units(p.range_units);
+            info.controls.set_auto_standby(p.auto_standby);
             if let Some(ranges) = &p.ranges
                 && !ranges.is_empty()
             {
@@ -994,5 +1007,25 @@ mod tests {
             persistence_at(blocker.join(SETTINGS_FILE)).load(),
             Loaded::Unusable
         ));
+    }
+
+    /// A settings file written before auto standby existed enables it at its
+    /// default, so an upgrade stands an unwatched radar down like a fresh
+    /// install does.
+    #[test]
+    fn auto_standby_defaults_to_one_minute_for_old_settings() {
+        let radar: Radar = serde_json::from_str(r#"{"id": 1, "user_name": "Bow"}"#).unwrap();
+        assert_eq!(radar.auto_standby, DEFAULT_AUTO_STANDBY as i32);
+    }
+
+    #[test]
+    fn auto_standby_round_trips() {
+        let radar = Radar {
+            auto_standby: 3,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&radar).unwrap();
+        let back: Radar = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.auto_standby, 3);
     }
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -988,6 +988,9 @@ pub async fn start_session(
     // depends on this host's addressing, so it is driven by address changes as
     // well as by the tick — the tick alone would still catch it, but only after
     // a delay, and a radar discovered between ticks needs evaluating too.
+    //
+    // The tick also decides, per antenna, whether nobody has watched the radar
+    // long enough for its brand receiver to let it stand down (issue #633).
     let watchdog_radars = radars.clone();
     let mut watchdog_rx_ip_change = tx_ip_change.subscribe();
     subsystem.start(SubsystemBuilder::new(
@@ -1006,6 +1009,7 @@ pub async fn start_session(
                     },
                     _ = interval.tick() => {
                         watchdog_radars.mark_silent_radars_off();
+                        watchdog_radars.refresh_stand_down();
                         watchdog_radars.refresh_command_reachability();
                     }
                 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -397,6 +397,18 @@ pub struct RadarInfo {
     /// brand receivers (which hold a clone) and the watchdog (reading the map)
     /// observe the same value. Updated via `mark_input`, read via `input_silence`.
     last_input: Arc<AtomicU64>,
+
+    /// Milliseconds since [`RADAR_EPOCH`] the watchdog last saw a spoke
+    /// subscriber on this radar's antenna (issue #633). A dual-range pair
+    /// shares one antenna, so the stamp is refreshed on every range while any
+    /// of them is watched. Shared via `Arc` like `last_input`.
+    last_watched: Arc<AtomicU64>,
+
+    /// Whether the brand receiver should stop holding the radar up so it can
+    /// stand down: nobody has watched the antenna for the `AutoStandby` period
+    /// of every range. Decided per antenna by the watchdog
+    /// (`SharedRadars::refresh_stand_down`), read via `stand_down()`.
+    stand_down: Arc<AtomicBool>,
 }
 
 /// Number of trailing characters of an identity that make a radar
@@ -566,6 +578,10 @@ impl RadarInfo {
             // Seed with "now" so a freshly discovered radar isn't immediately
             // considered silent before its first report arrives.
             last_input: Arc::new(AtomicU64::new(now_millis())),
+            // Seed with "now" so a radar nobody ever watches stands down one
+            // auto-standby period after discovery, not at once.
+            last_watched: Arc::new(AtomicU64::new(now_millis())),
+            stand_down: Arc::new(AtomicBool::new(false)),
         };
 
         log::trace!("Created RadarInfo {:?}", info);
@@ -620,6 +636,34 @@ impl RadarInfo {
     /// How long it has been since the last packet was received from this radar.
     pub(crate) fn input_silence(&self) -> Duration {
         Duration::from_millis(now_millis().saturating_sub(self.last_input.load(Ordering::Relaxed)))
+    }
+
+    fn mark_watched_at(&self, now: u64) {
+        self.last_watched.store(now, Ordering::Relaxed);
+    }
+
+    fn unwatched_for_at(&self, now: u64) -> Duration {
+        Duration::from_millis(now.saturating_sub(self.last_watched.load(Ordering::Relaxed)))
+    }
+
+    /// Whether the brand receiver should stop holding this radar up so it can
+    /// stand down. See the `stand_down` field.
+    pub(crate) fn stand_down(&self) -> bool {
+        self.stand_down.load(Ordering::Relaxed)
+    }
+
+    fn set_stand_down(&self, stand_down: bool) {
+        self.stand_down.store(stand_down, Ordering::Relaxed);
+    }
+
+    /// The key shared by every range of one antenna: a dual-range radar's
+    /// ranges differ only in their trailing "A"/"B", a single-range radar is
+    /// its own antenna.
+    pub(crate) fn antenna_key(&self) -> &str {
+        self.dual
+            .as_deref()
+            .and_then(|dual| self.key.strip_suffix(dual))
+            .unwrap_or(&self.key)
     }
 
     /// Recompute the idle flag from this radar's live power state and spoke
@@ -1086,6 +1130,33 @@ impl SharedRadars {
         }
     }
 
+    /// Decide for every antenna whether its ranges should let the radar stand
+    /// down, and write the verdict to each of them. Called on a fixed cadence
+    /// by the radar watchdog. Any range with a spoke subscriber keeps the whole
+    /// antenna watched; see [`antenna_should_stand_down`] for the verdict.
+    pub(crate) fn refresh_stand_down(&self) {
+        self.refresh_stand_down_at(now_millis());
+    }
+
+    fn refresh_stand_down_at(&self, now: u64) {
+        let radars = self.radars.read().unwrap();
+        let mut antennas: HashMap<&str, Vec<&RadarInfo>> = HashMap::new();
+        for info in radars.info.values() {
+            antennas.entry(info.antenna_key()).or_default().push(info);
+        }
+        for ranges in antennas.values() {
+            if ranges.iter().any(|r| r.message_tx.receiver_count() > 0) {
+                ranges.iter().for_each(|r| r.mark_watched_at(now));
+            }
+            let periods: Vec<(Option<Duration>, Duration)> = ranges
+                .iter()
+                .map(|r| (r.controls.auto_standby(), r.unwatched_for_at(now)))
+                .collect();
+            let stand_down = antenna_should_stand_down(&periods);
+            ranges.iter().for_each(|r| r.set_stand_down(stand_down));
+        }
+    }
+
     ///
     /// Return every radar that has been discovered, including those that have
     /// not yet reported their ranges. Use this where a radar should surface as
@@ -1380,6 +1451,23 @@ pub(crate) fn should_idle(power: Option<i32>, spoke_receiver_count: usize) -> bo
 /// is powered off from the operator's point of view.
 fn should_power_off(silence: Duration, current_power: Option<i32>) -> bool {
     silence >= SharedRadars::RADAR_SILENCE_TIMEOUT && current_power != Some(Power::Off as i32)
+}
+
+/// Decide whether one antenna should be let go so it can stand down. Each
+/// entry is one range: its `AutoStandby` period (`None` = off) and how long
+/// nobody has watched it. The ranges of a dual-range radar share the antenna,
+/// so every one of them must agree: a range set to Off, or watched more
+/// recently than its period, holds the whole antenna up.
+///
+/// "Watched" is the spoke-broadcast subscriber count only, by design: control
+/// PUTs and REST reads do not keep a radar transmitting, and neither does ARPA
+/// tracking or an armed guard zone — a radar nobody is looking at stands down
+/// even while it is tracking. See docs/internals/radar-status.md.
+fn antenna_should_stand_down(ranges: &[(Option<Duration>, Duration)]) -> bool {
+    !ranges.is_empty()
+        && ranges
+            .iter()
+            .all(|(period, unwatched)| period.is_some_and(|period| *unwatched >= period))
 }
 
 // The actual values are not arbitrary: these are the exact values as reported
@@ -2716,13 +2804,161 @@ mod tests {
         assert!(should_power_off(SharedRadars::RADAR_SILENCE_TIMEOUT, None));
     }
 
+    // ----- stand-down (issue #633) -----
+
+    const PERIOD: Duration = Duration::from_secs(60);
+
+    #[test]
+    fn antenna_should_stand_down_single_range() {
+        assert!(!antenna_should_stand_down(&[]));
+        assert!(!antenna_should_stand_down(&[(None, PERIOD * 10)]));
+        assert!(!antenna_should_stand_down(&[(
+            Some(PERIOD),
+            PERIOD - Duration::from_secs(1)
+        )]));
+        assert!(antenna_should_stand_down(&[(Some(PERIOD), PERIOD)]));
+        assert!(antenna_should_stand_down(&[(Some(PERIOD), PERIOD * 10)]));
+    }
+
+    #[test]
+    fn antenna_should_stand_down_only_when_every_range_agrees() {
+        // A range set to Off holds the antenna up.
+        assert!(!antenna_should_stand_down(&[
+            (Some(PERIOD), PERIOD * 10),
+            (None, PERIOD * 10)
+        ]));
+        // So does a range that has not yet reached its own period.
+        assert!(!antenna_should_stand_down(&[
+            (Some(PERIOD), PERIOD * 10),
+            (Some(PERIOD * 5), PERIOD * 2)
+        ]));
+        assert!(antenna_should_stand_down(&[
+            (Some(PERIOD), PERIOD * 10),
+            (Some(PERIOD * 5), PERIOD * 5)
+        ]));
+    }
+
+    #[test]
+    fn antenna_key_strips_dual_suffix() {
+        let radars = SharedRadars::new();
+        let a = test_helpers::radar_info(&radars, "633A", Some("A"));
+        let b = test_helpers::radar_info(&radars, "633A", Some("B"));
+        let single = test_helpers::radar_info(&radars, "633S", None);
+        assert_eq!(a.antenna_key(), b.antenna_key());
+        assert_ne!(a.key(), b.key());
+        assert_eq!(single.antenna_key(), single.key());
+    }
+
+    #[test]
+    fn refresh_stand_down_keeps_a_watched_antenna_up_on_every_range() {
+        let radars = SharedRadars::new();
+        let a = radars
+            .add(test_helpers::radar_info(&radars, "633B", Some("A")))
+            .unwrap();
+        let b = radars
+            .add(test_helpers::radar_info(&radars, "633B", Some("B")))
+            .unwrap();
+        let _watching_a = a.message_tx.subscribe();
+        a.mark_watched_at(0);
+        b.mark_watched_at(0);
+
+        radars.refresh_stand_down_at(PERIOD.as_millis() as u64 + 1000);
+
+        assert_eq!(
+            b.unwatched_for_at(PERIOD.as_millis() as u64 + 1000),
+            Duration::ZERO
+        );
+        assert!(!a.stand_down());
+        assert!(!b.stand_down());
+    }
+
+    #[test]
+    fn refresh_stand_down_stands_both_ranges_down_together() {
+        let radars = SharedRadars::new();
+        let a = radars
+            .add(test_helpers::radar_info(&radars, "633C", Some("A")))
+            .unwrap();
+        let b = radars
+            .add(test_helpers::radar_info(&radars, "633C", Some("B")))
+            .unwrap();
+        a.mark_watched_at(0);
+        b.mark_watched_at(0);
+        let later = PERIOD.as_millis() as u64 + 1000;
+
+        radars.refresh_stand_down_at(later);
+        assert!(a.stand_down());
+        assert!(b.stand_down());
+
+        // Switching one range off brings the whole antenna back up.
+        b.controls.set_auto_standby(0);
+        radars.refresh_stand_down_at(later);
+        assert!(!a.stand_down());
+        assert!(!b.stand_down());
+    }
+
+    #[test]
+    fn refresh_stand_down_leaves_an_unrelated_radar_alone() {
+        let radars = SharedRadars::new();
+        let pair = radars
+            .add(test_helpers::radar_info(&radars, "633D", Some("A")))
+            .unwrap();
+        let other = radars
+            .add(test_helpers::radar_info(&radars, "633E", None))
+            .unwrap();
+        let _watching_other = other.message_tx.subscribe();
+        pair.mark_watched_at(0);
+        other.mark_watched_at(0);
+
+        radars.refresh_stand_down_at(PERIOD.as_millis() as u64 + 1000);
+
+        assert!(pair.stand_down());
+        assert!(!other.stand_down());
+    }
+
     mod test_helpers {
         use super::*;
+        use crate::radar::settings::new_auto_standby;
+        use clap::Parser;
+
         /// Mint a stand-in for `RadarInfo.is_idle` so the test above
         /// doesn't have to construct a full `RadarInfo`. If the field
         /// type changes, the caller fails to compile.
         pub(super) fn dummy_is_idle_field() -> Arc<AtomicBool> {
             Arc::new(AtomicBool::new(false))
+        }
+
+        /// A radar with the `AutoStandby` control at its default, keyed on
+        /// `serial` plus the optional dual-range suffix.
+        pub(super) fn radar_info(
+            radars: &SharedRadars,
+            serial: &str,
+            dual: Option<&str>,
+        ) -> RadarInfo {
+            let args = Cli::parse_from(["mayara-server"]);
+            let addr = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 6878);
+            RadarInfo::new(
+                radars,
+                &args,
+                Brand::Emulator,
+                Some(serial),
+                None,
+                dual,
+                16,
+                2048,
+                512,
+                addr,
+                Ipv4Addr::new(10, 0, 0, 1),
+                addr,
+                addr,
+                addr,
+                |id, tx| {
+                    let mut controls = HashMap::new();
+                    new_auto_standby().build(&mut controls);
+                    SharedControls::new(id, tx, &args, controls)
+                },
+                false,
+                false,
+            )
         }
     }
 

--- a/src/lib/radar/settings.rs
+++ b/src/lib/radar/settings.rs
@@ -11,6 +11,7 @@ use std::{
     fmt::{self, Display},
     str::FromStr,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 use strum::{EnumCount, EnumIter, EnumString, IntoStaticStr};
 use thiserror::Error;
@@ -172,6 +173,7 @@ pub enum ControlId {
     StcRange,
     AntiJamming,
     EchoFormat,
+    AutoStandby,
 }
 
 impl Display for ControlId {
@@ -258,7 +260,7 @@ impl ControlId {
             | ControlId::PulseWidth => Category::Info,
             ControlId::SupplyVoltage | ControlId::DeviceTemperature => Category::Info,
             ControlId::ScanAverageMode | ControlId::ScanAverageSensitivity => Category::Advanced,
-            ControlId::ParkPosition => Category::Installation,
+            ControlId::ParkPosition | ControlId::AutoStandby => Category::Installation,
             ControlId::TransmitChannel => Category::Advanced,
             ControlId::NoiseRejection
             | ControlId::TargetBoost
@@ -386,6 +388,9 @@ impl ControlId {
                 "Anti-jamming filter reduces interference from other radars on the same frequency"
             }
             ControlId::EchoFormat => "Experimental echo format request (NXT only: IMO or Tile)",
+            ControlId::AutoStandby => {
+                "Let the radar stand down when nobody has watched it for this long"
+            }
         }
     }
 
@@ -479,6 +484,7 @@ impl ControlId {
             ControlId::StcRange => "STC range",
             ControlId::AntiJamming => "Anti-jamming",
             ControlId::EchoFormat => "Echo format",
+            ControlId::AutoStandby => "Auto standby",
         }
     }
 
@@ -565,6 +571,7 @@ impl ControlId {
             ControlId::StcRange => ControlDestination::Command,
             ControlId::AntiJamming => ControlDestination::Command,
             ControlId::EchoFormat => ControlDestination::Command,
+            ControlId::AutoStandby => ControlDestination::Internal,
         }
     }
 }
@@ -1811,6 +1818,30 @@ impl SharedControls {
             .unwrap_or(0)
     }
 
+    /// No-op on a brand that does not offer the control.
+    pub(crate) fn set_auto_standby(&self, value: i32) {
+        let mut locked = self.controls.write().unwrap();
+        if let Some(control) = locked.controls.get_mut(&ControlId::AutoStandby) {
+            let _ = control.set(value as f64, None, None, None);
+        }
+    }
+
+    /// The wire value of the `AutoStandby` control, for persistence; `None`
+    /// on a brand that does not offer the control.
+    pub(crate) fn auto_standby_index(&self) -> Option<i32> {
+        self.get(&ControlId::AutoStandby)
+            .and_then(|c| c.value)
+            .map(|v| v as i32)
+    }
+
+    /// How long nobody may watch this radar before it is let go to stand
+    /// down; `None` when auto standby is off or not offered.
+    pub(crate) fn auto_standby(&self) -> Option<Duration> {
+        AUTO_STANDBY_CHOICES
+            .get(usize::try_from(self.auto_standby_index()?).ok()?)
+            .and_then(|(_, period)| *period)
+    }
+
     /// Returns the current ARPA max speed setting: 0 = Normal (25kn), 1 = Medium (40kn), 2 = Fast (50kn)
     pub fn doppler_auto_track(&self) -> bool {
         self.get(&ControlId::DopplerAutoTrack)
@@ -2592,6 +2623,15 @@ impl ControlBuilder {
         self
     }
 
+    pub(crate) fn default_value(mut self, value: f64) -> Self {
+        if self.frozen {
+            panic!("{} already frozen", self.control.item.control_id);
+        }
+        self.control.item.default_value = Some(value);
+        self.control.value = Some(value);
+        self
+    }
+
     pub(crate) fn wire_scale_step(mut self, step: f64) -> Self {
         if self.frozen {
             panic!("{} already frozen", self.control.item.control_id);
@@ -2677,6 +2717,25 @@ impl ControlBuilder {
     pub(crate) fn take(self) -> (ControlId, Control) {
         (self.control.item.control_id, self.control)
     }
+}
+
+/// The `AutoStandby` list control: index is the wire value, the period is how
+/// long nobody may watch the radar before it is let go; `None` is Off.
+const AUTO_STANDBY_CHOICES: [(&str, Option<Duration>); 5] = [
+    ("Off", None),
+    ("1 min", Some(Duration::from_secs(60))),
+    ("5 min", Some(Duration::from_secs(5 * 60))),
+    ("15 min", Some(Duration::from_secs(15 * 60))),
+    ("30 min", Some(Duration::from_secs(30 * 60))),
+];
+pub(crate) const DEFAULT_AUTO_STANDBY: usize = 1;
+
+/// The `AutoStandby` control, for brands whose receiver honours
+/// [`RadarInfo::stand_down`](crate::radar::RadarInfo::stand_down); a brand
+/// that does not must not offer the control.
+pub(crate) fn new_auto_standby() -> ControlBuilder {
+    let names: Vec<&str> = AUTO_STANDBY_CHOICES.iter().map(|(name, _)| *name).collect();
+    new_list(ControlId::AutoStandby, &names).default_value(DEFAULT_AUTO_STANDBY as f64)
 }
 
 pub(crate) fn new_numeric(control_id: ControlId, min_value: f64, max_value: f64) -> ControlBuilder {
@@ -4800,5 +4859,42 @@ mod test {
         // `value` takes any JSON and is converted where it is read, so it is
         // left exactly as sent.
         assert_eq!(zone.value, Some(serde_json::json!("0.5")));
+    }
+
+    // ----- AutoStandby (issue #633) -----
+
+    fn controls_with_auto_standby() -> SharedControls {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let mut controls = HashMap::new();
+        new_auto_standby().build(&mut controls);
+        SharedControls::new("nav1234".to_string(), tx, &args, controls)
+    }
+
+    #[test]
+    fn auto_standby_defaults_to_one_minute() {
+        let controls = controls_with_auto_standby();
+        assert_eq!(controls.auto_standby_index(), Some(1));
+        assert_eq!(controls.auto_standby(), Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn auto_standby_maps_index_to_period() {
+        let controls = controls_with_auto_standby();
+        controls.set_auto_standby(0);
+        assert_eq!(controls.auto_standby(), None, "index 0 is Off");
+        controls.set_auto_standby(4);
+        assert_eq!(controls.auto_standby(), Some(Duration::from_secs(30 * 60)));
+        assert!(controls.set(&ControlId::AutoStandby, 5., None).is_err());
+    }
+
+    #[test]
+    fn auto_standby_is_absent_on_a_brand_that_does_not_offer_it() {
+        let args = Cli::parse_from(["my_program"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let controls = SharedControls::new("kod1234".to_string(), tx, &args, HashMap::new());
+        controls.set_auto_standby(0);
+        assert_eq!(controls.auto_standby_index(), None);
+        assert_eq!(controls.auto_standby(), None);
     }
 }


### PR DESCRIPTION
Leave mayara running with nobody looking at the radar — no GUI, no chartplotter app — and a Navico radar kept turning and transmitting indefinitely, ageing the magnetron and drawing power for an audience of nobody. Now every radar gets an **Auto standby** setting (Off / 1 / 5 / 15 / 30 min, default 1 min, under Installation): once nobody has watched the radar for that long, mayara lets it stand down. The moment a viewer comes back the radar is available again; it stays in standby until that viewer asks for transmit.

"Watching" means a live spoke stream — a GUI, mayara_pi, `--output`, or a running recording. Control changes and REST reads do not keep a radar transmitting, and neither does ARPA tracking or an armed guard zone. The two ranges of a dual-range radar are one antenna and stand down together, only when both agree; a range set to Off holds the whole radar up.

Verified on a HALO24 (`nav1034A`/`B`): 60 s after the last viewer disconnected both ranges dropped the stay-alive, and the radar left Transmit by itself about 25 s later. Reconnecting the GUI resumed the stay-alive on both ranges within a tick.

## Implementation

- `AutoStandby` is a mayara-side (`Internal`) list control, offered only by brands whose receiver honours it (`new_auto_standby()` in `navico/settings.rs`), persisted per radar like `SpokeProcessing`.
- The 5 s radar watchdog decides per antenna (`SharedRadars::refresh_stand_down`, pure `antenna_should_stand_down`): any range with a spoke subscriber keeps the antenna watched; the verdict is written to every range's `RadarInfo::stand_down` flag.
- Navico reads the flag on its existing report-request tick and leaves out `COMMAND_STAY_ON_A` (`a0 c1`) while standing down; the `04 c2` / `01 c2` state queries continue so the radar's state keeps arriving. No standby command is sent — the ping is a per-client watchdog, so an MFD also using the radar keeps it up with its own and no "sole controller" detection is needed.
- Raymarine, Koden and Furuno follow as separate PRs (each a one-line read of the flag on their tick); Garmin is deferred.

Part of #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds per-radar Auto standby with Off, 1, 5, 15, and 30 minute options. The default is 1 minute.
- Persists the setting and exposes it through REST and WebSocket control updates.
- Uses a watchdog to evaluate spoke subscribers per antenna and coordinate dual-range radars.
- Prevents stand-down when any range is watched or when Auto standby is disabled.
- Updates Navico receivers to omit stay-alive requests while standing down.
- Documents subscriber behavior and brand support. Navico is supported; other brands remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->