### PR TITLE
feat(raymarine): let an unwatched radar stand down after a set time

### DIFF
--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -107,7 +107,11 @@ the radar never stands down. Per brand:
   client asks for Transmit. Measured on a HALO24: the radar leaves Transmit about 25 s
   after the last ping, so with the 1 min default the antenna goes quiet roughly 85 s after
   the last viewer disconnects.
-- **Raymarine, Koden, Furuno, Garmin**: not yet; see the issue for the per-brand notes.
+- **Raymarine**: the radar drops a controller it has not heard from for about a minute, so
+  the 1 s heartbeat (and the 5 s extended one) is left out while standing down. An MFD using
+  the radar sends its own heartbeat and keeps it up. Whether every model then leaves
+  Transmit by itself is still to be confirmed on hardware (#664).
+- **Koden, Furuno, Garmin**: not yet; see #665, #666, #667.
 
 ## ARPA counts as a subscriber — for idle
 

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -184,6 +184,9 @@ pub(crate) struct RaymarineReportReceiver {
     command_sender: Option<Command>,
     heartbeat_deadline: Instant,
     heartbeat_counter: u32,
+    /// Whether the last heartbeat tick left the keep-alives out, so the
+    /// transition is logged once rather than every second.
+    stood_down: bool,
     wake_deadline: Instant,
     external_seen: Arc<ExternalControllerWitness>,
     reported_unknown: HashMap<u32, bool>,
@@ -291,6 +294,7 @@ impl RaymarineReportReceiver {
             command_sender,
             heartbeat_deadline: now + HEARTBEAT_INTERVAL,
             heartbeat_counter: 0,
+            stood_down: false,
             wake_deadline: now + OBSERVATION_WINDOW,
             external_seen,
             reported_unknown: HashMap::new(),
@@ -522,6 +526,25 @@ impl RaymarineReportReceiver {
         // busy-loops. The next tick retries the heartbeat a second later.
         self.heartbeat_deadline += HEARTBEAT_INTERVAL;
         if let Some(ref mut cs) = self.command_sender {
+            // The heartbeat is what holds the radar up for us: the radar drops
+            // a controller it has not heard from for ~60 s, so leaving it out
+            // lets an unwatched radar stand down. An MFD using the radar keeps
+            // it up with its own.
+            let stand_down = self.common.info.stand_down();
+            if stand_down != self.stood_down {
+                self.stood_down = stand_down;
+                if stand_down {
+                    log::info!(
+                        "{}: nobody watching, dropping heartbeat so the radar can stand down",
+                        self.common.key
+                    );
+                } else {
+                    log::info!("{}: client connected, resuming heartbeat", self.common.key);
+                }
+            }
+            if stand_down {
+                return Ok(());
+            }
             cs.send_heartbeat().await?;
 
             // Every 5th heartbeat (every 5 seconds), also send the

--- a/src/lib/brand/raymarine/report.rs
+++ b/src/lib/brand/raymarine/report.rs
@@ -43,6 +43,18 @@ const WAKE_INTERVAL: Duration = Duration::from_secs(3);
 const OBSERVATION_WINDOW: Duration = Duration::from_secs(5);
 const EXTERNAL_QUIET_WINDOW: Duration = Duration::from_secs(60);
 
+/// The keep-alives one heartbeat tick sends: the 1 s heartbeat, and every
+/// fifth tick the extended 5 s one. Nothing while the radar should stand
+/// down: the heartbeat is what holds the radar up for us, and the radar
+/// drops a controller it has not heard from for ~60 s. `counter` is the
+/// number of heartbeats sent so far.
+fn heartbeats_for_tick(stand_down: bool, counter: u32) -> (bool, bool) {
+    if stand_down {
+        return (false, false);
+    }
+    (true, (counter + 1).is_multiple_of(5))
+}
+
 /// Decide how a Power request affects the "re-apply transmit once the radar
 /// reaches standby" flag, given the radar's last reported power state.
 /// Returns `Some(new_flag)` when the request changes it, `None` to leave it.
@@ -526,10 +538,8 @@ impl RaymarineReportReceiver {
         // busy-loops. The next tick retries the heartbeat a second later.
         self.heartbeat_deadline += HEARTBEAT_INTERVAL;
         if let Some(ref mut cs) = self.command_sender {
-            // The heartbeat is what holds the radar up for us: the radar drops
-            // a controller it has not heard from for ~60 s, so leaving it out
-            // lets an unwatched radar stand down. An MFD using the radar keeps
-            // it up with its own.
+            // An MFD using the radar keeps it up with its own heartbeat, so
+            // standing down needs no "am I the only controller" check.
             let stand_down = self.common.info.stand_down();
             if stand_down != self.stood_down {
                 self.stood_down = stand_down;
@@ -542,15 +552,12 @@ impl RaymarineReportReceiver {
                     log::info!("{}: client connected, resuming heartbeat", self.common.key);
                 }
             }
-            if stand_down {
-                return Ok(());
+            let (heartbeat, extended) = heartbeats_for_tick(stand_down, self.heartbeat_counter);
+            if heartbeat {
+                cs.send_heartbeat().await?;
+                self.heartbeat_counter += 1;
             }
-            cs.send_heartbeat().await?;
-
-            // Every 5th heartbeat (every 5 seconds), also send the
-            // extended keep-alive with MARPA/AIS option data.
-            self.heartbeat_counter += 1;
-            if self.heartbeat_counter.is_multiple_of(5) {
+            if extended {
                 cs.send_heartbeat_5s().await?;
             }
         }
@@ -714,8 +721,35 @@ impl RaymarineReportReceiver {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_reapply_transmit, transmit_should_defer};
+    use super::{heartbeats_for_tick, should_reapply_transmit, transmit_should_defer};
     use crate::radar::Power;
+
+    // ----- heartbeat ticks (stand-down, issue #664) -----
+
+    #[test]
+    fn every_fifth_heartbeat_carries_the_extended_keep_alive() {
+        let sent: Vec<(bool, bool)> = (0..10).map(|n| heartbeats_for_tick(false, n)).collect();
+        assert!(sent.iter().all(|(heartbeat, _)| *heartbeat));
+        let extended: Vec<u32> = (0..10u32)
+            .filter(|n| heartbeats_for_tick(false, *n).1)
+            .collect();
+        assert_eq!(extended, vec![4, 9]);
+    }
+
+    #[test]
+    fn standing_down_sends_no_keep_alive_at_all() {
+        for n in 0..10 {
+            assert_eq!(heartbeats_for_tick(true, n), (false, false));
+        }
+    }
+
+    #[test]
+    fn resuming_picks_the_cadence_up_where_it_left_off() {
+        // Four heartbeats sent, then a stand-down; the first tick after
+        // resuming is the fifth and carries the extended keep-alive.
+        assert_eq!(heartbeats_for_tick(true, 4), (false, false));
+        assert_eq!(heartbeats_for_tick(false, 4), (true, true));
+    }
 
     /// Drive a `pending_transmit` flag through the same two decisions the
     /// receiver applies — arm on a Power request (`note_power_request`), and

--- a/src/lib/brand/raymarine/settings.rs
+++ b/src/lib/brand/raymarine/settings.rs
@@ -6,8 +6,8 @@ use crate::{
     radar::Power,
     radar::RadarInfo,
     radar::settings::{
-        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
-        new_sector, new_string,
+        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_auto_standby, new_list,
+        new_numeric, new_sector, new_string,
     },
     radar::units::Units,
     stream::SignalKDelta,
@@ -107,6 +107,9 @@ pub(crate) fn new(
     }
     new_string(ControlId::SerialNumber).build(&mut controls);
 
+    // The report receiver drops the heartbeat while the radar should stand down
+    new_auto_standby().build(&mut controls);
+
     // Raymarine is nautical-only - no RangeUnits control, default is already 0 (Nautical)
     SharedControls::new(radar_id, sk_client_tx, args, controls)
 }
@@ -152,5 +155,24 @@ pub(crate) fn update_when_model_known(
     // the Radar API exposes and accepts Off for these radars.
     if model.model == BaseModel::Quantum {
         controls.add_valid_value(&ControlId::Power, Power::Off as i32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::time::Duration;
+
+    /// Both Raymarine families are held up by the same heartbeat, so both
+    /// offer the control, enabled at its default.
+    #[test]
+    fn raymarine_offers_auto_standby_at_one_minute() {
+        let args = Cli::parse_from(["mayara-server"]);
+        for model in [BaseModel::Quantum, BaseModel::RD] {
+            let tx = tokio::sync::broadcast::Sender::new(1);
+            let controls = new("ray1234".to_string(), tx, &args, model);
+            assert_eq!(controls.auto_standby(), Some(Duration::from_secs(60)));
+        }
     }
 }


### PR DESCRIPTION
A Raymarine radar kept transmitting for as long as mayara ran, even with nobody looking at it: mayara sent the radar its heartbeat every second regardless of whether any client was watching. The **Auto standby** setting from #663 (Off / 1 / 5 / 15 / 30 min, default 1 min) now applies to Raymarine radars too: once nobody has watched the radar for that long, mayara stops sending the heartbeat and lets the radar stand down; the moment a viewer comes back the heartbeat resumes. An MFD that is also using the radar keeps it up with its own heartbeat, so nothing changes for it.

Not yet verified on Raymarine hardware: the firmware drops a controller it has not heard from for ~60 s, but whether every model then leaves Transmit on its own still needs a live check, as does the side effect that a wired Quantum only reports once it has seen a heartbeat (#228) and may therefore show as Off in the GUI while stood down.

## Implementation

`new_auto_standby()` in `raymarine/settings.rs` (both Quantum and RD), and `send_heartbeat()` in `raymarine/report.rs` returns before the sends while `RadarInfo::stand_down()` is set, logging the transition once each way. The deadline keeps advancing so the tick cadence is unchanged, and the Quantum wake nudge is untouched (it only runs before the first status report).

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds Raymarine Auto standby support for Quantum and RD radars.
- Skips regular and extended heartbeat messages when `RadarInfo::stand_down()` is active.
- Logs stand-down state changes once and preserves MFD-controlled radar operation.
- Documents Raymarine controller timeout behavior and pending hardware verification.
- Adds coverage confirming a 60-second Auto standby setting for both radar models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->