### PR TITLE
feat(koden): let an unwatched radar stand down after a set time

### DIFF
--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -120,7 +120,10 @@ the radar never stands down. Per brand:
   memory is set only by a Transmit request that reached the radar through mayara and
   cleared by a Standby request through mayara or by the radar reporting anything but
   Transmit.
-- **Koden, Garmin**: not yet; see #665, #667.
+- **Koden**: the radar answers a keep-alive mayara sends every 10 s; it is left out while
+  standing down. Whether the radar then leaves Transmit by itself is still to be confirmed
+  on hardware (#665).
+- **Garmin**: not yet; see #667.
 
 ## ARPA counts as a subscriber — for idle
 

--- a/src/lib/brand/koden/report.rs
+++ b/src/lib/brand/koden/report.rs
@@ -16,6 +16,9 @@ use crate::util::PrintableSlice;
 pub(crate) struct KodenReportReceiver {
     common: CommonRadar,
     command_sender: Option<Command>,
+    /// Whether the last keep-alive tick left the packet out, so the
+    /// transition is logged once rather than every 10 s.
+    stood_down: bool,
 }
 
 impl KodenReportReceiver {
@@ -48,6 +51,7 @@ impl KodenReportReceiver {
         KodenReportReceiver {
             common,
             command_sender,
+            stood_down: false,
         }
     }
 
@@ -90,10 +94,28 @@ impl KodenReportReceiver {
                 }
 
                 _ = sleep_until(next_keepalive) => {
-                    if let Some(ref cmd) = self.command_sender {
-                        cmd.send_keepalive().await?;
-                    }
                     next_keepalive = Instant::now() + Duration::from_secs(KEEPALIVE_INTERVAL_SECS);
+                    if let Some(ref cmd) = self.command_sender {
+                        // The keep-alive is what holds the radar up for us, so it
+                        // is left out while nobody is watching and the radar
+                        // may stand down. Another controller keeps it up with
+                        // its own.
+                        let stand_down = self.common.info.stand_down();
+                        if stand_down != self.stood_down {
+                            self.stood_down = stand_down;
+                            if stand_down {
+                                log::info!(
+                                    "{}: nobody watching, dropping keep-alive so the radar can stand down",
+                                    self.common.key
+                                );
+                            } else {
+                                log::info!("{}: client connected, resuming keep-alive", self.common.key);
+                            }
+                        }
+                        if !stand_down {
+                            cmd.send_keepalive().await?;
+                        }
+                    }
                 }
 
                 result = recv_socket.recv_from(&mut buf) => {

--- a/src/lib/brand/koden/settings.rs
+++ b/src/lib/brand/koden/settings.rs
@@ -5,8 +5,8 @@ use super::protocol::KODEN_ANGLE_SCALE;
 use crate::{
     Cli,
     radar::settings::{
-        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
-        new_sector, new_string,
+        ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_auto_standby, new_list,
+        new_numeric, new_sector, new_string,
     },
     stream::SignalKDelta,
 };
@@ -53,5 +53,25 @@ pub(crate) fn new(
         .wire_offset(-1.)
         .build(&mut controls);
 
+    // The report receiver drops the keep-alive while the radar should stand down
+    new_auto_standby().build(&mut controls);
+
     SharedControls::new(radar_id, sk_client_tx, args, controls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::time::Duration;
+
+    /// The receiver drops the keep-alive while standing down, so the control
+    /// is offered, enabled at its default.
+    #[test]
+    fn koden_offers_auto_standby_at_one_minute() {
+        let args = Cli::parse_from(["mayara-server"]);
+        let tx = tokio::sync::broadcast::Sender::new(1);
+        let controls = new("kod1234".to_string(), tx, &args);
+        assert_eq!(controls.auto_standby(), Some(Duration::from_secs(60)));
+    }
 }


### PR DESCRIPTION
A Koden radar kept transmitting for as long as mayara ran, even with nobody looking at it: mayara sent the radar its keep-alive every ten seconds regardless of whether any client was watching. The **Auto standby** setting from #663 (Off / 1 / 5 / 15 / 30 min, default 1 min) now applies to Koden radars too: once nobody has watched the radar for that long, mayara stops sending the keep-alive and lets the radar stand down; the moment a viewer comes back the keep-alive resumes. Another controller on the network keeps the radar up with its own keep-alive, so nothing changes for it.

Not verified on Koden hardware: the protocol notes only record that the radar acknowledges the keep-alive, not what it does when it stops. If a Koden radar turns out to keep transmitting without it, this brand needs the Furuno approach from #669 (an explicit standby for a transmit that was asked through mayara).

## Implementation

`new_auto_standby()` in `koden/settings.rs`, and the 10 s tick in `koden/report.rs` skips `send_keepalive()` while `RadarInfo::stand_down()` is set, logging the transition once each way. The tick cadence is unchanged.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU