### PR TITLE
fix(raymarine): RD heater hour count is in tenths of an hour

### DIFF
--- a/src/lib/brand/raymarine/report/rd.rs
+++ b/src/lib/brand/raymarine/report/rd.rs
@@ -522,7 +522,7 @@ pub(super) fn process_status_report(receiver: &mut RaymarineReportReceiver, data
 #[derive(Deserialize, Debug, Clone, Copy)]
 #[repr(C, packed)]
 struct FixedReport {
-    magnetron_time: u16,
+    heater_time: u16, // tenths of an hour, the MFD's "Heater hour count"
     _fieldx_2: [u8; 6],
     magnetron_current: u8,
     _fieldx_3: [u8; 11],
@@ -601,7 +601,7 @@ pub(super) fn process_fixed_report(receiver: &mut RaymarineReportReceiver, data:
     if receiver.model.is_some() {
         receiver
             .common
-            .set_value(&ControlId::TransmitTime, report.magnetron_time);
+            .set_value(&ControlId::OperatingTime, report.heater_time);
         receiver
             .common
             .set_value(&ControlId::MagnetronCurrent, report.magnetron_current);

--- a/src/lib/brand/raymarine/settings.rs
+++ b/src/lib/brand/raymarine/settings.rs
@@ -75,8 +75,13 @@ pub(crate) fn new(
             new_numeric(ControlId::SeaClutterCurve, 1., 2.).build(&mut controls);
         }
         BaseModel::RD => {
-            new_numeric(ControlId::TransmitTime, 0., 65535.)
+            // The scanner's "Heater hour count": lifetime magnetron heater time,
+            // standby and transmit summed, as a u16 in tenths of an hour.
+            // Confirmed against an E120 self-test screen showing 2792.3 h for a
+            // wire value of 27923.
+            new_numeric(ControlId::OperatingTime, 0., 6553.5)
                 .read_only(true)
+                .wire_scale_step(0.1)
                 .wire_units(Units::Hours)
                 .build(&mut controls);
             new_numeric(ControlId::MagnetronCurrent, 0., 65535.)

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -332,11 +332,16 @@ impl Telemetry {
     }
 }
 
-/// A radar's lifetime transmit counter in whole hours, which is the unit the
-/// radars that keep one count in. `None` when the radar keeps no such counter,
-/// or has not reported it yet.
+/// A radar's lifetime counter in whole hours, which is the unit the radars
+/// that keep one count in. Transmit time where the radar counts that; failing
+/// that its operating time, which is what a Raymarine RD keeps (its magnetron
+/// heater hours, standby and transmit summed). Either one tells how worn the
+/// radar is, which is what the report wants. `None` when the radar keeps no
+/// such counter, or has not reported it yet.
 fn transmit_hours(controls: &SharedControls) -> Option<u64> {
-    let seconds = controls.get(&ControlId::TransmitTime)?.value?;
+    let seconds = [ControlId::TransmitTime, ControlId::OperatingTime]
+        .iter()
+        .find_map(|id| controls.get(id)?.value)?;
     Some((seconds / SECS_PER_HOUR) as u64)
 }
 
@@ -397,6 +402,18 @@ mod tests {
 
     fn without_transmit_time() -> SharedControls {
         shared(HashMap::new())
+    }
+
+    /// The controls of a Raymarine RD: no transmit counter, but an operating
+    /// one, in tenths of an hour on the wire.
+    fn with_operating_time() -> SharedControls {
+        let mut controls = HashMap::new();
+        new_numeric(ControlId::OperatingTime, 0., 6553.5)
+            .read_only(true)
+            .wire_scale_step(0.1)
+            .wire_units(Units::Hours)
+            .build(&mut controls);
+        shared(controls)
     }
 
     fn shared(controls: HashMap<ControlId, Control>) -> SharedControls {
@@ -558,7 +575,20 @@ mod tests {
     #[test]
     fn a_radar_that_has_not_reported_a_transmit_counter_has_no_hours() {
         assert_eq!(transmit_hours(&with_transmit_time()), None);
+        assert_eq!(transmit_hours(&with_operating_time()), None);
         assert_eq!(transmit_hours(&without_transmit_time()), None);
+    }
+
+    /// A radar that counts operating rather than transmit time still reports
+    /// its hours, at the scale the wire value carries: an RD reporting 27923
+    /// (tenths of an hour) is 2792 whole hours, not 27923.
+    #[test]
+    fn operating_time_stands_in_for_a_missing_transmit_counter() {
+        let controls = with_operating_time();
+        controls
+            .set_value_auto_enabled(&ControlId::OperatingTime, 27923., None, None)
+            .unwrap();
+        assert_eq!(transmit_hours(&controls), Some(2792));
     }
 
     #[test]

--- a/tests/replay_raymarine_rd418d.rs
+++ b/tests/replay_raymarine_rd418d.rs
@@ -10,6 +10,7 @@
 
 mod common;
 
+use mayara::radar::settings::ControlId;
 use mayara::{Cli, replay};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::Path;
@@ -85,10 +86,26 @@ async fn replay_raymarine_rd418d() {
                         let key = &keys[0];
                         let info = radars.get_by_key(key).expect("radar info");
 
-                        // Wait until the model has been identified
+                        // The 0x010002 fixed report carries the scanner's
+                        // heater hour count as a u16 in tenths of an hour;
+                        // this capture's scanner reads 6892 on the wire.
+                        let operating_time = info
+                            .controls
+                            .get(&ControlId::OperatingTime)
+                            .and_then(|c| c.value())
+                            .and_then(|v| v.as_f64());
+
+                        // Wait until the model has been identified and the
+                        // fixed report has been seen
                         if info.controls.model_name() == Some("RD418D".to_string())
                             && !info.ranges.all.is_empty()
+                            && operating_time.is_some()
                         {
+                            assert_eq!(
+                                operating_time,
+                                Some(689.2 * 3600.),
+                                "heater hour count 6892 on the wire is 689.2 h, stored in seconds"
+                            );
                             assert!(
                                 key.starts_with("ray"),
                                 "expected Raymarine key, got: {}",


### PR DESCRIPTION
## Summary

- The u16 at offset 217 of the RD fixed report (0x00010002) is the scanner's **Heater hour count**: lifetime magnetron heater time, standby and transmit summed, in units of 0.1 h. We treated it as whole hours, so a radar the E120 self-test shows at 2792.3 h was reported as 27923 h.
- Scale the wire value by 0.1 and publish it as `OperatingTime` rather than `TransmitTime`, since the heater runs in standby too. Navico and Furuno keep `TransmitTime` with its transmit-only meaning. Max drops to 6553.5 h to match a u16 in tenths.
- Telemetry read `TransmitTime` alone, so RD radars would have dropped out of the transmit-time histogram (and before this fix fed it ten times their real hours). It now falls back to `OperatingTime`; the `transmit_hours` field name on the wire is unchanged, so the receiver needs no change.

Confirmed against an E120 Diagnostics → Scanners self-test screen (Heater hour count 2792.3) versus wire value 27923 from a pcap of the same scanner. The same screen lists Magnetron Current and Rotation time next to it, matching the struct offsets 225 and 237.

## API note

For RD radars the read-only control id changes from `transmitTime` to `operatingTime`. The OpenCPN plugin needs no change: it formats any read-only `*Time` control as a duration.

## Test plan

- [x] `cargo test`: 549 lib tests pass, including two new telemetry tests (wire 27923 → 2792 h; RD with no reported value → no hours)
- [x] `cargo clippy --all-targets` and `cargo fmt --check` clean
- [ ] Live RD radar shows ~2792 h in the info controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2GBUFeDXKoxd4XxDd1H8A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Reports Raymarine RD heater time as `OperatingTime`, scaled in 0.1-hour increments with a maximum of 6553.5 hours.
- Renames the RD read-only control from `transmitTime` to `operatingTime`.
- Uses `OperatingTime` as the telemetry fallback when `TransmitTime` is unavailable.
- Adds telemetry tests for operating-time fallback and scale conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->