### PR TITLE
feat(furuno): stand down a radar that transmits on mayara's behalf

### DIFF
--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -113,10 +113,11 @@ the radar never stands down. Per brand:
   Transmit by itself is still to be confirmed on hardware (#664).
 - **Furuno**: the radar is not held up by anything mayara sends: it keeps transmitting until
   some client tells it to stop, and the firmware has no notion of standing down when a
-  client goes away (see `research/furuno/drs4d-nxt-firmware.md`). So the receiver remembers,
-  per range, whether the radar is transmitting because a client asked for it through mayara,
-  and while standing down sends that range a Standby request itself. A transmit an MFD
-  started is never touched: the memory is set only by a Transmit request through mayara and
+  client goes away (see `research/furuno/drs4d-nxt-firmware.md`). So the receiver remembers
+  whether the radar is transmitting because a client asked for it through mayara (both
+  ranges share one transmitter, so this is one fact for the antenna), and while standing
+  down sends a Standby request itself. A transmit an MFD started is never touched: the
+  memory is set only by a Transmit request that reached the radar through mayara and
   cleared by a Standby request through mayara or by the radar reporting anything but
   Transmit.
 - **Koden, Garmin**: not yet; see #665, #667.

--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -111,7 +111,15 @@ the radar never stands down. Per brand:
   the 1 s heartbeat (and the 5 s extended one) is left out while standing down. An MFD using
   the radar sends its own heartbeat and keeps it up. Whether every model then leaves
   Transmit by itself is still to be confirmed on hardware (#664).
-- **Koden, Furuno, Garmin**: not yet; see #665, #666, #667.
+- **Furuno**: the radar is not held up by anything mayara sends: it keeps transmitting until
+  some client tells it to stop, and the firmware has no notion of standing down when a
+  client goes away (see `research/furuno/drs4d-nxt-firmware.md`). So the receiver remembers,
+  per range, whether the radar is transmitting because a client asked for it through mayara,
+  and while standing down sends that range a Standby request itself. A transmit an MFD
+  started is never touched: the memory is set only by a Transmit request through mayara and
+  cleared by a Standby request through mayara or by the radar reporting anything but
+  Transmit.
+- **Koden, Garmin**: not yet; see #665, #667.
 
 ## ARPA counts as a subscriber — for idle
 

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -54,13 +54,17 @@ const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// A session that survived this long counts as stable: reset the backoff.
 const RECONNECT_STABLE_AFTER: Duration = Duration::from_secs(60);
 
-/// Whether a range's transmit counts as ours after a client's Power request
-/// through mayara: a Transmit request makes it ours, any other Power request
-/// ends that, and a request we cannot read leaves it alone.
-fn transmit_is_ours_after(current: bool, request: Option<Power>) -> bool {
-    match request {
-        Some(Power::Transmit) => true,
-        Some(_) => false,
+/// Our claim on the transmitter after a client's control request for `range`
+/// goes through mayara: a Transmit request makes the transmit ours (on that
+/// range), any other Power request ends the claim, and anything else leaves
+/// it alone. Applied only once the request has reached the radar.
+fn transmit_claim_after(current: Option<i32>, range: i32, cv: &ControlValue) -> Option<i32> {
+    if cv.id != ControlId::Power {
+        return current;
+    }
+    match cv.as_value().ok().and_then(|v| Power::from_value(&v).ok()) {
+        Some(Power::Transmit) => Some(range),
+        Some(_) => None,
         None => current,
     }
 }
@@ -123,13 +127,16 @@ pub(crate) struct FurunoReportReceiver {
     stream: Option<TcpStream>,
     command_sender: Option<Command>,
     report_request_interval: Duration,
-    /// Per range: whether the radar is transmitting because a client asked
-    /// for it through mayara. A Furuno radar keeps transmitting until some
-    /// client tells it to stop, so standing down means sending that request
-    /// ourselves, and only for a transmit that was ours to begin with: an MFD's
-    /// transmit is never touched. Cleared as soon as the radar reports
-    /// anything but Transmit, or a client asks for Standby through mayara.
-    transmit_is_ours: [bool; 2],
+    /// The dual-range id a client asked to Transmit through mayara, while
+    /// that transmit is still ours to stand down. A Furuno radar keeps
+    /// transmitting until some client tells it to stop, so standing down
+    /// means sending that request ourselves, and only for a transmit that was
+    /// ours to begin with: an MFD's transmit is never touched. Both ranges
+    /// share one transmitter, so this is one fact for the antenna. Cleared as
+    /// soon as the radar reports anything but Transmit, or a client asks for
+    /// Standby through mayara; only recorded once the request reached the
+    /// radar.
+    transmit_is_ours: Option<i32>,
     model_known: bool,
     model: RadarModel,
 
@@ -217,7 +224,7 @@ impl FurunoReportReceiver {
             multicast_socket: None,
             broadcast_socket: None,
             prev_spoke: [Vec::new(), Vec::new()],
-            transmit_is_ours: [false; 2],
+            transmit_is_ours: None,
             prev_angle: [0, 0],
             guard_zone_alarm: [false, false],
             alarm_active: false,
@@ -401,8 +408,9 @@ impl FurunoReportReceiver {
                             if let Some(ref mut cs) = self.command_sender {
                                 cs.dual_range_id = 0;
                             }
-                            self.note_power_request(0, &cv.control_value);
-                            self.common.process_control_update( cv, &mut self.command_sender).await?
+                            let claim = transmit_claim_after(self.transmit_is_ours, 0, &cv.control_value);
+                            self.common.process_control_update( cv, &mut self.command_sender).await?;
+                            self.transmit_is_ours = claim;
                         },
                     }
                 },
@@ -421,11 +429,12 @@ impl FurunoReportReceiver {
                             if let Some(ref mut cs) = self.command_sender {
                                 cs.dual_range_id = 1;
                             }
-                            self.note_power_request(1, &cv.control_value);
+                            let claim = transmit_claim_after(self.transmit_is_ours, 1, &cv.control_value);
                             if let Some(ref mut cb) = self.common_b
                                 && let Err(e) = cb.process_control_update(cv, &mut self.command_sender).await {
                                     return Err(e);
                                 }
+                            self.transmit_is_ours = claim;
                         },
                     }
                 },
@@ -565,44 +574,25 @@ impl FurunoReportReceiver {
         }
     }
 
-    /// Remember whether the transmit a client is asking for through mayara is
-    /// ours to stand down later; a Standby request ends that.
-    fn note_power_request(&mut self, range: usize, cv: &ControlValue) {
-        if cv.id != ControlId::Power {
-            return;
-        }
-        let request = cv.as_value().ok().and_then(|v| Power::from_value(&v).ok());
-        self.transmit_is_ours[range] =
-            transmit_is_ours_after(self.transmit_is_ours[range], request);
-    }
-
-    /// Nobody is watching: put every range that is transmitting on our behalf
+    /// Nobody is watching: if the radar is transmitting on our behalf, put it
     /// back in Standby. The radar itself never stands down on losing a
     /// client, so this is the only way an unwatched Furuno radar stops.
     async fn stand_down_our_transmit(&mut self) -> Result<(), RadarError> {
-        for range in 0..2 {
-            if !self.transmit_is_ours[range] {
-                continue;
-            }
-            let Some(cs) = &mut self.command_sender else {
-                return Ok(());
-            };
-            let target = if range == 0 {
-                &self.common
-            } else if let Some(cb) = &self.common_b {
-                cb
-            } else {
-                continue;
-            };
-            log::info!(
-                "{}: nobody watching and the radar transmits for us, sending standby",
-                target.key
-            );
-            cs.dual_range_id = range as i32;
-            let standby = ControlValue::new(ControlId::Power, Value::from(Power::Standby as i32));
-            cs.set_control(&standby, &target.info.controls).await?;
-            self.transmit_is_ours[range] = false;
-        }
+        let (Some(range), Some(cs)) = (self.transmit_is_ours, &mut self.command_sender) else {
+            return Ok(());
+        };
+        let target = match (&self.common_b, range) {
+            (Some(cb), 1) => cb,
+            _ => &self.common,
+        };
+        log::info!(
+            "{}: nobody watching and the radar transmits for us, sending standby",
+            target.key
+        );
+        cs.dual_range_id = range;
+        let standby = ControlValue::new(ControlId::Power, Value::from(Power::Standby as i32));
+        cs.set_control(&standby, &target.info.controls).await?;
+        self.transmit_is_ours = None;
         Ok(())
     }
 
@@ -635,11 +625,6 @@ impl FurunoReportReceiver {
     /// Return a mutable reference to the CommonRadar for the given dual range ID.
     /// `drid` 0 = Range A (self.common), `drid` 1 = Range B (self.common_b).
     /// Falls back to Range A if Range B is not configured.
-    /// The `transmit_is_ours` slot for a wire dual-range id.
-    fn range_index(drid: u8) -> usize {
-        usize::from(drid == 1)
-    }
-
     fn common_for_range(&mut self, drid: u8) -> &mut CommonRadar {
         if drid == 1
             && let Some(ref mut cb) = self.common_b
@@ -793,8 +778,11 @@ impl FurunoReportReceiver {
                 let is_standby = matches!(generic_state, Power::Standby);
                 let power_value = generic_state as i32 as f64;
                 let drid = self.extract_drid(&command_id, &numbers);
+                // Both ranges share the transmitter (see the coupled-transmit
+                // propagation below), so any range leaving Transmit ends our
+                // claim on it.
                 if generic_state != Power::Transmit {
-                    self.transmit_is_ours[Self::range_index(drid)] = false;
+                    self.transmit_is_ours = None;
                 }
                 let target = self.common_for_range(drid);
                 target.set_value(&ControlId::Power, power_value);
@@ -2243,17 +2231,33 @@ mod tests {
 
     // ----- stand-down: only a transmit that was ours (issue #666) -----
 
-    #[test]
-    fn a_transmit_asked_through_mayara_is_ours_until_standby_is_asked() {
-        assert!(transmit_is_ours_after(false, Some(Power::Transmit)));
-        assert!(!transmit_is_ours_after(true, Some(Power::Standby)));
-        assert!(!transmit_is_ours_after(true, Some(Power::Off)));
+    fn power_request(power: Power) -> ControlValue {
+        ControlValue::new(ControlId::Power, Value::from(power as i32))
     }
 
     #[test]
-    fn an_unreadable_power_request_changes_nothing() {
-        assert!(transmit_is_ours_after(true, None));
-        assert!(!transmit_is_ours_after(false, None));
+    fn a_transmit_asked_through_mayara_is_ours_until_standby_is_asked() {
+        assert_eq!(
+            transmit_claim_after(None, 1, &power_request(Power::Transmit)),
+            Some(1)
+        );
+        assert_eq!(
+            transmit_claim_after(Some(1), 0, &power_request(Power::Standby)),
+            None
+        );
+        assert_eq!(
+            transmit_claim_after(Some(0), 0, &power_request(Power::Off)),
+            None
+        );
+    }
+
+    #[test]
+    fn other_controls_and_unreadable_requests_leave_the_claim_alone() {
+        let gain = ControlValue::new(ControlId::Gain, Value::from(50));
+        assert_eq!(transmit_claim_after(Some(0), 0, &gain), Some(0));
+        let junk = ControlValue::new(ControlId::Power, Value::from("nonsense"));
+        assert_eq!(transmit_claim_after(Some(1), 1, &junk), Some(1));
+        assert_eq!(transmit_claim_after(None, 0, &junk), None);
     }
 
     /// A radar that keeps dropping the control session must be backed off

--- a/src/lib/brand/furuno/report.rs
+++ b/src/lib/brand/furuno/report.rs
@@ -22,14 +22,16 @@ use super::protocol::{
 };
 use super::settings;
 use crate::Cli;
+use crate::brand::CommandSender;
 use crate::network;
 use crate::radar::CommonRadar;
 use crate::radar::SharedRadars;
 use crate::radar::SpokeBearing;
-use crate::radar::settings::ControlId;
+use crate::radar::settings::{ControlId, ControlValue};
 use crate::radar::{Power, RadarError, RadarInfo};
 use crate::replay::RadarSocket;
 use crate::util::PrintableSpoke;
+use serde_json::Value;
 
 /// TCP keepalive timing for the Furuno control socket. Tunes how quickly the
 /// kernel detects that the radar has silently dropped the connection after
@@ -51,6 +53,17 @@ const RECONNECT_BACKOFF_MIN: Duration = Duration::from_secs(1);
 const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// A session that survived this long counts as stable: reset the backoff.
 const RECONNECT_STABLE_AFTER: Duration = Duration::from_secs(60);
+
+/// Whether a range's transmit counts as ours after a client's Power request
+/// through mayara: a Transmit request makes it ours, any other Power request
+/// ends that, and a request we cannot read leaves it alone.
+fn transmit_is_ours_after(current: bool, request: Option<Power>) -> bool {
+    match request {
+        Some(Power::Transmit) => true,
+        Some(_) => false,
+        None => current,
+    }
+}
 
 /// Split out from the connection loop so the policy can be exercised without a
 /// radar: the loop supplies real elapsed times and sleeps.
@@ -110,6 +123,13 @@ pub(crate) struct FurunoReportReceiver {
     stream: Option<TcpStream>,
     command_sender: Option<Command>,
     report_request_interval: Duration,
+    /// Per range: whether the radar is transmitting because a client asked
+    /// for it through mayara. A Furuno radar keeps transmitting until some
+    /// client tells it to stop, so standing down means sending that request
+    /// ourselves, and only for a transmit that was ours to begin with: an MFD's
+    /// transmit is never touched. Cleared as soon as the radar reports
+    /// anything but Transmit, or a client asks for Standby through mayara.
+    transmit_is_ours: [bool; 2],
     model_known: bool,
     model: RadarModel,
 
@@ -197,6 +217,7 @@ impl FurunoReportReceiver {
             multicast_socket: None,
             broadcast_socket: None,
             prev_spoke: [Vec::new(), Vec::new()],
+            transmit_is_ours: [false; 2],
             prev_angle: [0, 0],
             guard_zone_alarm: [false, false],
             alarm_active: false,
@@ -308,6 +329,10 @@ impl FurunoReportReceiver {
                     }
                     deadline = Instant::now() + self.report_request_interval;
 
+                    if self.common.info.stand_down() {
+                        self.stand_down_our_transmit().await?;
+                    }
+
                     // Recompute idle: standby + zero spoke subscribers. Exit
                     // points (control PUT, power-change report, new WS
                     // subscriber) clear is_idle directly so this only needs
@@ -376,6 +401,7 @@ impl FurunoReportReceiver {
                             if let Some(ref mut cs) = self.command_sender {
                                 cs.dual_range_id = 0;
                             }
+                            self.note_power_request(0, &cv.control_value);
                             self.common.process_control_update( cv, &mut self.command_sender).await?
                         },
                     }
@@ -395,6 +421,7 @@ impl FurunoReportReceiver {
                             if let Some(ref mut cs) = self.command_sender {
                                 cs.dual_range_id = 1;
                             }
+                            self.note_power_request(1, &cv.control_value);
                             if let Some(ref mut cb) = self.common_b
                                 && let Err(e) = cb.process_control_update(cv, &mut self.command_sender).await {
                                     return Err(e);
@@ -538,6 +565,47 @@ impl FurunoReportReceiver {
         }
     }
 
+    /// Remember whether the transmit a client is asking for through mayara is
+    /// ours to stand down later; a Standby request ends that.
+    fn note_power_request(&mut self, range: usize, cv: &ControlValue) {
+        if cv.id != ControlId::Power {
+            return;
+        }
+        let request = cv.as_value().ok().and_then(|v| Power::from_value(&v).ok());
+        self.transmit_is_ours[range] =
+            transmit_is_ours_after(self.transmit_is_ours[range], request);
+    }
+
+    /// Nobody is watching: put every range that is transmitting on our behalf
+    /// back in Standby. The radar itself never stands down on losing a
+    /// client, so this is the only way an unwatched Furuno radar stops.
+    async fn stand_down_our_transmit(&mut self) -> Result<(), RadarError> {
+        for range in 0..2 {
+            if !self.transmit_is_ours[range] {
+                continue;
+            }
+            let Some(cs) = &mut self.command_sender else {
+                return Ok(());
+            };
+            let target = if range == 0 {
+                &self.common
+            } else if let Some(cb) = &self.common_b {
+                cb
+            } else {
+                continue;
+            };
+            log::info!(
+                "{}: nobody watching and the radar transmits for us, sending standby",
+                target.key
+            );
+            cs.dual_range_id = range as i32;
+            let standby = ControlValue::new(ControlId::Power, Value::from(Power::Standby as i32));
+            cs.set_control(&standby, &target.info.controls).await?;
+            self.transmit_is_ours[range] = false;
+        }
+        Ok(())
+    }
+
     fn login_to_radar(&mut self) -> Result<(), RadarError> {
         if self.command_sender.is_none() {
             return Ok(());
@@ -567,6 +635,11 @@ impl FurunoReportReceiver {
     /// Return a mutable reference to the CommonRadar for the given dual range ID.
     /// `drid` 0 = Range A (self.common), `drid` 1 = Range B (self.common_b).
     /// Falls back to Range A if Range B is not configured.
+    /// The `transmit_is_ours` slot for a wire dual-range id.
+    fn range_index(drid: u8) -> usize {
+        usize::from(drid == 1)
+    }
+
     fn common_for_range(&mut self, drid: u8) -> &mut CommonRadar {
         if drid == 1
             && let Some(ref mut cb) = self.common_b
@@ -720,6 +793,9 @@ impl FurunoReportReceiver {
                 let is_standby = matches!(generic_state, Power::Standby);
                 let power_value = generic_state as i32 as f64;
                 let drid = self.extract_drid(&command_id, &numbers);
+                if generic_state != Power::Transmit {
+                    self.transmit_is_ours[Self::range_index(drid)] = false;
+                }
                 let target = self.common_for_range(drid);
                 target.set_value(&ControlId::Power, power_value);
 
@@ -2164,6 +2240,21 @@ async fn conditional_read(
 mod tests {
     use super::*;
     use crate::radar::Legend;
+
+    // ----- stand-down: only a transmit that was ours (issue #666) -----
+
+    #[test]
+    fn a_transmit_asked_through_mayara_is_ours_until_standby_is_asked() {
+        assert!(transmit_is_ours_after(false, Some(Power::Transmit)));
+        assert!(!transmit_is_ours_after(true, Some(Power::Standby)));
+        assert!(!transmit_is_ours_after(true, Some(Power::Off)));
+    }
+
+    #[test]
+    fn an_unreadable_power_request_changes_nothing() {
+        assert!(transmit_is_ours_after(true, None));
+        assert!(!transmit_is_ours_after(false, None));
+    }
 
     /// A radar that keeps dropping the control session must be backed off
     /// exponentially: hammering relogins exhausts the firmware's session slot

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -45,7 +45,7 @@ pub(crate) fn new(
     new_string(ControlId::SerialNumber).build(&mut controls);
     new_list(ControlId::RangeUnits, &["Nautical", "Metric"]).build(&mut controls);
 
-    // The report receiver closes the control session while the radar should stand down
+    // The report receiver stands a transmit that was asked through mayara down itself
     new_auto_standby().build(&mut controls);
 
     SharedControls::new(radar_id, sk_client_tx, args, controls)
@@ -687,8 +687,8 @@ mod tests {
     use clap::Parser;
     use std::time::Duration;
 
-    /// The receiver closes the control session while standing down, so the
-    /// control is offered, enabled at its default.
+    /// The receiver sends a Standby for a transmit that was ours while
+    /// standing down, so the control is offered, enabled at its default.
     #[test]
     fn furuno_offers_auto_standby_at_one_minute() {
         let args = Cli::parse_from(["mayara-server"]);

--- a/src/lib/brand/furuno/settings.rs
+++ b/src/lib/brand/furuno/settings.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use crate::{
     Cli,
     radar::settings::{
-        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
-        new_sector, new_string,
+        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_auto_standby, new_list,
+        new_numeric, new_sector, new_string,
     },
     radar::{
         FRAC_NM_2, FRAC_NM_4, FRAC_NM_8, FRAC_NM_16, NM, RadarInfo, range::Ranges, units::Units,
@@ -44,6 +44,9 @@ pub(crate) fn new(
 
     new_string(ControlId::SerialNumber).build(&mut controls);
     new_list(ControlId::RangeUnits, &["Nautical", "Metric"]).build(&mut controls);
+
+    // The report receiver closes the control session while the radar should stand down
+    new_auto_standby().build(&mut controls);
 
     SharedControls::new(radar_id, sk_client_tx, args, controls)
 }
@@ -676,4 +679,21 @@ fn get_ranges_by_model(model: &RadarModel) -> Vec<i32> {
         km_table.len(),
     );
     ranges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::time::Duration;
+
+    /// The receiver closes the control session while standing down, so the
+    /// control is offered, enabled at its default.
+    #[test]
+    fn furuno_offers_auto_standby_at_one_minute() {
+        let args = Cli::parse_from(["mayara-server"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let controls = new("fur1234".to_string(), tx, &args);
+        assert_eq!(controls.auto_standby(), Some(Duration::from_secs(60)));
+    }
 }


### PR DESCRIPTION
A Furuno radar kept transmitting for as long as anyone had asked it to, even with nobody looking at it: unlike Navico or Raymarine, nothing mayara sends holds the radar up, and the radar's own firmware has no notion of standing down when a client goes away (worked out from the DRS4D-NXT firmware: `research/furuno/drs4d-nxt-firmware.md`). The **Auto standby** setting from #663 now applies to Furuno radars in the only way that is safe: once nobody has watched the radar for the set time, mayara puts it in Standby itself, but **only if the radar is transmitting because someone asked for that through mayara**. A transmit started by a plotter or PC on another address is never touched, so an MFD that is using the radar keeps it exactly as it is.

Once a viewer returns the radar stays in Standby until that viewer asks for Transmit, as with the other brands. Not yet verified on a DRS4D-NXT.

## Implementation

- `new_auto_standby()` in `furuno/settings.rs`.
- The receiver keeps `transmit_is_ours` per range: set by a Transmit request arriving on the control channel (`note_power_request`, pure `transmit_is_ours_after`), cleared by a Standby/Off request through mayara or by any `$N69` status report that is not Transmit. On its 5 s tick, while `RadarInfo::stand_down()` is set, `stand_down_our_transmit()` sends `$S69` standby for each range still marked ours and clears the mark.
- The control session is kept: it is needed to send the standby, and closing it changes nothing for the antenna anyway.

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds Furuno Auto standby support.

- Tracks transmission ownership per range for requests made through Mayara.
- Sends Standby only for Mayara-owned transmissions when a range becomes idle.
- Preserves transmissions started by other clients.
- Clears ownership after Standby/Off requests or non-Transmit status reports.
- Registers Auto standby with a 60-second default.
- Adds ownership and settings tests.
- Updates radar-status documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->