### PR TITLE
feat(garmin): stand down a radar that transmits on mayara's behalf

### DIFF
--- a/docs/internals/radar-status.md
+++ b/docs/internals/radar-status.md
@@ -123,7 +123,13 @@ the radar never stands down. Per brand:
 - **Koden**: the radar answers a keep-alive mayara sends every 10 s; it is left out while
   standing down. Whether the radar then leaves Transmit by itself is still to be confirmed
   on hardware (#665).
-- **Garmin**: not yet; see #667.
+- **Garmin**: nothing mayara sends holds the radar up either: its firmware drops a silent CDM
+  peer after 30 s and then only stops broadcasting spokes, the transmitter keeps running (see
+  `research/garmin/gmr-xhd-firmware.md`). So the receiver keeps the same claim as Furuno,
+  shared by both ranges of a dual-range scanner, and while standing down sends a Standby
+  itself; the claim ends when the radar reports Standby or Off, so a request the radar ignored
+  is repeated on the next tick. mayara keeps sending its CDM heartbeat so the radar keeps
+  reporting and discovery keeps working.
 
 ## ARPA counts as a subscriber — for idle
 

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -16,8 +16,8 @@ use crate::network;
 use crate::radar::settings::{ControlId, ControlValue};
 use crate::radar::spoke::GenericSpoke;
 use crate::radar::{
-    BYTE_LOOKUP_LENGTH, CommonRadar, DopplerMode, Legend, Power, RadarError, RadarInfo,
-    SharedRadars, transmit_claim_after_report, transmit_claim_after_request,
+    BYTE_LOOKUP_LENGTH, CommonRadar, DUAL_RANGE_A, DUAL_RANGE_B, DopplerMode, Legend, Power,
+    RadarError, RadarInfo, SharedRadars, transmit_claim_after_report, transmit_claim_after_request,
 };
 use crate::replay::RadarSocket;
 use crate::util::c_string;
@@ -103,7 +103,7 @@ pub(crate) struct GarminReportReceiver {
     data_socket: Option<RadarSocket>,
     command_sender: Option<Command>,
     reported_unknown: HashMap<u32, bool>,
-    /// The range (0 = A, 1 = B) a client asked to Transmit through mayara,
+    /// The dual-range id a client asked to Transmit through mayara,
     /// while that transmit is still ours to stand down. A Garmin radar keeps
     /// transmitting until a client tells it to stop and does nothing on losing
     /// its CDM peers but stop broadcasting spokes (research/garmin/
@@ -391,7 +391,7 @@ impl GarminReportReceiver {
                     match r {
                         Err(_) => {},
                         Ok(cv) => {
-                            let claim = transmit_claim_after_request(self.transmit_is_ours, 0, &cv.control_value);
+                            let claim = transmit_claim_after_request(self.transmit_is_ours, DUAL_RANGE_A, &cv.control_value);
                             if self.common.process_control_update(cv, &mut self.command_sender).await.is_ok() {
                                 self.transmit_is_ours = claim;
                             }
@@ -402,7 +402,7 @@ impl GarminReportReceiver {
                     match r {
                         Err(_) => {},
                         Ok(cv) => {
-                            let claim = transmit_claim_after_request(self.transmit_is_ours, 1, &cv.control_value);
+                            let claim = transmit_claim_after_request(self.transmit_is_ours, DUAL_RANGE_B, &cv.control_value);
                             if let Some(ref mut cb) = self.common_b
                                 && cb.process_control_update(cv, &mut self.command_sender_b).await.is_ok() {
                                 self.transmit_is_ours = claim;
@@ -1257,7 +1257,7 @@ impl GarminReportReceiver {
             return;
         };
         let (target, sender) = match (&self.common_b, range) {
-            (Some(cb), 1) => (cb, &mut self.command_sender_b),
+            (Some(cb), DUAL_RANGE_B) => (cb, &mut self.command_sender_b),
             _ => (&self.common, &mut self.command_sender),
         };
         let Some(cs) = sender else {

--- a/src/lib/brand/garmin/report.rs
+++ b/src/lib/brand/garmin/report.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, bail};
 use std::collections::HashMap;
 use std::io;
 use std::time::Duration;
-use tokio::time::sleep;
+use tokio::time::{Instant, sleep, sleep_until};
 use tokio_graceful_shutdown::SubsystemHandle;
 
 use super::GarminRadarType;
@@ -11,15 +11,21 @@ use super::command::Command;
 use super::protocol::*;
 use super::range_table;
 use crate::Cli;
+use crate::brand::CommandSender;
 use crate::network;
-use crate::radar::settings::ControlId;
+use crate::radar::settings::{ControlId, ControlValue};
 use crate::radar::spoke::GenericSpoke;
 use crate::radar::{
     BYTE_LOOKUP_LENGTH, CommonRadar, DopplerMode, Legend, Power, RadarError, RadarInfo,
-    SharedRadars,
+    SharedRadars, transmit_claim_after_report, transmit_claim_after_request,
 };
 use crate::replay::RadarSocket;
 use crate::util::c_string;
+use serde_json::Value;
+
+/// How often the receiver checks whether the radar should stand down; the
+/// watchdog that decides it ticks at the same rate.
+const STAND_DOWN_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Lookup table for converting raw wire pixel values to legend indices.
 /// For xHD, values are halved to make room for special legend entries.
@@ -97,6 +103,14 @@ pub(crate) struct GarminReportReceiver {
     data_socket: Option<RadarSocket>,
     command_sender: Option<Command>,
     reported_unknown: HashMap<u32, bool>,
+    /// The range (0 = A, 1 = B) a client asked to Transmit through mayara,
+    /// while that transmit is still ours to stand down. A Garmin radar keeps
+    /// transmitting until a client tells it to stop and does nothing on losing
+    /// its CDM peers but stop broadcasting spokes (research/garmin/
+    /// gmr-xhd-firmware.md), so standing down means sending Standby ourselves,
+    /// and only for a transmit that was ours: an MFD's transmit is never
+    /// touched. Both ranges share the scanner, so this is one fact for it.
+    transmit_is_ours: Option<i32>,
 
     range_a: RangeState,
     range_b: Option<RangeState>,
@@ -199,6 +213,7 @@ impl GarminReportReceiver {
             data_socket: None,
             command_sender,
             reported_unknown: HashMap::new(),
+            transmit_is_ours: None,
             range_a: RangeState {
                 range_meters: 0,
                 doppler: DopplerMode::None,
@@ -317,12 +332,19 @@ impl GarminReportReceiver {
         );
         let mut report_buf = Vec::with_capacity(10000);
         let mut data_buf = Vec::with_capacity(10000);
+        let mut stand_down_check = Instant::now() + STAND_DOWN_CHECK_INTERVAL;
 
         loop {
             tokio::select! {
                 _ = subsys.on_shutdown_requested() => {
                     log::debug!("{}: shutdown", self.common.key);
                     return Err(RadarError::Shutdown);
+                },
+                _ = sleep_until(stand_down_check) => {
+                    stand_down_check = Instant::now() + STAND_DOWN_CHECK_INTERVAL;
+                    if self.common.info.stand_down() {
+                        self.stand_down_our_transmit().await;
+                    }
                 },
                 r = async {
                     if let Some(sock) = self.report_socket.as_mut() {
@@ -369,7 +391,10 @@ impl GarminReportReceiver {
                     match r {
                         Err(_) => {},
                         Ok(cv) => {
-                            let _ = self.common.process_control_update(cv, &mut self.command_sender).await;
+                            let claim = transmit_claim_after_request(self.transmit_is_ours, 0, &cv.control_value);
+                            if self.common.process_control_update(cv, &mut self.command_sender).await.is_ok() {
+                                self.transmit_is_ours = claim;
+                            }
                         },
                     }
                 },
@@ -377,8 +402,10 @@ impl GarminReportReceiver {
                     match r {
                         Err(_) => {},
                         Ok(cv) => {
-                            if let Some(ref mut cb) = self.common_b {
-                                let _ = cb.process_control_update(cv, &mut self.command_sender_b).await;
+                            let claim = transmit_claim_after_request(self.transmit_is_ours, 1, &cv.control_value);
+                            if let Some(ref mut cb) = self.common_b
+                                && cb.process_control_update(cv, &mut self.command_sender_b).await.is_ok() {
+                                self.transmit_is_ours = claim;
                             }
                         },
                     }
@@ -815,8 +842,7 @@ impl GarminReportReceiver {
             HD_STATE_SPINNING_UP => Power::Preparing,
             _ => Power::Off,
         };
-        self.common
-            .set_value(&ControlId::Power, power as i32 as f64);
+        self.note_reported_power(power);
 
         self.common.set_value_enabled(
             &ControlId::WarmupTime,
@@ -863,8 +889,7 @@ impl GarminReportReceiver {
         } else {
             Power::Standby
         };
-        self.common
-            .set_value(&ControlId::Power, power as i32 as f64);
+        self.note_reported_power(power);
         Ok(())
     }
 
@@ -1210,9 +1235,42 @@ impl GarminReportReceiver {
             STATE_STOPPING | STATE_SPINNING_DOWN => Power::Preparing,
             _ => Power::Off,
         };
+        self.note_reported_power(power);
+        Ok(())
+    }
+
+    /// Publish the power the radar reported and let a Standby or Off end our
+    /// claim on the transmit, whoever put it there.
+    fn note_reported_power(&mut self, power: Power) {
+        self.transmit_is_ours = transmit_claim_after_report(self.transmit_is_ours, power);
         self.common
             .set_value(&ControlId::Power, power as i32 as f64);
-        Ok(())
+    }
+
+    /// Nobody is watching: if the radar is transmitting on our behalf, put it
+    /// in Standby. The radar itself never stands down on losing a client, so
+    /// this is the only way an unwatched Garmin radar stops. A send failure is
+    /// logged and retried on the next tick; the claim stays until the radar
+    /// reports Standby.
+    async fn stand_down_our_transmit(&mut self) {
+        let Some(range) = self.transmit_is_ours else {
+            return;
+        };
+        let (target, sender) = match (&self.common_b, range) {
+            (Some(cb), 1) => (cb, &mut self.command_sender_b),
+            _ => (&self.common, &mut self.command_sender),
+        };
+        let Some(cs) = sender else {
+            return;
+        };
+        log::info!(
+            "{}: nobody watching and the radar transmits for us, sending standby",
+            target.key
+        );
+        let standby = ControlValue::new(ControlId::Power, Value::from(Power::Standby as i32));
+        if let Err(e) = cs.set_control(&standby, &target.info.controls).await {
+            log::warn!("{}: standby request failed: {}", target.key, e);
+        }
     }
 
     fn process_state_change(&mut self, data: &[u8]) -> Result<(), Error> {

--- a/src/lib/brand/garmin/settings.rs
+++ b/src/lib/brand/garmin/settings.rs
@@ -7,8 +7,8 @@ use crate::{
     Cli,
     radar::{
         settings::{
-            ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_list, new_numeric,
-            new_sector, new_string,
+            ControlId, HAS_AUTO_NOT_ADJUSTABLE, SharedControls, new_auto, new_auto_standby,
+            new_list, new_numeric, new_sector, new_string,
         },
         units::Units,
     },
@@ -178,5 +178,31 @@ pub(crate) fn new(
         }
     }
 
+    // The report receiver stands a transmit that was asked through mayara down itself
+    new_auto_standby().build(&mut controls);
+
     SharedControls::new(radar_id, sk_client_tx, args, controls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::time::Duration;
+
+    /// The receiver sends a Standby for a transmit that was ours while
+    /// standing down, so the control is offered on every Garmin, enabled at
+    /// its default.
+    #[test]
+    fn garmin_offers_auto_standby_at_one_minute() {
+        let args = Cli::parse_from(["mayara-server"]);
+        for (radar_type, caps) in [
+            (GarminRadarType::HD, GarminCapabilities::for_legacy_hd()),
+            (GarminRadarType::XHD, GarminCapabilities::empty()),
+        ] {
+            let tx = tokio::sync::broadcast::Sender::new(1);
+            let controls = new("gar1234".to_string(), tx, &args, radar_type, &caps, false);
+            assert_eq!(controls.auto_standby(), Some(Duration::from_secs(60)));
+        }
+    }
 }

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -1453,6 +1453,11 @@ fn should_power_off(silence: Duration, current_power: Option<i32>) -> bool {
     silence >= SharedRadars::RADAR_SILENCE_TIMEOUT && current_power != Some(Power::Off as i32)
 }
 
+/// The dual-range ids a transmit claim is keyed on: the primary range and,
+/// on a dual-range radar, the secondary one.
+pub(crate) const DUAL_RANGE_A: i32 = 0;
+pub(crate) const DUAL_RANGE_B: i32 = 1;
+
 /// Which range's transmit is mayara's to stand down, for brands whose radar
 /// keeps transmitting until a client tells it to stop (Furuno, Garmin). The
 /// claim is the dual-range id a client asked to Transmit through mayara; a

--- a/src/lib/radar/mod.rs
+++ b/src/lib/radar/mod.rs
@@ -1453,6 +1453,40 @@ fn should_power_off(silence: Duration, current_power: Option<i32>) -> bool {
     silence >= SharedRadars::RADAR_SILENCE_TIMEOUT && current_power != Some(Power::Off as i32)
 }
 
+/// Which range's transmit is mayara's to stand down, for brands whose radar
+/// keeps transmitting until a client tells it to stop (Furuno, Garmin). The
+/// claim is the dual-range id a client asked to Transmit through mayara; a
+/// transmit started by any other controller is never claimed, so standing it
+/// down is never on the table.
+///
+/// After a client's control request for `range` has reached the radar: a
+/// Transmit request claims that range, any other Power request gives the
+/// claim up, anything else leaves it alone.
+pub(crate) fn transmit_claim_after_request(
+    current: Option<i32>,
+    range: i32,
+    cv: &ControlValue,
+) -> Option<i32> {
+    if cv.id != ControlId::Power {
+        return current;
+    }
+    match cv.as_value().ok().and_then(|v| Power::from_value(&v).ok()) {
+        Some(Power::Transmit) => Some(range),
+        Some(_) => None,
+        None => current,
+    }
+}
+
+/// After the radar reported its power: the claim ends once the radar is in
+/// Standby or Off, whoever put it there. Preparing is the radar warming or
+/// spinning up on the way to the Transmit we asked for, and keeps the claim.
+pub(crate) fn transmit_claim_after_report(current: Option<i32>, reported: Power) -> Option<i32> {
+    match reported {
+        Power::Standby | Power::Off => None,
+        _ => current,
+    }
+}
+
 /// Decide whether one antenna should be let go so it can stand down. Each
 /// entry is one range: its `AutoStandby` period (`None` = off) and how long
 /// nobody has watched it. The ranges of a dual-range radar share the antenna,
@@ -2807,6 +2841,50 @@ mod tests {
     // ----- stand-down (issue #633) -----
 
     const PERIOD: Duration = Duration::from_secs(60);
+
+    fn power_request(power: Power) -> ControlValue {
+        ControlValue::new(ControlId::Power, Value::from(power as i32))
+    }
+
+    #[test]
+    fn a_transmit_asked_through_mayara_is_claimed_until_standby_is_asked() {
+        assert_eq!(
+            transmit_claim_after_request(None, 1, &power_request(Power::Transmit)),
+            Some(1)
+        );
+        assert_eq!(
+            transmit_claim_after_request(Some(1), 0, &power_request(Power::Standby)),
+            None
+        );
+        assert_eq!(
+            transmit_claim_after_request(Some(0), 0, &power_request(Power::Off)),
+            None
+        );
+    }
+
+    #[test]
+    fn other_controls_and_unreadable_requests_leave_the_claim_alone() {
+        let gain = ControlValue::new(ControlId::Gain, Value::from(50));
+        assert_eq!(transmit_claim_after_request(Some(0), 0, &gain), Some(0));
+        let junk = ControlValue::new(ControlId::Power, Value::from("nonsense"));
+        assert_eq!(transmit_claim_after_request(Some(1), 1, &junk), Some(1));
+        assert_eq!(transmit_claim_after_request(None, 0, &junk), None);
+    }
+
+    #[test]
+    fn the_claim_survives_warm_up_and_ends_in_standby() {
+        assert_eq!(
+            transmit_claim_after_report(Some(0), Power::Preparing),
+            Some(0)
+        );
+        assert_eq!(
+            transmit_claim_after_report(Some(0), Power::Transmit),
+            Some(0)
+        );
+        assert_eq!(transmit_claim_after_report(Some(0), Power::Standby), None);
+        assert_eq!(transmit_claim_after_report(Some(1), Power::Off), None);
+        assert_eq!(transmit_claim_after_report(None, Power::Transmit), None);
+    }
 
     #[test]
     fn antenna_should_stand_down_single_range() {


### PR DESCRIPTION
A Garmin radar kept transmitting for as long as anyone had asked it to, even with nobody looking at it. Withholding mayara's CDM heartbeat would not have helped: the scanner firmware (decoded from Garmin's `GUPDATE.GCD`, see `research/garmin/gmr-xhd-firmware.md`) drops a silent peer after 30 s and then merely stops broadcasting spokes; nothing on that path touches the transmitter, and mayara needs the heartbeat for discovery anyway. The **Auto standby** setting from #663 now applies to Garmin radars the same way as to Furuno (#669): once nobody has watched the radar for the set time, mayara puts it in Standby itself, but **only if the radar is transmitting because someone asked for that through mayara**. A transmit started by a chartplotter is never touched.

Not yet verified on Garmin hardware.

## Implementation

- `new_auto_standby()` in `garmin/settings.rs` (every Garmin, both ranges of a dual-range scanner).
- The receiver gains a 5 s tick (it had no timer arm) and a claim `transmit_is_ours`, kept per scanner since both ranges share it: set by a Transmit request that reached the radar through mayara (`transmit_claim_after_request`), ended by a Standby/Off request through mayara or by the radar reporting Standby/Off (`transmit_claim_after_report`). Preparing (warming or spinning up towards our Transmit) keeps the claim. While `stand_down()` holds, `stand_down_our_transmit()` sends the Standby command on the claimed range; a request the radar ignored is repeated on the next tick, since the claim only ends on the radar's own report.
- The claim helpers live in `radar/mod.rs` with tests, so Furuno can switch to them and pick up the Preparing fix in a follow-up.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds Garmin Auto standby support.

- Registers automatic standby for HD and XHD scanners with a 60-second default.
- Tracks transmission claims per scanner and range, including during Preparing.
- Sends and repeats Standby requests after the configured unwatched interval.
- Controls only transmissions initiated through Mayara.
- Preserves CDM heartbeat discovery and leaves chartplotter-initiated transmission unchanged.
- Releases claims when Mayara requests Standby or Off, or when the radar reports those states.
- Adds shared claim helpers, timer handling, documentation, and unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->